### PR TITLE
Makefile: add support for compiling m1n1 with clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,10 @@ ARCH := aarch64-linux-gnu-
 
 CFLAGS := -O2 -Wall -Wundef -Werror=strict-prototypes -fno-common -fno-PIE \
 	-Werror=implicit-function-declaration -Werror=implicit-int \
-	-ffreestanding -mabi=lp64 -fpic -ffunction-sections -fdata-sections
+	-ffreestanding -fpic -ffunction-sections -fdata-sections \
+	-fno-stack-protector -mgeneral-regs-only
 
-LDFLAGS := -T m1n1.ld -EL -maarch64elf --no-undefined -X -shared -Bsymbolic \
+LDFLAGS := -T m1n1.ld -EL -maarch64elf --no-undefined -X -Bsymbolic \
 	-z notext --no-apply-dynamic-relocs --orphan-handling=warn --strip-debug \
 	-z nocopyreloc --gc-sections -pie
 
@@ -18,10 +19,17 @@ TARGET := m1n1.macho
 
 DEPDIR := build/.deps
 
+ifeq ($(USE_CLANG),1)
+CC := clang --target=$(ARCH)
+AS := clang --target=$(ARCH)
+LD := ld.lld
+OBJCOPY := llvm-objcopy
+else
 CC := $(ARCH)gcc
 AS := $(ARCH)gcc
 LD := $(ARCH)ld
 OBJCOPY := $(ARCH)objcopy
+endif
 
 .PHONY: all clean format
 all: build/$(TARGET)

--- a/m1n1.ld
+++ b/m1n1.ld
@@ -3,12 +3,10 @@ ENTRY(_start)
 /* Fake virtual load address for the mach-o */
 _va_base = 0xFFFFFE0007004000;
 
-/* We are actually relocatable */
-_base = 0;
-
 _stack_size = 0x20000;
 
-. = _base;
+/* We are actually relocatable */
+. = 0;
 
 PHDRS
 {
@@ -19,6 +17,8 @@ PHDRS
 }
 
 SECTIONS {
+    _base = .;
+
     .header : {
         _mach_header = .;
         /* mach-o header */

--- a/m1n1.ld
+++ b/m1n1.ld
@@ -155,6 +155,10 @@ SECTIONS {
     _data_size = . - _data_start;
     _end = .;
 
+    .symtab 0 : { *(.symtab) }
+    .strtab 0 : { *(.strtab) }
+    .shstrtab 0 : { *(.shstrtab) }
+
     /DISCARD/ : {
         *(.discard)
         *(.discard.*)

--- a/src/exception.c
+++ b/src/exception.c
@@ -69,7 +69,7 @@ void exc_fiq(u64 *regs)
 
     if (timer_ctl == 0x5) {
         uart_puts("  timer IRQ, masking");
-        msr(CNTP_CTL_EL0, 7);
+        msr(CNTP_CTL_EL0, 7L);
     }
 
     // print_regs(regs);

--- a/src/start.S
+++ b/src/start.S
@@ -69,7 +69,7 @@ _vectors_start:
 .globl _start
 .type _start, @function
 _start:
-    mov x9, x0
+    mov x19, x0
 
     mov w0, 'm'
     bl debug_putc
@@ -84,7 +84,7 @@ _start:
     bl debug_putc
 
     adrp x0, _base
-    mov x10, x0
+    mov x20, x0
     adrp x1, _rela_start
     add x1, x1, :lo12:_rela_start
     adrp x2, _rela_end
@@ -98,8 +98,8 @@ _start:
     mov w0, '\n'
     bl debug_putc
     
-    mov x0, x9
-    mov x1, x10
+    mov x0, x19
+    mov x1, x20
     bl _start_c
     b .
 

--- a/src/start.S
+++ b/src/start.S
@@ -93,7 +93,7 @@ _start:
 
     mov w0, '1'
     bl debug_putc
-    mov w0, '\r'
+    mov w0, 0xd /* '\r', clang compat */
     bl debug_putc
     mov w0, '\n'
     bl debug_putc
@@ -106,7 +106,7 @@ _start:
 .globl exc_unk
 .type exc_unk, @function
 exc_unk:
-    mov w0, '\r'
+    mov w0, 0xd /* '\r', clang compat */
     bl debug_putc
     mov w0, '\n'
     bl debug_putc
@@ -124,7 +124,7 @@ exc_unk:
     bl debug_putc
     mov w0, '!'
     bl debug_putc
-    mov w0, '\r'
+    mov w0, 0xd /* '\r', clang compat */
     bl debug_putc
     mov w0, '\n'
     bl debug_putc

--- a/src/types.h
+++ b/src/types.h
@@ -19,8 +19,6 @@ typedef int64_t s64;
 typedef u64 uintptr_t;
 typedef s64 ptrdiff_t;
 
-#define NULL ((void *)0)
-
 #define ALIGNED(x) __attribute__((aligned(x)))
 #define PACKED __attribute__((packed))
 


### PR DESCRIPTION
@svenpeter42 and I worked on getting m1n1 to compile cleanly with clang, and I think we got something that should work.
This PR enables m1n1 to be built with clang, by adding the `USE_CLANG=1` argument when invoking `make`.

Notable changes:
- the `-mabi=lp64` flag was removed since clang doesn't understand it and `aarch64-linux-gnu-gcc` builds in that mode by default.
- the `-fno-stack-protector` flag was added since clang inserts stack protector guards that produce a linker error otherwise.
- the `-mgeneral-regs-only` flag was added since clang produces code that writes to the `qN` registers otherwise, and m1n1 doesn't save those during interrupts.
- the `-shared` linker flag was removed since LLD doesn't like it being used together with `-pie` and GNU ld behaves the same without it (since `-pie` effectively overrides it).
- the sections `.symtab`, `.strtab`, and `.shstrtab` were added to the linker script explicitly to avoid an LLD warning. This only makes explicit what GNU ld already does implicitly.
- the `_base` symbol in the linker script is set inside the `SECTIONS` block instead of outside, otherwise LLD interprets the symbol as the absolute value 0 and does not generate relocations for it.
- all mentions of `'\r'` in assembler files were replaced with `0xd` to workaround the fact that LLVM doesn't recognize `'\r'` in asm files (most likely a bug).

Except for the `-mgeneral-regs-only` change, the resulting binary when built with GCC doesn't differ in any way (byte-identical, except for the build tag). ~~The Clang codegen is obviously quite different at points, and I haven't gotten around to diffing it properly, but on first glance the codegen looks okay.~~

The Clang codegen revealed some bugs in m1n1:

Notable necessary bug fixes:
- the `_start` function in `start.S` violated the AArch64 calling convention and used caller-saved register accross function calls, and this coincidentally worked with GCC, but not with clang.

Notable warning fixes:
- the `msr` macro seems to take a long, and clang warns if you're not explicit about that. (added `L` suffix for the `msr` call in `exception.c`)
- cherry-picked PR #11 because not having that fixed caused clang to print lots of warnings

Since I don't have an M1, I can't test this yet, and therefore I have marked this PR as [WIP].
I opened this now to have a progress and discussion board and to avoid duplicate efforts.

Test Timeline:
- 4be59ab: crashed in memcpy due to calling convention bug in `_start`
- f7f54d2: crashed on chainloading itself due to invalid relocation for `_base`
- e0ac143: boots and can chainload itself (removed [WIP] label)