### PR TITLE
Signedness: Replaces int to uint32_t and size_t for unsigned values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ ARCH := aarch64-linux-gnu-
 
 CFLAGS := -O2 -Wall -Wundef -Werror=strict-prototypes -fno-common -fno-PIE \
 	-Werror=implicit-function-declaration -Werror=implicit-int \
+	-Wsign-compare -Wunused-parameter \
 	-ffreestanding -fpic -ffunction-sections -fdata-sections \
 	-fno-stack-protector -mgeneral-regs-only -mstrict-align
 

--- a/src/adt.c
+++ b/src/adt.c
@@ -56,12 +56,12 @@ int adt_check_header(const void *adt)
     return _adt_check_node_offset(adt, 0);
 }
 
-static int _adt_string_eq(const char *a, const char *b, int len)
+static int _adt_string_eq(const char *a, const char *b, size_t len)
 {
     return (strlen(a) == len) && (memcmp(a, b, len) == 0);
 }
 
-static int _adt_nodename_eq(const char *a, const char *b, int len)
+static int _adt_nodename_eq(const char *a, const char *b, size_t len)
 {
     if (memcmp(a, b, len) != 0)
         return 0;
@@ -76,9 +76,9 @@ static int _adt_nodename_eq(const char *a, const char *b, int len)
 
 const struct adt_property *adt_get_property_namelen(const void *adt, int offset,
                                                     const char *name,
-                                                    int namelen)
+                                                    size_t namelen)
 {
-    dprintf("adt_get_property_namelen(%p, %d, \"%s\", %d)\n", adt, offset, name,
+    dprintf("adt_get_property_namelen(%p, %d, \"%s\", %u)\n", adt, offset, name,
             namelen);
 
     for (offset = adt_first_property_offset(adt, offset); (offset >= 0);
@@ -102,7 +102,7 @@ const struct adt_property *adt_get_property(const void *adt, int nodeoffset,
 }
 
 const void *adt_getprop_namelen(const void *adt, int nodeoffset,
-                                const char *name, int namelen, int *lenp)
+                                const char *name, size_t namelen, u32 *lenp)
 {
     const struct adt_property *prop;
 
@@ -118,7 +118,7 @@ const void *adt_getprop_namelen(const void *adt, int nodeoffset,
 }
 
 const void *adt_getprop_by_offset(const void *adt, int offset,
-                                  const char **namep, int *lenp)
+                                  const char **namep, u32 *lenp)
 {
     const struct adt_property *prop;
 
@@ -134,15 +134,15 @@ const void *adt_getprop_by_offset(const void *adt, int offset,
 }
 
 const void *adt_getprop(const void *adt, int nodeoffset, const char *name,
-                        int *lenp)
+                        u32 *lenp)
 {
     return adt_getprop_namelen(adt, nodeoffset, name, strlen(name), lenp);
 }
 
 int adt_getprop_copy(const void *adt, int nodeoffset, const char *name,
-                     void *out, int len)
+                     void *out, size_t len)
 {
-    int plen;
+    u32 plen;
 
     const void *p = adt_getprop(adt, nodeoffset, name, &plen);
 
@@ -160,7 +160,7 @@ int adt_first_child_offset(const void *adt, int offset)
 {
     const struct adt_node_hdr *node = ADT_NODE(adt, offset);
 
-    int cnt = node->property_count;
+    u32 cnt = node->property_count;
     offset = adt_first_property_offset(adt, offset);
 
     while (cnt--) {
@@ -174,7 +174,7 @@ int adt_next_sibling_offset(const void *adt, int offset)
 {
     const struct adt_node_hdr *node = ADT_NODE(adt, offset);
 
-    int cnt = node->child_count;
+    u32 cnt = node->child_count;
     offset = adt_first_child_offset(adt, offset);
 
     while (cnt--) {
@@ -185,7 +185,7 @@ int adt_next_sibling_offset(const void *adt, int offset)
 }
 
 int adt_subnode_offset_namelen(const void *adt, int offset, const char *name,
-                               int namelen)
+                               size_t namelen)
 {
     const struct adt_node_hdr *node = ADT_NODE(adt, offset);
 
@@ -193,7 +193,7 @@ int adt_subnode_offset_namelen(const void *adt, int offset, const char *name,
 
     offset = adt_first_child_offset(adt, offset);
 
-    for (int i = 0; i < node->child_count; i++) {
+    for (u32 i = 0; i < node->child_count; i++) {
         const char *cname = adt_get_name(adt, offset);
 
         if (_adt_nodename_eq(cname, name, namelen))

--- a/src/adt.h
+++ b/src/adt.h
@@ -4,6 +4,8 @@
 #define XDT_H
 
 #include <stdint.h>
+#include <stddef.h>
+#include "types.h"
 
 #define ADT_ERR_NOTFOUND 1
 #define ADT_ERR_BADOFFSET 4
@@ -15,19 +17,19 @@ extern void *adt;
 
 struct adt_property {
     char name[32];
-    uint32_t size;
-    uint8_t value[];
+    u32 size;
+    u8 value[];
 };
 
 struct adt_node_hdr {
-    uint32_t property_count;
-    uint32_t child_count;
+    u32 property_count;
+    u32 child_count;
 };
 
 #define ADT_NODE(adt, offset)                                                  \
-    ((const struct adt_node_hdr *)(((uint8_t *)(adt)) + (offset)))
+    ((const struct adt_node_hdr *)(((u8 *)(adt)) + (offset)))
 #define ADT_PROP(adt, offset)                                                  \
-    ((const struct adt_property *)(((uint8_t *)(adt)) + (offset)))
+    ((const struct adt_property *)(((u8 *)(adt)) + (offset)))
 #define ADT_SIZE(node) ((node)->size & 0x7fffffff)
 
 /* This API is designed to match libfdt's read-only API */
@@ -37,6 +39,7 @@ int adt_check_header(const void *adt);
 
 static inline int adt_first_property_offset(const void *adt, int offset)
 {
+    UNUSED(adt);
     return offset + sizeof(struct adt_node_hdr);
 }
 
@@ -57,26 +60,24 @@ int adt_first_child(const void *adt, int offset);
 int adt_next_sibling(const void *adt, int offset);
 
 int adt_subnode_offset_namelen(const void *adt, int parentoffset,
-                               const char *name, int namelen);
+                               const char *name, size_t namelen);
 int adt_subnode_offset(const void *adt, int parentoffset, const char *name);
 int adt_path_offset(const void *adt, const char *path);
 const char *adt_get_name(const void *adt, int nodeoffset);
 const struct adt_property *adt_get_property_namelen(const void *adt,
                                                     int nodeoffset,
                                                     const char *name,
-                                                    int namelen);
+                                                    size_t namelen);
 const struct adt_property *adt_get_property(const void *adt, int nodeoffset,
                                             const char *name);
 const void *adt_getprop_by_offset(const void *adt, int offset,
-                                  const char **namep, int *lenp);
+                                  const char **namep, u32 *lenp);
 const void *adt_getprop_namelen(const void *adt, int nodeoffset,
-                                const char *name, int namelen, int *lenp);
+                                const char *name, size_t namelen, u32 *lenp);
 const void *adt_getprop(const void *adt, int nodeoffset, const char *name,
-                        int *lenp);
-const void *adt_getprop_length(const void *adt, int nodeoffset,
-                               const char *name, int len);
+                        u32 *lenp);
 int adt_getprop_copy(const void *adt, int nodeoffset, const char *name,
-                     void *out, int len);
+                     void *out, size_t len);
 
 #define ADT_GETPROP(adt, nodeoffset, name, val)                                \
     adt_getprop_copy(adt, nodeoffset, name, (val), sizeof(*(val)))

--- a/src/exception.c
+++ b/src/exception.c
@@ -72,7 +72,7 @@ void exc_irq(u64 *regs)
     printf(" UERSTAT: 0x%x\n", uerstat);
     printf(" UFSTAT: 0x%x\n", ufstat);
 #endif
-
+    UNUSED(regs);
     // print_regs(regs);
 }
 
@@ -87,6 +87,7 @@ void exc_fiq(u64 *regs)
         msr(CNTP_CTL_EL0, 7L);
     }
 
