### PR TITLE
utils.h: Fix 'asm-operand-widths' warnings with clang

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -215,8 +215,12 @@ static inline u8 mask8(u64 addr, u8 clear, u8 set)
     })
 #define mrs(reg) _mrs(reg)
 
-#define _msr(reg, val) ({ __asm__ volatile("msr\t" #reg ", %0" : : "r"(val)); })
-#define msr(reg, val)  _msr(reg, val)
+#define _msr(reg, val)                                                                             \
+    ({                                                                                             \
+        u64 __val = (u64)val;                                                                      \
+        __asm__ volatile("msr\t" #reg ", %0" : : "r"(__val));                                      \
+    })
+#define msr(reg, val) _msr(reg, val)
 
 #define sysop(op) __asm__ volatile(op ::: "memory")
 


### PR DESCRIPTION
Clang raises 'asm-operand-widths' warnings in inline assembly code when the size of an operand is < 64 bits and the operand width is unspecified.
Warnings are raised in `_msr(reg, val)` macro, i.e. the datatype of the operand may vary. 
In the macro we cast the operand to 64 bits, forcing the use of the right 64-bit register size.

Signed-off-by: Ariel Machado <ariel@fe.up.pt>