### PR TITLE
MMU: use alle2 instead of vmalls12e1is to invalidate TLBs

### DIFF
--- a/src/memory.c
+++ b/src/memory.c
@@ -295,7 +295,7 @@ static void mmu_configure(void)
 
     // Armv8-A Address Translation, 100940_0101_en, page 28
     sysop("dsb ishst");
-    sysop("tlbi vmalls12e1is");
+    sysop("tlbi alle2");
     sysop("dsb ish");
     sysop("isb");
 }


### PR DESCRIPTION
I can't remember why I used vmalls12e1is but this leads to
the following bug:

  1. Load m1n1 with normal MMU setup
  2. Disable all mappings, recompile and chainload to that m1n1
  3. Everything will work fine for a while even though it should explode
     when enabling the MMU.

This happens becuse there are still stale TLB entries in some cache.

Signed-off-by: Sven Peter <sven@svenpeter.dev>