### PR TITLE
build: fix problem with arch-less data on older GNU binutils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ build/%.bin: data/%.png
 
 build/%.o: build/%.bin
 	@echo "  BIN   $@"
-	@$(OBJCOPY) -I binary -O elf64-littleaarch64 $< $@
+	@$(OBJCOPY) -I binary -B aarch64 -O elf64-littleaarch64 $< $@
 
 build/main.o: build/build_tag.h src/main.c
 


### PR DESCRIPTION
Seems (possibly older) versions of binutils, like 2.31.1 set the ELF arch to 'no machine' when the input format is arch-less, causing a link failure later.