### PR TITLE
Add writeread functions + proxy ops

### DIFF
--- a/proxyclient/proxy.py
+++ b/proxyclient/proxy.py
@@ -308,6 +308,10 @@ class M1N1Proxy:
     P_MASK32 = 0x111
     P_MASK16 = 0x112
     P_MASK8 = 0x113
+    P_WRITEREAD64 = 0x114
+    P_WRITEREAD32 = 0x115
+    P_WRITEREAD16 = 0x116
+    P_WRITEREAD8 = 0x117
 
     P_MEMCPY64 = 0x200
     P_MEMCPY32 = 0x201
@@ -486,6 +490,15 @@ class M1N1Proxy:
         self.request(self.P_MASK16, addr, clear, set)
     def mask8(self, addr, clear, set):
         self.request(self.P_MASK8, addr, clear, set)
+
+    def writeread64(self, addr, data):
+        return self.request(self.P_WRITEREAD64, addr, data)
+    def writeread32(self, addr, data):
+        return self.request(self.P_WRITEREAD32, addr, data)
+    def writeread16(self, addr, data):
+        return self.request(self.P_WRITEREAD16, addr, data)
+    def writeread8(self, addr, data):
+        return self.request(self.P_WRITEREAD8, addr, data)
 
     def memcpy64(self, dst, src, size):
         if src & 7 or dst & 7:

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -149,6 +149,23 @@ int proxy_process(ProxyRequest *request, ProxyReply *reply)
             reply->retval = mask8(request->args[0], request->args[1], request->args[2]);
             break;
 
+        case P_WRITEREAD64:
+            exc_guard = GUARD_MARK;
+            reply->retval = writeread64(request->args[0], request->args[1]);
+            break;
+        case P_WRITEREAD32:
+            exc_guard = GUARD_MARK;
+            reply->retval = writeread32(request->args[0], request->args[1]);
+            break;
+        case P_WRITEREAD16:
+            exc_guard = GUARD_MARK;
+            reply->retval = writeread16(request->args[0], request->args[1]);
+            break;
+        case P_WRITEREAD8:
+            exc_guard = GUARD_MARK;
+            reply->retval = writeread8(request->args[0], request->args[1]);
+            break;
+
         case P_MEMCPY64:
             exc_guard = GUARD_RETURN;
             memcpy64((void *)request->args[0], (void *)request->args[1], request->args[2]);

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -36,6 +36,10 @@ typedef enum {
     P_MASK32,
     P_MASK16,
     P_MASK8,
+    P_WRITEREAD64,
+    P_WRITEREAD32,
+    P_WRITEREAD16,
+    P_WRITEREAD8,
 
     P_MEMCPY64 = 0x200, // Memory block transfer functions
     P_MEMCPY32,

--- a/src/utils.h
+++ b/src/utils.h
@@ -56,6 +56,12 @@ static inline u64 mask64(u64 addr, u64 clear, u64 set)
     return data;
 }
 
+static inline u64 writeread64(u64 addr, u64 data)
+{
+    write64(addr, data);
+    return read64(addr);
+}
+
 static inline u32 read32(u64 addr)
 {
     u32 data;
@@ -66,6 +72,12 @@ static inline u32 read32(u64 addr)
 static inline void write32(u64 addr, u32 data)
 {
     __asm__ volatile("str\t%w0, [%1]" : : "r"(data), "r"(addr) : "memory");
+}
+
+static inline u32 writeread32(u64 addr, u32 data)
+{
+    write32(addr, data);
+    return read32(addr);
 }
 
 static inline u32 set32(u64 addr, u32 set)
@@ -156,6 +168,12 @@ static inline u16 mask16(u64 addr, u16 clear, u16 set)
     return data;
 }
 
+static inline u16 writeread16(u64 addr, u16 data)
+{
+    write16(addr, data);
+    return read16(addr);
+}
+
 static inline u8 read8(u64 addr)
 {
     u32 data;
@@ -203,6 +221,12 @@ static inline u8 mask8(u64 addr, u8 clear, u8 set)
                      : "r"(addr), "r"(set), "r"(clear)
                      : "memory");
     return data;
+}
+
+static inline u8 writeread8(u64 addr, u8 data)
+{
+    write8(addr, data);
+    return read8(addr);
 }
 
 #define sys_reg(op0, op1, CRn, CRm, op2) s##op0##_##op1##_c##CRn##_c##CRm##_##op2


### PR DESCRIPTION
These functions all perform a store direcly followed by a load.
This is useful to e.g. useful to find busy bits which might
already be cleared a few cycles after a write.