### PR TITLE
tooling: Add container setup for build environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:buster-slim
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y build-essential bash git locales gcc-aarch64-linux-gnu libc6-dev-arm64-cross device-tree-compiler imagemagick \
+    && rm -rf /var/lib/apt/lists/* \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+ENV LANG en_US.utf8
+
+WORKDIR /m1n1
+COPY . .
+
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ The output will be in build/m1n1.macho.
 
 To build on a native arm64 machine, use `make ARCH=`.
 
+### Building using the container setup
+
+If you have a container runtime installed, like Podman or Docker, you can make use of the compose setup, which contains all build dependencies.
+
+```shell
+$ git clone --recursive https://github.com/AsahiLinux/m1n1.git
+$ cd m1n1
+$ podman-compose run m1n1 make
+$ # or
+$ docker-compose run m1n1 make
+```
+
 ## Usage
 
 Our [developer quickstart](https://github.com/AsahiLinux/docs/wiki/Developer-Quickstart#using-m1n1)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,5 @@
+services:
+  m1n1:
+    build: .
+    volumes:
+      - .:/m1n1


### PR DESCRIPTION
This allows compiling m1n1 on any platform that supports containers / Docker and doesn't require using a separate Linux build machine.

With Docker(-Compose) installed building m1n1 can be done by running: 

```
$ docker-compose build
$ docker-compose run m1n1 make
```
