### PR TITLE
adt: fix ignored qualifiers in adt_getprop_copy function prototype

### DIFF
--- a/src/adt.c
+++ b/src/adt.c
@@ -139,8 +139,8 @@ const void *adt_getprop(const void *adt, int nodeoffset, const char *name,
     return adt_getprop_namelen(adt, nodeoffset, name, strlen(name), lenp);
 }
 
-const int adt_getprop_copy(const void *adt, int nodeoffset, const char *name,
-                           void *out, int len)
+int adt_getprop_copy(const void *adt, int nodeoffset, const char *name,
+                     void *out, int len)
 {
     int plen;
 

--- a/src/adt.h
+++ b/src/adt.h
@@ -75,8 +75,8 @@ const void *adt_getprop(const void *adt, int nodeoffset, const char *name,
                         int *lenp);
 const void *adt_getprop_length(const void *adt, int nodeoffset,
                                const char *name, int len);
-const int adt_getprop_copy(const void *adt, int nodeoffset, const char *name,
-                           void *out, int len);
+int adt_getprop_copy(const void *adt, int nodeoffset, const char *name,
+                     void *out, int len);
 
 #define ADT_GETPROP(adt, nodeoffset, name, val)                                \
     adt_getprop_copy(adt, nodeoffset, name, (val), sizeof(*(val)))


### PR DESCRIPTION
This commit removes the unnecessary `const` on `adt_getprop_copy()` in both the header and the C file, since `const int` as a return type does not do anything different than just `int`, and the added `const` might be confusing to some.

See also the discussion in #5 "add missing const to src/adt.h".