### PR TITLE
change #include <string.h> to #include "string.h"

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: MIT */
 
-#include <string.h>
+#include "string.h"
 
 // Routines based on The Public Domain C Library
 


### PR DESCRIPTION
this is required to fix the following error when compiling with clang:

```
  CC    build/string.o
src/string.c:3:10: error: 'string.h' file not found with <angled> include; use "quotes" instead
         ^~~~~~~~~~
         "string.h"
```

Signed-off-by: Sven Peter <sven@svenpeter.dev>