+    UNUSED(regs);
     // print_regs(regs);
 }
 

--- a/src/startup.c
+++ b/src/startup.c
@@ -65,6 +65,7 @@ void dump_boot_args(struct boot_args *ba)
 
 void _start_c(void *boot_args, void *base)
 {
+    UNUSED(base);
     uart_putchar('s');
     uart_init();
     uart_putchar('c');

--- a/src/types.h
+++ b/src/types.h
@@ -19,6 +19,7 @@ typedef int64_t s64;
 typedef u64 uintptr_t;
 typedef s64 ptrdiff_t;
 
+#define UNUSED(x) (void)(x)
 #define ALIGNED(x) __attribute__((aligned(x)))
 #define PACKED __attribute__((packed))
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -41,7 +41,7 @@ void hexdump(const void *d, size_t len)
     }
 }
 
-void regdump(u64 addr, int len)
+void regdump(u64 addr, size_t len)
 {
     u64 i, off;
     for (off = 0; off < len; off += 32) {

--- a/src/utils.h
+++ b/src/utils.h
@@ -234,7 +234,7 @@ void memset8(void *dst, u8 value, size_t size);
 void memcpy8(void *dst, void *src, size_t size);
 
 void hexdump(const void *d, size_t len);
-void regdump(u64 addr, int len);
+void regdump(u64 addr, size_t len);
 int sprintf(char *str, const char *fmt, ...);
 int debug_printf(const char *fmt, ...);
 void udelay(u32 d);


### PR DESCRIPTION
Signedness: 
- `adt.c`: Replaces `int` usage to `uint32_t` for property size (`lenp`) and `size_t` for property name length (`len`).  
This change differs from the API in libfdt but is consistent with the data types of the property and their usage.
- adt.h: Removes `adt_getprop_length` declaration without implementation

Increases compiler warnings to expose some common issues to review:
- Makefile: `Wsign-compare` / `Wunused-parameters` 
-  UNUSED macro to suppress this warning in function parameters that are in ongoing work, debug or subject to API review.

Signed-off-by: Ariel Machado <ariel@fe.up.pt>