### PR TITLE
Fix broken hexdumps in proxy.py

### DIFF
--- a/proxyclient/proxy.py
+++ b/proxyclient/proxy.py
@@ -16,7 +16,7 @@ def ascii(s):
         if c < 0x20 or c > 0x7e:
             s2 += "."
         else:
-            s2 += c
+            s2 += chr(c)
     return s2
 
 def pad(s,c,l):
@@ -30,7 +30,7 @@ def chexdump(s,st=0):
             i + st,
             hexdump(s[i:i+8], ' ').rjust(23),
             hexdump(s[i+8:i+16], ' ').rjust(23),
-            ascii(s[i:i+16]),rjust(16)))
+            ascii(s[i:i+16]).rjust(16)))
 
 def chexdump32(s, st=0, abbreviate=True):
     last = None


### PR DESCRIPTION
Proxy.py has a few typos that appear if you try to use debug mode and dump a region of memory. This should fix those.