### PR TITLE
Makefile: allow to override ARCH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ARCH := aarch64-linux-gnu-
+ARCH ?= aarch64-linux-gnu-
 
 CFLAGS := -O2 -Wall -Wundef -Werror=strict-prototypes -fno-common -fno-PIE \
 	-Werror=implicit-function-declaration -Werror=implicit-int \


### PR DESCRIPTION
I need to run `ARCH=aarch64-unknown-linux-gnu- PATH="/Users/speter/asahi/aarch64-unknown-linux-gnu/bin/:$PATH" make $@` due to my toolchain which won't work unless I can override `ARCH` in the Makefile.