### PR TITLE
types.h: remove redundant definition of NULL (defined in stddef.h)

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -19,8 +19,6 @@ typedef int64_t s64;
 typedef u64 uintptr_t;
 typedef s64 ptrdiff_t;
 
-#define NULL ((void *)0)
-
 #define ALIGNED(x) __attribute__((aligned(x)))
 #define PACKED __attribute__((packed))
 


### PR DESCRIPTION
This PR fixes a warning found by compiling m1n1 with clang.

- `src/types.h` redefines `NULL`, which is already defined in `<stddef.h>`