### PR TITLE
DART, power/clock management and USB support (without phy init)

### DIFF
--- a/3rdparty_licenses/LICENSE.BSD-3.dwc3
+++ b/3rdparty_licenses/LICENSE.BSD-3.dwc3
@@ -1,0 +1,33 @@
+Copyright (C) 2010-2011 Texas Instruments Incorporated - http://www.ti.com
+
+Authors: Felipe Balbi <balbi@ti.com>,
+	    Sebastian Andrzej Siewior <bigeasy@linutronix.de>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions, and the following disclaimer,
+   without modification.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. The names of the above-listed copyright holders may not be used
+   to endorse or promote products derived from this software without
+   specific prior written permission.
+
+ALTERNATIVELY, this software may be distributed under the terms of the
+GNU General Public License ("GPL") version 2, as published by the Free
+Software Foundation.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ LIBFDT_OBJECTS := $(patsubst %,libfdt/%, \
 	fdt_wip.o fdt.o)
 
 OBJECTS := adt.o bootlogo_128.o bootlogo_256.o chickens.o dart.o exception.o exception_asm.o fb.o \
-	heapblock.o kboot.o main.o memory.o memory_asm.o payload.o proxy.o smp.o start.o startup.o \
+	heapblock.o kboot.o main.o memory.o memory_asm.o payload.o pmgr.o proxy.o smp.o start.o startup.o \
 	string.o uart.o uartproxy.o utils.o utils_asm.o vsprintf.o wdt.o $(MINILZLIB_OBJECTS) \
 	$(TINF_OBJECTS) $(DLMALLOC_OBJECTS) $(LIBFDT_OBJECTS)
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ LIBFDT_OBJECTS := $(patsubst %,libfdt/%, \
 	fdt_wip.o fdt.o)
 
 OBJECTS := adt.o bootlogo_128.o bootlogo_256.o chickens.o dart.o exception.o exception_asm.o fb.o \
-	heapblock.o kboot.o main.o memory.o memory_asm.o payload.o pmgr.o proxy.o smp.o start.o startup.o \
+	heapblock.o kboot.o main.o memory.o memory_asm.o payload.o pmgr.o proxy.o ringbuffer.o smp.o start.o startup.o \
 	string.o uart.o uartproxy.o utils.o utils_asm.o vsprintf.o wdt.o $(MINILZLIB_OBJECTS) \
 	$(TINF_OBJECTS) $(DLMALLOC_OBJECTS) $(LIBFDT_OBJECTS)
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ LIBFDT_OBJECTS := $(patsubst %,libfdt/%, \
 
 OBJECTS := adt.o bootlogo_128.o bootlogo_256.o chickens.o dart.o exception.o exception_asm.o fb.o \
 	heapblock.o kboot.o main.o memory.o memory_asm.o payload.o pmgr.o proxy.o ringbuffer.o smp.o start.o startup.o \
-	string.o uart.o uartproxy.o utils.o utils_asm.o vsprintf.o wdt.o $(MINILZLIB_OBJECTS) \
+	string.o uart.o uartproxy.o usb_dwc3.o utils.o utils_asm.o vsprintf.o wdt.o $(MINILZLIB_OBJECTS) \
 	$(TINF_OBJECTS) $(DLMALLOC_OBJECTS) $(LIBFDT_OBJECTS)
 
 DTS := t8103-j274.dts

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ LIBFDT_OBJECTS := $(patsubst %,libfdt/%, \
 
 OBJECTS := adt.o bootlogo_128.o bootlogo_256.o chickens.o dart.o exception.o exception_asm.o fb.o \
 	heapblock.o kboot.o main.o memory.o memory_asm.o payload.o pmgr.o proxy.o ringbuffer.o smp.o start.o startup.o \
-	string.o uart.o uartproxy.o usb_dwc3.o utils.o utils_asm.o vsprintf.o wdt.o $(MINILZLIB_OBJECTS) \
+	string.o uart.o uartproxy.o usb.o usb_dwc3.o utils.o utils_asm.o vsprintf.o wdt.o $(MINILZLIB_OBJECTS) \
 	$(TINF_OBJECTS) $(DLMALLOC_OBJECTS) $(LIBFDT_OBJECTS)
 
 DTS := t8103-j274.dts

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ LIBFDT_OBJECTS := $(patsubst %,libfdt/%, \
 	fdt_addresses.o fdt_empty_tree.o fdt_ro.o fdt_rw.o fdt_strerror.o fdt_sw.o \
 	fdt_wip.o fdt.o)
 
-OBJECTS := adt.o bootlogo_128.o bootlogo_256.o chickens.o exception.o exception_asm.o fb.o \
+OBJECTS := adt.o bootlogo_128.o bootlogo_256.o chickens.o dart.o exception.o exception_asm.o fb.o \
 	heapblock.o kboot.o main.o memory.o memory_asm.o payload.o proxy.o smp.o start.o startup.o \
 	string.o uart.o uartproxy.o utils.o utils_asm.o vsprintf.o wdt.o $(MINILZLIB_OBJECTS) \
 	$(TINF_OBJECTS) $(DLMALLOC_OBJECTS) $(LIBFDT_OBJECTS)

--- a/README.md
+++ b/README.md
@@ -102,3 +102,5 @@ the public domain ([CC0](3rdparty_licenses/LICENSE.CC0)).
 m1n1 embeds portions of [PDCLib](https://github.com/DevSolar/pdclib), which is in the public
 domain ([CC0](3rdparty_licenses/LICENSE.CC0)).
 
+m1n1 embeds portions of the 2013 dwc3 usb linux driver, which is [BSD-or-GPLv2 dual-licensed](3rdparty_licenses/LICENSE.BSD-3.dwc3) and copyright
+* Copyright (C) 2010-2011 Texas Instruments Incorporated - http://www.ti.com

--- a/proxyclient/proxy.py
+++ b/proxyclient/proxy.py
@@ -354,6 +354,11 @@ class M1N1Proxy:
     P_KBOOT_SET_INITRD = 0x702
     P_KBOOT_PREPARE_DT = 0x703
 
+    P_DART_INIT = 0x800
+    P_DART_MAP = 0x801
+    P_DART_UNMAP = 0x802
+    P_DART_SHUTDOWN = 0x803
+
     def __init__(self, iface, debug=False):
         self.debug = debug
         self.iface = iface
@@ -603,6 +608,15 @@ class M1N1Proxy:
         self.request(self.P_KBOOT_SET_INITRD, base, size)
     def kboot_prepare_dt(self, dt_addr):
         return self.request(self.P_KBOOT_PREPARE_DT, dt_addr)
+
+    def dart_init(self, regs, device):
+        return self.request(self.P_DART_INIT, regs, device)
+    def dart_map(self, dart, iova, buffer, length):
+        return self.request(self.P_DART_MAP, dart, iova, buffer, length)
+    def dart_unmap(self, dart, iova, length):
+        self.request(self.P_DART_UNMAP, dart, iova, length)
+    def dart_shutdown(self, dart):
+        self.request(self.P_DART_SHUTDOWN, dart)
 
 if __name__ == "__main__":
     import serial

--- a/src/dart.c
+++ b/src/dart.c
@@ -1,0 +1,214 @@
+/* SPDX-License-Identifier: MIT */
+
+#include "assert.h"
+#include "dart.h"
+#include "malloc.h"
+#include "memory.h"
+#include "string.h"
+#include "utils.h"
+
+#define DART_CONFIG      0x60
+#define DART_CONFIG_LOCK BIT(15)
+
+#define DART_ERROR              0x40
+#define DART_ERROR_DOMAIN_SHIFT 24
+#define DART_ERROR_DOMAIN_MASK  0xf
+#define DART_ERROR_CODE_MASK    0xffffff
+#define DART_ERROR_FLAG         BIT(31)
+#define DART_ERROR_READ_FAULT   BIT(4)
+#define DART_ERROR_WRITE_FAULT  BIT(3)
+#define DART_ERROR_NO_PTE       BIT(2)
+#define DART_ERROR_NO_L1        BIT(1)
+#define DART_ERROR_NO_L0        BIT(0)
+
+#define DART_DOMAIN_SELECT 0x34
+
+#define DART_DOMAIN_COMMAND            0x20
+#define DART_DOMAIN_COMMAND_BUSY       BIT(2)
+#define DART_DOMAIN_COMMAND_INVALIDATE BIT(20)
+
+#define DART_DOMAIN_COMMAND_BUSY_TIMEOUT 100
+
+#define DART_DEVICE2DOMAIN_MAP 0x80
+
+#define DART_ERROR_ADDR_HI 0x54
+#define DART_ERROR_ADDR_LO 0x50
+
+#define DART_TCR(domain)          0x100 + 4 * (domain)
+#define DART_TCR_TRANSLATE_ENABLE BIT(7)
+#define DART_TCR_BYPASS_ENABLE    BIT(8)
+
+#define DART_TTBR(domain, idx) 0x200 + 16 * (domain) + 4 * (idx)
+#define DART_TTBR_VALID        BIT(31)
+#define DART_TTBR_SHIFT        12
+
+#define DART_PTE_VALID 0b11
+
+struct dart_dev {
+    uintptr_t regs;
+    u8 device;
+
+    u64 *l1;
+};
+
+static void dart_tlb_invalidate(dart_dev_t *dart)
+{
+    /*
+     * add a DMA barrier here to be safe since we don't exactly know
+     * how the DART reads the pagetables.
+     */
+    dma_wmb();
+
+    write32(dart->regs + DART_DOMAIN_SELECT, BIT(dart->device));
+    write32(dart->regs + DART_DOMAIN_COMMAND, DART_DOMAIN_COMMAND_INVALIDATE);
+
+    if (poll32(dart->regs + DART_DOMAIN_COMMAND, DART_DOMAIN_COMMAND_BUSY, 0, 100))
+        printf("dart: DART_DOMAIN_COMMAND_BUSY did not clear.\n");
+}
+
+dart_dev_t *dart_init(uintptr_t base, u8 device)
+{
+    dart_dev_t *dart = malloc(sizeof(*dart));
+    if (!dart)
+        return NULL;
+
+    dart->regs = base;
+    dart->device = device;
+    dart->l1 = NULL;
+
+    if (read32(dart->regs + DART_CONFIG) & DART_CONFIG_LOCK) {
+        printf("dart: dart at %p is locked\n", dart->regs);
+        goto error;
+    }
+
+    dart->l1 = memalign(SZ_16K, 4 * SZ_16K);
+    if (!dart->l1)
+        goto error;
+    memset(dart->l1, 0, 4 * SZ_16K);
+
+    write32(dart->regs + DART_TTBR(device, 0),
+            DART_TTBR_VALID | (((uintptr_t)dart->l1) >> DART_TTBR_SHIFT));
+    write32(dart->regs + DART_TTBR(device, 1),
+            DART_TTBR_VALID | (((uintptr_t)dart->l1 + SZ_16K) >> DART_TTBR_SHIFT));
+    write32(dart->regs + DART_TTBR(device, 2),
+            DART_TTBR_VALID | (((uintptr_t)dart->l1 + 2 * SZ_16K) >> DART_TTBR_SHIFT));
+    write32(dart->regs + DART_TTBR(device, 3),
+            DART_TTBR_VALID | (((uintptr_t)dart->l1 + 3 * SZ_16K) >> DART_TTBR_SHIFT));
+
+    write32(dart->regs + DART_TCR(device), DART_TCR_TRANSLATE_ENABLE);
+    dart_tlb_invalidate(dart);
+
+    return dart;
+
+error:
+    free(dart->l1);
+    free(dart);
+    return NULL;
+}
+
+static u64 *dart_get_l2(dart_dev_t *dart, u32 idx)
+{
+    if (dart->l1[idx] & DART_PTE_VALID)
+        return (u64 *)(dart->l1[idx] & ~DART_PTE_VALID);
+
+    u64 *tbl = memalign(SZ_16K, SZ_16K);
+    if (!tbl)
+        return NULL;
+
+    memset(tbl, 0, SZ_16K);
+    dart->l1[idx] = (uintptr_t)tbl | DART_PTE_VALID;
+    return tbl;
+}
+
+static int dart_map_page(dart_dev_t *dart, uintptr_t iova, uintptr_t paddr)
+{
+    u32 l1_index = (iova >> 25) & 0x1fff;
+    u32 l2_index = (iova >> 14) & 0x7ff;
+
+    u64 *l2 = dart_get_l2(dart, l1_index);
+    if (!l2) {
+        printf("dart: couldn't create l2 for iova %llx\n", iova);
+        return -1;
+    }
+
+    if (l2[l2_index] & DART_PTE_VALID) {
+        printf("dart: iova %llx already has a valid PTE: %llx\n", iova, l2[l2_index]);
+        return -1;
+    }
+
+    l2[l2_index] = (uintptr_t)paddr | DART_PTE_VALID;
+
+    return 0;
+}
+
+int dart_map(dart_dev_t *dart, uintptr_t iova, void *bfr, size_t len)
+{
+    uintptr_t paddr = (uintptr_t)bfr;
+    u64 offset = 0;
+
+    if (len % SZ_16K)
+        return -1;
+    if (paddr % SZ_16K)
+        return -1;
+    if (iova % SZ_16K)
+        return -1;
+
+    while (offset < len) {
+        int ret = dart_map_page(dart, iova + offset, paddr + offset);
+
+        if (ret) {
+            dart_unmap(dart, iova, offset);
+            return ret;
+        }
+
+        offset += SZ_16K;
+    }
+
+    dart_tlb_invalidate(dart);
+    return 0;
+}
+
+static void dart_unmap_page(dart_dev_t *dart, uintptr_t iova)
+{
+    u32 l1_index = (iova >> 25) & 0x1fff;
+    u32 l2_index = (iova >> 14) & 0x7ff;
+
+    if (!(dart->l1[l1_index] & DART_PTE_VALID))
+        return;
+
+    u64 *l2 = (u64 *)(dart->l1[l1_index] & ~DART_PTE_VALID);
+    l2[l2_index] = 0;
+}
+
+void dart_unmap(dart_dev_t *dart, uintptr_t iova, size_t len)
+{
+    if (len % SZ_16K)
+        return;
+    if (iova % SZ_16K)
+        return;
+
+    while (len) {
+        dart_unmap_page(dart, iova);
+
+        len -= SZ_16K;
+        iova += SZ_16K;
+    }
+
+    dart_tlb_invalidate(dart);
+}
+
+void dart_shutdown(dart_dev_t *dart)
+{
+    write32(dart->regs + DART_TCR(dart->device), 0);
+    for (int i = 0; i < 4; ++i)
+        write32(dart->regs + DART_TTBR(dart->device, i), 0);
+    dart_tlb_invalidate(dart);
+
+    for (int i = 0; i < SZ_16K / 8; ++i) {
+        if (dart->l1[i] & DART_PTE_VALID)
+            free((void *)(dart->l1[i] & ~DART_PTE_VALID));
+    }
+
+    free(dart->l1);
+    free(dart);
+}

--- a/src/dart.h
+++ b/src/dart.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: MIT */
+
+#ifndef DART_H
+#define DART_H
+
+#include "types.h"
+
+typedef struct dart_dev dart_dev_t;
+
+dart_dev_t *dart_init(uintptr_t base, u8 device);
+int dart_map(dart_dev_t *dart, uintptr_t iova, void *bfr, size_t len);
+void dart_unmap(dart_dev_t *dart, uintptr_t iova, size_t len);
+void dart_shutdown(dart_dev_t *dart);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -7,6 +7,7 @@
 #include "heapblock.h"
 #include "memory.h"
 #include "payload.h"
+#include "pmgr.h"
 #include "smp.h"
 #include "string.h"
 #include "uart.h"
@@ -58,6 +59,7 @@ void m1n1_main(void)
 
     print_info();
     wdt_disable();
+    pmgr_init();
 
     printf("Checking for payloads...\n");
 

--- a/src/main.c
+++ b/src/main.c
@@ -12,6 +12,7 @@
 #include "string.h"
 #include "uart.h"
 #include "uartproxy.h"
+#include "usb.h"
 #include "utils.h"
 #include "wdt.h"
 #include "xnuboot.h"

--- a/src/memory.h
+++ b/src/memory.h
@@ -5,8 +5,6 @@
 
 #include "types.h"
 
-#define SZ_16K 0x4000
-
 void ic_ivau_range(void *addr, size_t length);
 void dc_ivac_range(void *addr, size_t length);
 void dc_zva_range(void *addr, size_t length);

--- a/src/memory.h
+++ b/src/memory.h
@@ -5,6 +5,8 @@
 
 #include "types.h"
 
+#define SZ_16K 0x4000
+
 void ic_ivau_range(void *addr, size_t length);
 void dc_ivac_range(void *addr, size_t length);
 void dc_zva_range(void *addr, size_t length);

--- a/src/pmgr.c
+++ b/src/pmgr.c
@@ -1,0 +1,204 @@
+/* SPDX-License-Identifier: MIT */
+
+#include "adt.h"
+#include "pmgr.h"
+#include "string.h"
+#include "types.h"
+#include "utils.h"
+
+#define PMGR_POLL_TIMEOUT 10000
+
+#define PMGR_TARGET_MODE_MASK 0x0f
+#define PMGR_TARGET_MODE(m)   (((m)&0xf))
+#define PMGR_ACTUAL_MODE_MASK 0xf0
+#define PMGR_ACTUAL_MODE(m)   (((m)&0xf) << 4)
+
+#define PMGR_MODE_ENABLE  0xf
+#define PMGR_MODE_DISABLE 0
+
+#define PMGR_FLAG_VIRTUAL 0x10
+
+#define PMGR_FIND_DEVICE_EIGNORE -2
+
+struct pmgr_device {
+    u32 flags;
+    u16 alias;
+    u8 unk1[4];
+    u8 addr_offset;
+    u8 psreg_idx;
+    u8 unk2[14];
+    u16 id;
+    u8 unk3[4];
+    const char name[0x10];
+} PACKED;
+
+static int pmgr_initialized = 0;
+
+static int pmgr_path[8];
+static int pmgr_offset;
+
+static const u32 *pmgr_ps_regs = NULL;
+static u32 pmgr_ps_regs_len = 0;
+
+static const struct pmgr_device *pmgr_devices = NULL;
+static u32 pmgr_devices_len = 0;
+
+int pmgr_init(void)
+{
+    pmgr_offset = adt_path_offset_trace(adt, "/arm-io/pmgr", pmgr_path);
+    if (pmgr_offset < 0) {
+        printf("pmgr: Error getting /arm-io/pmgr node\n");
+        return -1;
+    }
+
+    pmgr_ps_regs = adt_getprop(adt, pmgr_offset, "ps-regs", &pmgr_ps_regs_len);
+    if (pmgr_ps_regs == NULL || pmgr_ps_regs_len == 0) {
+        printf("pmgr: Error getting /arm-io/pmgr ps-regs\n.");
+        return -1;
+    }
+
+    pmgr_devices = adt_getprop(adt, pmgr_offset, "devices", &pmgr_devices_len);
+    if (pmgr_devices == NULL || pmgr_devices_len == 0) {
+        printf("pmgr: Error getting /arm-io/pmgr devices.\n");
+        return -1;
+    }
+
+    pmgr_devices_len /= sizeof(*pmgr_devices);
+    pmgr_initialized = 1;
+
+    printf("pmgr: initialized, %d devices found.\n", pmgr_devices_len);
+
+    return 0;
+}
+
+static uintptr_t pmgr_get_psreg(u8 idx)
+{
+    if (idx * 12 >= pmgr_ps_regs_len) {
+        printf("pmgr: Index %d is out of bounds for ps-regs\n", idx);
+        return 0;
+    }
+
+    u32 reg_idx = pmgr_ps_regs[3 * idx];
+    u32 reg_offset = pmgr_ps_regs[3 * idx + 1];
+
+    u64 pmgr_reg;
+    if (adt_get_reg(adt, pmgr_path, "reg", reg_idx, &pmgr_reg, NULL) < 0) {
+        printf("pmgr: Error getting /arm-io/pmgr regs\n");
+        return 0;
+    }
+
+    return pmgr_reg + reg_offset;
+}
+
+static int pmgr_find_device(u16 id, uintptr_t *base)
+{
+    for (u32 i = 0; i < pmgr_devices_len; ++i) {
+        const struct pmgr_device *device = &pmgr_devices[i];
+
+        if (device->id != id)
+            continue;
+        if (device->flags & PMGR_FLAG_VIRTUAL) {
+            /*
+             * FIXME/TODO:
+             * There are some virtual devices (e.g. USB-AUDIO-V) that lead to
+             * a non-existing device with index zero. Work around
+             * this by returning a specific error code that will let the
+             * callers know to just ignore this device for now.
+             */
+            if (device->alias == 0)
+                return PMGR_FIND_DEVICE_EIGNORE;
+            return pmgr_find_device(device->alias, base);
+        }
+
+        uintptr_t addr = pmgr_get_psreg(device->psreg_idx);
+        if (addr == 0)
+            return -1;
+
+        *base = addr + (device->addr_offset << 3);
+        return 0;
+    }
+
+    return -1;
+}
+
+static int pmgr_set_mode(u16 id, u8 target_mode)
+{
+    if (!pmgr_initialized) {
+        printf("pmgr: pmgr_set_mode() called before successful pmgr_init()\n");
+        return -1;
+    }
+
+    uintptr_t addr;
+    int res = pmgr_find_device(id, &addr);
+    if (res == PMGR_FIND_DEVICE_EIGNORE) {
+        return 0;
+    } else if (res < 0) {
+        printf("pmgr: Unable to find device with id %d\n", id);
+        return -1;
+    }
+
+    mask32(addr, PMGR_TARGET_MODE_MASK, PMGR_TARGET_MODE(target_mode));
+    if (poll32(addr, PMGR_ACTUAL_MODE_MASK, PMGR_ACTUAL_MODE(target_mode), PMGR_POLL_TIMEOUT) < 0) {
+        printf("pmgr: timeout while trying to set mode %x for device %d at %p: %x\n", target_mode,
+               id, addr, read32(addr));
+        return -1;
+    }
+
+    return 0;
+}
+
+int pmgr_clock_enable(u16 id)
+{
+    return pmgr_set_mode(id, PMGR_MODE_ENABLE);
+}
+
+int pmgr_clock_disable(u16 id)
+{
+    return pmgr_set_mode(id, PMGR_MODE_DISABLE);
+}
+
+static int pmgr_adt_find_clocks(const char *path, const u32 **clocks, u32 *n_clocks)
+{
+    int node_offset = adt_path_offset(adt, path);
+    if (node_offset < 0) {
+        printf("pmgr: Error getting node %s\n", path);
+        return -1;
+    }
+
+    *clocks = adt_getprop(adt, node_offset, "clock-gates", n_clocks);
+    if (*clocks == NULL || *n_clocks == 0) {
+        printf("pmgr: Error getting %s clock-gates.\n", path);
+        return -1;
+    }
+
+    *n_clocks /= 4;
+
+    return 0;
+}
+
+static int pmgr_adt_clocks_set_mode(const char *path, u8 target_mode)
+{
+    const u32 *clocks;
+    u32 n_clocks;
+    int ret = 0;
+
+    if (pmgr_adt_find_clocks(path, &clocks, &n_clocks) < 0)
+        return -1;
+
+    for (u32 i = 0; i < n_clocks; ++i) {
+        if (pmgr_set_mode(clocks[i], target_mode))
+            ret = -1;
+    }
+
+    return ret;
+}
+
+int pmgr_adt_clocks_enable(const char *path)
+{
+    return pmgr_adt_clocks_set_mode(path, PMGR_MODE_ENABLE);
+}
+
+int pmgr_adt_clocks_disable(const char *path)
+{
+    return pmgr_adt_clocks_set_mode(path, PMGR_MODE_DISABLE);
+}

--- a/src/pmgr.h
+++ b/src/pmgr.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: MIT */
+
+#ifndef PMGR_H
+#define PMGR_H
+
+#include "types.h"
+
+int pmgr_init(void);
+
+int pmgr_clock_enable(u16 id);
+int pmgr_clock_disable(u16 id);
+
+int pmgr_adt_clocks_enable(const char *path);
+int pmgr_adt_clocks_disable(const char *path);
+
+#endif

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -1,11 +1,12 @@
 /* SPDX-License-Identifier: MIT */
 
-#include "proxy.h"
+#include "dart.h"
 #include "exception.h"
 #include "heapblock.h"
 #include "kboot.h"
 #include "malloc.h"
 #include "memory.h"
+#include "proxy.h"
 #include "smp.h"
 #include "types.h"
 #include "uart.h"
@@ -307,6 +308,20 @@ int proxy_process(ProxyRequest *request, ProxyReply *reply)
             break;
         case P_KBOOT_PREPARE_DT:
             reply->retval = kboot_prepare_dt((void *)request->args[0]);
+            break;
+
+        case P_DART_INIT:
+            reply->retval = (u64)dart_init(request->args[0], request->args[1]);
+            break;
+        case P_DART_MAP:
+            reply->retval = dart_map((dart_dev_t *)request->args[0], request->args[1],
+                                     (void *)request->args[2], request->args[3]);
+            break;
+        case P_DART_UNMAP:
+            dart_unmap((dart_dev_t *)request->args[0], request->args[1], request->args[2]);
+            break;
+        case P_DART_SHUTDOWN:
+            dart_shutdown((dart_dev_t *)request->args[0]);
             break;
 
         default:

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -82,6 +82,11 @@ typedef enum {
     P_KBOOT_SET_INITRD,
     P_KBOOT_PREPARE_DT,
 
+    P_DART_INIT = 0x800, // DART iommu ops
+    P_DART_MAP,
+    P_DART_UNMAP,
+    P_DART_SHUTDOWN,
+
 } ProxyOp;
 
 #define S_OK     0

--- a/src/ringbuffer.c
+++ b/src/ringbuffer.c
@@ -1,0 +1,81 @@
+#include "ringbuffer.h"
+#include "malloc.h"
+#include "types.h"
+
+ringbuffer_t *ringbuffer_alloc(size_t len)
+{
+    ringbuffer_t *bfr = malloc(sizeof(*bfr));
+    if (!bfr)
+        return NULL;
+
+    bfr->buffer = malloc(len);
+    if (!bfr->buffer) {
+        free(bfr);
+        return NULL;
+    }
+
+    bfr->read = 0;
+    bfr->write = 0;
+    bfr->len = len;
+
+    return bfr;
+}
+
+void ringbuffer_free(ringbuffer_t *bfr)
+{
+    if (bfr)
+        free(bfr->buffer);
+    free(bfr);
+}
+
+size_t ringbuffer_read(u8 *target, size_t len, ringbuffer_t *bfr)
+{
+    size_t read;
+
+    for (read = 0; read < len; ++read) {
+        if (bfr->read == bfr->write)
+            break;
+
+        *target = bfr->buffer[bfr->read];
+        target++;
+
+        bfr->read++;
+        bfr->read %= bfr->len;
+    }
+
+    return read;
+}
+
+size_t ringbuffer_write(const u8 *src, size_t len, ringbuffer_t *bfr)
+{
+    size_t written;
+
+    for (written = 0; written < len; ++written) {
+        if (((bfr->write + 1) % bfr->len) == bfr->read)
+            break;
+
+        bfr->buffer[bfr->write] = *src;
+        src++;
+
+        bfr->write++;
+        bfr->write %= bfr->len;
+    }
+
+    return written;
+}
+
+size_t ringbuffer_get_used(ringbuffer_t *bfr)
+{
+    size_t read = bfr->read;
+    size_t write = bfr->write;
+
+    if (write < read)
+        write += bfr->len;
+
+    return write - read;
+}
+
+size_t ringbuffer_get_free(ringbuffer_t *bfr)
+{
+    return bfr->len - ringbuffer_get_used(bfr);
+}

--- a/src/ringbuffer.h
+++ b/src/ringbuffer.h
@@ -1,0 +1,22 @@
+#ifndef RINGBUFFER_H
+#define RINGBUFFER_H
+
+#include "types.h"
+
+typedef struct {
+    u8 *buffer;
+    size_t len;
+    size_t read;
+    size_t write;
+} ringbuffer_t;
+
+ringbuffer_t *ringbuffer_alloc(size_t len);
+void ringbuffer_free(ringbuffer_t *bfr);
+
+size_t ringbuffer_read(u8 *target, size_t len, ringbuffer_t *bfr);
+size_t ringbuffer_write(const u8 *src, size_t len, ringbuffer_t *bfr);
+
+size_t ringbuffer_get_used(ringbuffer_t *bfr);
+size_t ringbuffer_get_free(ringbuffer_t *bfr);
+
+#endif

--- a/src/types.h
+++ b/src/types.h
@@ -36,4 +36,7 @@ typedef s64 ptrdiff_t;
 #define HAVE_UINTPTR_T 1
 #define UPTRDIFF_T     uintptr_t
 
+#define SZ_16K (1 << 14)
+#define SZ_1M  (1 << 20)
+
 #endif

--- a/src/usb.c
+++ b/src/usb.c
@@ -1,0 +1,133 @@
+/* SPDX-License-Identifier: MIT */
+
+#include "usb.h"
+#include "adt.h"
+#include "dart.h"
+#include "malloc.h"
+#include "pmgr.h"
+#include "types.h"
+#include "usb_dwc3.h"
+#include "usb_dwc3_regs.h"
+#include "utils.h"
+
+struct usb_drd_regs {
+    uintptr_t drd_regs;
+    uintptr_t atc;
+};
+
+static const struct {
+    const char *dart_path;
+    const char *dart_mapper_path;
+    const char *atc_path;
+    const char *drd_path;
+} usb_drd_paths[2] = {
+    {
+        .dart_path = "/arm-io/dart-usb0",
+        .dart_mapper_path = "/arm-io/dart-usb0/mapper-usb0",
+        .atc_path = "/arm-io/atc-phy0",
+        .drd_path = "/arm-io/usb-drd0",
+    },
+    {
+        .dart_path = "/arm-io/dart-usb1",
+        .dart_mapper_path = "/arm-io/dart-usb1/mapper-usb1",
+        .atc_path = "/arm-io/atc-phy1",
+        .drd_path = "/arm-io/usb-drd1",
+    },
+};
+
+static dart_dev_t *usb_dart_init(const char *path, const char *mapper_path)
+{
+    int dart_path[8];
+    int dart_offset;
+    int mapper_offset;
+
+    dart_offset = adt_path_offset_trace(adt, path, dart_path);
+    if (dart_offset < 0) {
+        printf("usb: Error getting DART node %s\n", path);
+        return NULL;
+    }
+
+    mapper_offset = adt_path_offset(adt, mapper_path);
+    if (mapper_offset < 0) {
+        printf("usb: Error getting DART mapper node %s\n", mapper_path);
+        return NULL;
+    }
+
+    u64 dart_base;
+    if (adt_get_reg(adt, dart_path, "reg", 1, &dart_base, NULL) < 0) {
+        printf("usb: Error getting DART %s base address.\n", path);
+        return NULL;
+    }
+
+    u32 dart_idx;
+    if (ADT_GETPROP(adt, mapper_offset, "reg", &dart_idx) < 0) {
+        printf("usb: Error getting DART %s device index/\n", mapper_path);
+        return NULL;
+    }
+
+    return dart_init(dart_base, dart_idx);
+}
+
+static int usb_drd_get_regs(const char *phy_path, const char *drd_path, struct usb_drd_regs *regs)
+{
+    int adt_drd_path[8];
+    int adt_drd_offset;
+    int adt_phy_path[8];
+    int adt_phy_offset;
+
+    adt_drd_offset = adt_path_offset_trace(adt, drd_path, adt_drd_path);
+    if (adt_drd_offset < 0) {
+        printf("usb: Error getting drd node %s\n", drd_path);
+        return -1;
+    }
+
+    adt_phy_offset = adt_path_offset_trace(adt, phy_path, adt_phy_path);
+    if (adt_phy_offset < 0) {
+        printf("usb: Error getting phy node %s\n", phy_path);
+        return -1;
+    }
+
+    if (adt_get_reg(adt, adt_phy_path, "reg", 0, &regs->atc, NULL) < 0) {
+        printf("usb: Error getting reg with index 0 for %s.\n", phy_path);
+        return -1;
+    }
+    if (adt_get_reg(adt, adt_drd_path, "reg", 0, &regs->drd_regs, NULL) < 0) {
+        printf("usb: Error getting reg with index 0 for %s.\n", drd_path);
+        return -1;
+    }
+
+    return 0;
+}
+
+static void usb_phy_bringup(struct usb_drd_regs *usb_regs)
+{
+    /* TODO */
+}
+
+dwc3_dev_t *usb_bringup(u32 idx)
+{
+    if (idx >= 2)
+        return NULL;
+
+    if (pmgr_adt_clocks_enable(usb_drd_paths[idx].atc_path) < 0)
+        return NULL;
+
+    if (pmgr_adt_clocks_enable(usb_drd_paths[idx].dart_path) < 0)
+        return NULL;
+
+    if (pmgr_adt_clocks_enable(usb_drd_paths[idx].drd_path) < 0)
+        return NULL;
+
+    dart_dev_t *usb_dart =
+        usb_dart_init(usb_drd_paths[idx].dart_path, usb_drd_paths[idx].dart_mapper_path);
+    if (!usb_dart)
+        return NULL;
+
+    struct usb_drd_regs usb_regs;
+    if (usb_drd_get_regs(usb_drd_paths[idx].atc_path, usb_drd_paths[idx].drd_path, &usb_regs) < 0)
+        return NULL;
+
+    usb_phy_bringup(&usb_regs);
+
+    return usb_dwc3_init(usb_regs.drd_regs, usb_dart);
+}

--- a/src/usb.h
+++ b/src/usb.h
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: MIT */
+
+#ifndef USB_H
+#define USB_H
+
+#include "types.h"
+#include "usb_dwc3.h"
+
+dwc3_dev_t *usb_bringup(u32 idx);
+
+#endif

--- a/src/usb_dwc3.c
+++ b/src/usb_dwc3.c
@@ -1,0 +1,994 @@
+/* SPDX-License-Identifier: MIT */
+
+/*
+ * Useful references:
+ * - TI KeyStone II Architecture Universal Serial Bus 3.0 (USB 3.0) User's Guide
+ *   Literature Number: SPRUHJ7A, https://www.ti.com/lit/ug/spruhj7a/spruhj7a.pdf
+ * - https://www.beyondlogic.org/usbnutshell/usb1.shtml
+ */
+
+#include "dart.h"
+#include "malloc.h"
+#include "memory.h"
+#include "ringbuffer.h"
+#include "string.h"
+#include "types.h"
+#include "usb_dwc3.h"
+#include "usb_dwc3_regs.h"
+#include "usb_types.h"
+#include "utils.h"
+
+#include "../build/build_tag.h"
+
+#define MAX_ENDPOINTS   16
+#define CDC_BUFFER_SIZE SZ_1M
+
+#define usb_debug_printf(fmt, ...) debug_printf("usb-dwc3@%p: " fmt, dev->regs, ##__VA_ARGS__)
+
+#define STRING_DESCRIPTOR_LANGUAGES    0
+#define STRING_DESCRIPTOR_MANUFACTURER 1
+#define STRING_DESCRIPTOR_PRODUCT      2
+#define STRING_DESCRIPTOR_SERIAL       3
+
+#define CDC_DEVICE_CLASS 0x02
+
+#define CDC_USB_VID 0x1337
+#define CDC_USB_PID 0xbeef
+
+#define CDC_INTERFACE_CLASS         0x02
+#define CDC_INTERFACE_CLASS_DATA    0x0a
+#define CDC_INTERFACE_SUBCLASS_ACM  0x02
+#define CDC_INTERFACE_PROTOCOL_NONE 0x00
+#define CDC_INTERFACE_PROTOCOL_AT   0x01
+
+#define DWC3_SCRATCHPAD_SIZE SZ_16K
+#define TRB_BUFFER_SIZE      SZ_16K
+#define XFER_BUFFER_SIZE     SZ_16K
+#define PAD_BUFFER_SIZE      SZ_16K
+
+#define TRBS_PER_EP              (TRB_BUFFER_SIZE / (MAX_ENDPOINTS * sizeof(struct dwc3_trb)))
+#define XFER_BUFFER_BYTES_PER_EP (XFER_BUFFER_SIZE / MAX_ENDPOINTS)
+
+#define SCRATCHPAD_IOVA   0xbeef0000
+#define EVENT_BUFFER_IOVA 0xdead0000
+#define XFER_BUFFER_IOVA  0xbabe0000
+#define TRB_BUFFER_IOVA   0xf00d0000
+
+/* these map to the control endpoint 0x00/0x80 */
+#define USB_LEP_CTRL_OUT 0
+#define USB_LEP_CTRL_IN  1
+
+/* these map to physical endpoints 0x02 and 0x82 */
+#define USB_LEP_CDC_BULK_IN  5
+#define USB_LEP_CDC_BULK_OUT 4
+
+/* content doesn't matter at all, this is the setting linux writes by default */
+static const u8 cdc_default_line_coding[] = {0x80, 0x25, 0x00, 0x00, 0x00, 0x00, 0x08};
+
+enum ep0_state {
+    USB_DWC3_EP0_STATE_IDLE,
+    USB_DWC3_EP0_STATE_SETUP_HANDLE,
+    USB_DWC3_EP0_STATE_DATA_SEND,
+    USB_DWC3_EP0_STATE_DATA_RECV,
+    USB_DWC3_EP0_STATE_DATA_SEND_DONE,
+    USB_DWC3_EP0_STATE_DATA_RECV_DONE,
+    USB_DWC3_EP0_STATE_DATA_RECV_STATUS,
+    USB_DWC3_EP0_STATE_DATA_RECV_STATUS_DONE,
+    USB_DWC3_EP0_STATE_DATA_SEND_STATUS,
+    USB_DWC3_EP0_STATE_DATA_SEND_STATUS_DONE
+};
+
+typedef struct dwc3_dev {
+    /* USB DRD */
+    uintptr_t regs;
+    dart_dev_t *dart;
+
+    enum ep0_state ep0_state;
+    const void *ep0_buffer;
+    u32 ep0_buffer_len;
+    void *ep0_read_buffer;
+    u32 ep0_read_buffer_len;
+
+    void *evtbuffer;
+    u32 evt_buffer_offset;
+
+    void *scratchpad;
+    void *xferbuffer;
+    struct dwc3_trb *trbs;
+
+    struct {
+        u32 xfer_in_progress;
+
+        void *xfer_buffer;
+        uintptr_t xfer_buffer_iova;
+
+        struct dwc3_trb *trb;
+        uintptr_t trb_iova;
+    } endpoints[MAX_ENDPOINTS];
+
+    /* USB ACM CDC serial */
+    u8 cdc_line_coding[7];
+
+    ringbuffer_t *host2device;
+    ringbuffer_t *device2host;
+} dwc3_dev_t;
+
+static const struct usb_string_descriptor str_manufacturer =
+    make_usb_string_descriptor("Asahi Linux");
+static const struct usb_string_descriptor str_product =
+    make_usb_string_descriptor("m1n1 " BUILD_TAG);
+static const struct usb_string_descriptor str_serial = make_usb_string_descriptor("m1n1-uartproxy");
+
+static const struct usb_string_descriptor_languages str_langs = {.bLength = sizeof(str_langs) + 2,
+                                                                 .bDescriptorType =
+                                                                     USB_STRING_DESCRIPTOR,
+                                                                 .wLANGID = {USB_LANGID_EN_US}};
+
+struct cdc_dev_desc {
+    const struct usb_configuration_descriptor configuration;
+    const struct usb_interface_descriptor interface_management;
+    const struct cdc_union_functional_descriptor cdc_union_func;
+    const struct usb_endpoint_descriptor endpoint_notification;
+    const struct usb_interface_descriptor interface_data;
+    const struct usb_endpoint_descriptor endpoint_data_in;
+    const struct usb_endpoint_descriptor endpoint_data_out;
+} PACKED;
+
+static const struct usb_device_descriptor usb_cdc_device_descriptor = {
+    .bLength = sizeof(struct usb_device_descriptor),
+    .bDescriptorType = USB_DEVICE_DESCRIPTOR,
+    .bcdUSB = 0x0200,
+    .bDeviceClass = CDC_DEVICE_CLASS,
+    .bDeviceSubClass = 0, // unused
+    .bDeviceProtocol = 0, // unused
+    .bMaxPacketSize0 = 64,
+    .idVendor = CDC_USB_VID,
+    .idProduct = CDC_USB_PID,
+    .bcdDevice = 0x0100,
+    .iManufacturer = STRING_DESCRIPTOR_MANUFACTURER,
+    .iProduct = STRING_DESCRIPTOR_PRODUCT,
+    .iSerialNumber = STRING_DESCRIPTOR_SERIAL,
+    .bNumConfigurations = 1};
+
+static const struct cdc_dev_desc cdc_configuration_descriptor = {
+    .configuration = {.bLength = sizeof(cdc_configuration_descriptor.configuration),
+                      .bDescriptorType = USB_CONFIGURATION_DESCRIPTOR,
+                      .wTotalLength = sizeof(cdc_configuration_descriptor),
+                      .bNumInterfaces = 2,
+                      .bConfigurationValue = 1,
+                      .iConfiguration = 0,
+                      .bmAttributes = USB_CONFIGURATION_ATTRIBUTE_RES1,
+                      .bMaxPower = 250},
+    .interface_management = {.bLength = sizeof(cdc_configuration_descriptor.interface_management),
+                             .bDescriptorType = USB_INTERFACE_DESCRIPTOR,
+                             .bInterfaceNumber = 0,
+                             .bAlternateSetting = 0,
+                             .bNumEndpoints = 1,
+                             .bInterfaceClass = CDC_INTERFACE_CLASS,
+                             .bInterfaceSubClass = CDC_INTERFACE_SUBCLASS_ACM,
+                             .bInterfaceProtocol = CDC_INTERFACE_PROTOCOL_NONE,
+                             .iInterface = 0},
+    .cdc_union_func =
+        {
+            .bFunctionLength = sizeof(cdc_configuration_descriptor.cdc_union_func),
+            .bDescriptorType = USB_CDC_INTERFACE_FUNCTIONAL_DESCRIPTOR,
+            .bDescriptorSubtype = USB_CDC_UNION_SUBTYPE,
+            .bControlInterface = 0,
+            .bDataInterface = 1,
+        },
+    /*
+     * we actually never configure or use this endpoint on our side and just ignore it.
+     * it needs to exist in the descriptor though to make hosts correctly recognize
+     * us as a ACM CDC device.
+     */
+    .endpoint_notification = {.bLength = sizeof(cdc_configuration_descriptor.endpoint_notification),
+                              .bDescriptorType = USB_ENDPOINT_DESCRIPTOR,
+                              .bEndpointAddress = USB_ENDPOINT_ADDR_OUT(1),
+                              .bmAttributes = USB_ENDPOINT_ATTR_TYPE_INTERRUPT,
+                              .wMaxPacketSize = 64,
+                              .bInterval = 10},
+    .interface_data = {.bLength = sizeof(cdc_configuration_descriptor.interface_data),
+                       .bDescriptorType = USB_INTERFACE_DESCRIPTOR,
+                       .bInterfaceNumber = 1,
+                       .bAlternateSetting = 0,
+                       .bNumEndpoints = 2,
+                       .bInterfaceClass = CDC_INTERFACE_CLASS_DATA,
+                       .bInterfaceSubClass = 0, // unused
+                       .bInterfaceProtocol = 0, // unused
+                       .iInterface = 0},
+    .endpoint_data_in = {.bLength = sizeof(cdc_configuration_descriptor.endpoint_data_in),
+                         .bDescriptorType = USB_ENDPOINT_DESCRIPTOR,
+                         .bEndpointAddress = USB_ENDPOINT_ADDR_OUT(2),
+                         .bmAttributes = USB_ENDPOINT_ATTR_TYPE_BULK,
+                         .wMaxPacketSize = 512,
+                         .bInterval = 10},
+    .endpoint_data_out = {.bLength = sizeof(cdc_configuration_descriptor.endpoint_data_out),
+                          .bDescriptorType = USB_ENDPOINT_DESCRIPTOR,
+                          .bEndpointAddress = USB_ENDPOINT_ADDR_IN(2),
+                          .bmAttributes = USB_ENDPOINT_ATTR_TYPE_BULK,
+                          .wMaxPacketSize = 512,
+                          .bInterval = 10}};
+
+static const char *devt_names[] = {
+    "DisconnEvt", "USBRst",   "ConnectDone", "ULStChng", "WkUpEvt",      "Reserved",       "EOPF",
+    "SOF",        "Reserved", "ErrticErr",   "CmdCmplt", "EvntOverflow", "VndrDevTstRcved"};
+static const char *depvt_names[] = {
+    "Reserved",
+    "XferComplete",
+    "XferInProgress",
+    "XferNotReady",
+    "RxTxFifoEvt (IN->Underrun, OUT->Overrun)",
+    "Reserved",
+    "StreamEvt",
+    "EPCmdCmplt",
+};
+
+static const char *ep0_state_names[] = {
+    "STATE_IDLE",
+    "STATE_SETUP_HANDLE",
+    "STATE_DATA_SEND",
+    "STATE_DATA_RECV",
+    "STATE_DATA_SEND_DONE",
+    "STATE_DATA_RECV_DONE",
+    "STATE_DATA_RECV_STATUS",
+    "STATE_DATA_RECV_STATUS_DONE",
+    "STATE_DATA_SEND_STATUS",
+    "STATE_DATA_SEND_STATUS_DONE",
+};
+
+static int usb_dwc3_command(dwc3_dev_t *dev, u32 command, u32 par)
+{
+    write32(dev->regs + DWC3_DGCMDPAR, par);
+    write32(dev->regs + DWC3_DGCMD, command | DWC3_DGCMD_CMDACT);
+
+    if (poll32(dev->regs + DWC3_DGCMD, DWC3_DGCMD_CMDACT, 0, 1000)) {
+        usb_debug_printf("timeout while waiting for DWC3_DGCMD_CMDACT to clear.\n");
+        return -1;
+    }
+
+    return DWC3_DGCMD_STATUS(read32(dev->regs + DWC3_DGCMD));
+}
+
+static int usb_dwc3_ep_command(dwc3_dev_t *dev, u8 ep, u32 command, u32 par0, u32 par1, u32 par2)
+{
+    write32(dev->regs + DWC3_DEPCMDPAR0(ep), par0);
+    write32(dev->regs + DWC3_DEPCMDPAR1(ep), par1);
+    write32(dev->regs + DWC3_DEPCMDPAR2(ep), par2);
+    write32(dev->regs + DWC3_DEPCMD(ep), command | DWC3_DEPCMD_CMDACT);
+
+    if (poll32(dev->regs + DWC3_DEPCMD(ep), DWC3_DEPCMD_CMDACT, 0, 1000)) {
+        usb_debug_printf("timeout while waiting for DWC3_DEPCMD_CMDACT to clear.\n");
+        return -1;
+    }
+
+    return DWC3_DEPCMD_STATUS(read32(dev->regs + DWC3_DEPCMD(ep)));
+}
+
+static int usb_dwc3_ep_configure(dwc3_dev_t *dev, u8 ep, u8 type, u32 max_packet_len)
+{
+    u32 param0, param1;
+
+    param0 = DWC3_DEPCFG_EP_TYPE(type) | DWC3_DEPCFG_MAX_PACKET_SIZE(max_packet_len);
+    if (type == DWC3_DEPCMD_TYPE_BULK)
+        param0 |= DWC3_DEPCFG_FIFO_NUMBER(ep);
+
+    param1 =
+        DWC3_DEPCFG_XFER_COMPLETE_EN | DWC3_DEPCFG_XFER_NOT_READY_EN | DWC3_DEPCFG_EP_NUMBER(ep);
+
+    if (usb_dwc3_ep_command(dev, ep, DWC3_DEPCMD_SETEPCONFIG, param0, param1, 0)) {
+        usb_debug_printf("cannot issue DWC3_DEPCMD_SETEPCONFIG for EP %d.\n", ep);
+        return -1;
+    }
+
+    if (usb_dwc3_ep_command(dev, ep, DWC3_DEPCMD_SETTRANSFRESOURCE, 1, 0, 0)) {
+        usb_debug_printf("cannot issue DWC3_DEPCMD_SETTRANSFRESOURCE EP %d.\n", ep);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int usb_dwc3_ep_start_transfer(dwc3_dev_t *dev, u8 ep, uintptr_t trb_iova)
+{
+    if (dev->endpoints[ep].xfer_in_progress) {
+        usb_debug_printf(
+            "Tried to start a transfer for ep 0x%02x while another transfer is ongoing.\n", ep);
+        return -1;
+    }
+
+    dma_wmb();
+    int ret =
+        usb_dwc3_ep_command(dev, ep, DWC3_DEPCMD_STARTTRANSFER, trb_iova >> 32, (u32)trb_iova, 0);
+    if (ret) {
+        usb_debug_printf("cannot issue DWC3_DEPCMD_STARTTRANSFER for EP %d: %d.\n", ep, ret);
+        return ret;
+    }
+
+    dev->endpoints[ep].xfer_in_progress = 1;
+    return 0;
+}
+
+static uintptr_t usb_dwc3_init_trb(dwc3_dev_t *dev, u8 ep, struct dwc3_trb **trb)
+{
+    struct dwc3_trb *next_trb = dev->endpoints[ep].trb;
+
+    if (trb)
+        *trb = next_trb;
+
+    next_trb->ctrl = DWC3_TRB_CTRL_HWO | DWC3_TRB_CTRL_ISP_IMI | DWC3_TRB_CTRL_LST;
+    next_trb->size = DWC3_TRB_SIZE_LENGTH(0);
+    next_trb->bph = 0;
+    next_trb->bpl = dev->endpoints[ep].xfer_buffer_iova;
+
+    return dev->endpoints[ep].trb_iova;
+}
+
+static int usb_dwc3_run_data_trb(dwc3_dev_t *dev, u8 ep, u32 data_len)
+{
+    struct dwc3_trb *trb;
+    uintptr_t trb_iova = usb_dwc3_init_trb(dev, ep, &trb);
+
+    trb->ctrl |= DWC3_TRBCTL_CONTROL_DATA;
+    trb->size = DWC3_TRB_SIZE_LENGTH(data_len);
+
+    return usb_dwc3_ep_start_transfer(dev, ep, trb_iova);
+}
+
+static int usb_dwc3_start_setup_phase(dwc3_dev_t *dev)
+{
+    struct dwc3_trb *trb;
+    uintptr_t trb_iova = usb_dwc3_init_trb(dev, USB_LEP_CTRL_OUT, &trb);
+
+    trb->ctrl |= DWC3_TRBCTL_CONTROL_SETUP;
+    trb->size = DWC3_TRB_SIZE_LENGTH(sizeof(union usb_setup_packet));
+    return usb_dwc3_ep_start_transfer(dev, USB_LEP_CTRL_OUT, trb_iova);
+}
+
+static int usb_dwc3_start_status_phase(dwc3_dev_t *dev, u8 ep)
+{
+    struct dwc3_trb *trb;
+    uintptr_t trb_iova = usb_dwc3_init_trb(dev, ep, &trb);
+
+    trb->ctrl |= DWC3_TRBCTL_CONTROL_STATUS2;
+    trb->size = DWC3_TRB_SIZE_LENGTH(0);
+
+    return usb_dwc3_ep_start_transfer(dev, ep, trb_iova);
+}
+
+static int usb_dwc3_ep0_start_data_send_phase(dwc3_dev_t *dev)
+{
+    if (dev->ep0_buffer_len > XFER_BUFFER_BYTES_PER_EP) {
+        usb_debug_printf("Cannot xfer more than %d bytes but was requested to xfer %d on ep 1\n",
+                         XFER_BUFFER_BYTES_PER_EP, dev->ep0_buffer_len);
+        return -1;
+    }
+
+    memset(dev->endpoints[USB_LEP_CTRL_IN].xfer_buffer, 0, 64);
+    memcpy(dev->endpoints[USB_LEP_CTRL_IN].xfer_buffer, dev->ep0_buffer, dev->ep0_buffer_len);
+
+    return usb_dwc3_run_data_trb(dev, USB_LEP_CTRL_IN, dev->ep0_buffer_len);
+}
+
+static int usb_dwc3_ep0_start_data_recv_phase(dwc3_dev_t *dev)
+{
+    if (dev->ep0_buffer_len > XFER_BUFFER_BYTES_PER_EP) {
+        usb_debug_printf("Cannot xfer more than %d bytes but was requested to xfer %d on ep 0\n",
+                         XFER_BUFFER_BYTES_PER_EP, dev->ep0_buffer_len);
+        return -1;
+    }
+
+    memset(dev->endpoints[USB_LEP_CTRL_OUT].xfer_buffer, 0, 64);
+
+    return usb_dwc3_run_data_trb(dev, USB_LEP_CTRL_OUT, 64);
+}
+
+static void usb_dwc3_ep_set_stall(dwc3_dev_t *dev, u8 ep, u8 stall)
+{
+    if (stall)
+        usb_dwc3_ep_command(dev, ep, DWC3_DEPCMD_SETSTALL, 0, 0, 0);
+    else
+        usb_dwc3_ep_command(dev, ep, DWC3_DEPCMD_CLEARSTALL, 0, 0, 0);
+}
+
+static void usb_cdc_get_string_descriptor(u32 index, const void **descriptor, u16 *descriptor_len)
+{
+    switch (index) {
+        case STRING_DESCRIPTOR_LANGUAGES:
+            *descriptor = &str_langs;
+            *descriptor_len = str_langs.bLength;
+            break;
+        case STRING_DESCRIPTOR_MANUFACTURER:
+            *descriptor = &str_manufacturer;
+            *descriptor_len = str_manufacturer.bLength;
+            break;
+        case STRING_DESCRIPTOR_PRODUCT:
+            *descriptor = &str_product;
+            *descriptor_len = str_product.bLength;
+            break;
+        case STRING_DESCRIPTOR_SERIAL:
+            *descriptor = &str_serial;
+            *descriptor_len = str_serial.bLength;
+            break;
+        default:
+            *descriptor = NULL;
+            *descriptor_len = 0;
+    }
+}
+
+static int
+usb_dwc3_handle_ep0_get_descriptor(dwc3_dev_t *dev,
+                                   const struct usb_setup_packet_get_descriptor *get_descriptor)
+{
+    const void *descriptor = NULL;
+    u16 descriptor_len = 0;
+
+    switch (get_descriptor->type) {
+        case USB_DEVICE_DESCRIPTOR:
+            descriptor = &usb_cdc_device_descriptor;
+            descriptor_len = usb_cdc_device_descriptor.bLength;
+            break;
+        case USB_CONFIGURATION_DESCRIPTOR:
+            descriptor = &cdc_configuration_descriptor;
+            descriptor_len = cdc_configuration_descriptor.configuration.wTotalLength;
+            break;
+        case USB_STRING_DESCRIPTOR:
+            usb_cdc_get_string_descriptor(get_descriptor->index, &descriptor, &descriptor_len);
+            break;
+        default:
+            usb_debug_printf("Unknown descriptor type: %d\n", get_descriptor->type);
+            break;
+    }
+
+    if (descriptor) {
+        dev->ep0_buffer = descriptor;
+        dev->ep0_buffer_len = min(get_descriptor->wLength, descriptor_len);
+        return 0;
+    } else {
+        return -1;
+    }
+}
+
+static void usb_dwc3_ep0_handle_standard_device(dwc3_dev_t *dev,
+                                                const union usb_setup_packet *setup)
+{
+    switch (setup->raw.bRequest) {
+        case USB_REQUEST_SET_ADDRESS:
+            mask32(dev->regs + DWC3_DCFG, DWC3_DCFG_DEVADDR_MASK,
+                   DWC3_DCFG_DEVADDR(setup->set_address.address));
+            dev->ep0_state = USB_DWC3_EP0_STATE_DATA_SEND_STATUS;
+            break;
+
+        case USB_REQUEST_SET_CONFIGURATION:
+            /* we've already configured these endpoints so that we just need to enable them here */
+            set32(dev->regs + DWC3_DALEPENA, DWC3_DALEPENA_EP(USB_LEP_CDC_BULK_OUT));
+            set32(dev->regs + DWC3_DALEPENA, DWC3_DALEPENA_EP(USB_LEP_CDC_BULK_IN));
+            dev->ep0_state = USB_DWC3_EP0_STATE_DATA_SEND_STATUS;
+            break;
+
+        case USB_REQUEST_GET_DESCRIPTOR:
+            if (usb_dwc3_handle_ep0_get_descriptor(dev, &setup->get_descriptor) < 0) {
+                usb_dwc3_ep_set_stall(dev, 0, 1);
+                dev->ep0_state = USB_DWC3_EP0_STATE_IDLE;
+            } else {
+                dev->ep0_state = USB_DWC3_EP0_STATE_DATA_SEND;
+            }
+            break;
+
+        default:
+            usb_dwc3_ep_set_stall(dev, 0, 1);
+            dev->ep0_state = USB_DWC3_EP0_STATE_IDLE;
+            usb_debug_printf("unsupported SETUP packet\n");
+    }
+}
+
+static void usb_dwc3_ep0_handle_standard(dwc3_dev_t *dev, const union usb_setup_packet *setup)
+{
+    switch (setup->raw.bmRequestType & USB_REQUEST_TYPE_RECIPIENT_MASK) {
+        case USB_REQUEST_TYPE_RECIPIENT_DEVICE:
+            usb_dwc3_ep0_handle_standard_device(dev, setup);
+            break;
+
+        default:
+            usb_dwc3_ep_set_stall(dev, 0, 1);
+            dev->ep0_state = USB_DWC3_EP0_STATE_IDLE;
+            usb_debug_printf("unimplemented request recipient\n");
+    }
+}
+
+static void usb_dwc3_ep0_handle_class(dwc3_dev_t *dev, const union usb_setup_packet *setup)
+{
+    switch (setup->raw.bRequest) {
+        case USB_REQUEST_CDC_GET_LINE_CODING:
+            dev->ep0_buffer_len = min(setup->raw.wLength, sizeof(dev->cdc_line_coding));
+            dev->ep0_buffer = dev->cdc_line_coding;
+            dev->ep0_state = USB_DWC3_EP0_STATE_DATA_SEND;
+            break;
+
+        case USB_REQUEST_CDC_SET_CTRL_LINE_STATE:
+            dev->ep0_state = USB_DWC3_EP0_STATE_DATA_SEND_STATUS;
+            break;
+
+        case USB_REQUEST_CDC_SET_LINE_CODING:
+            dev->ep0_read_buffer = dev->cdc_line_coding;
+            dev->ep0_read_buffer_len = min(setup->raw.wLength, sizeof(dev->cdc_line_coding));
+            dev->ep0_state = USB_DWC3_EP0_STATE_DATA_RECV;
+            break;
+
+        default:
+            usb_dwc3_ep_set_stall(dev, 0, 1);
+            dev->ep0_state = USB_DWC3_EP0_STATE_IDLE;
+            usb_debug_printf("unsupported SETUP packet\n");
+    }
+}
+
+static void usb_dwc3_ep0_handle_setup(dwc3_dev_t *dev)
+{
+    const union usb_setup_packet *setup = dev->endpoints[0].xfer_buffer;
+
+    switch (setup->raw.bmRequestType & USB_REQUEST_TYPE_MASK) {
+        case USB_REQUEST_TYPE_STANDARD:
+            usb_dwc3_ep0_handle_standard(dev, setup);
+            break;
+        case USB_REQUEST_TYPE_CLASS:
+            usb_dwc3_ep0_handle_class(dev, setup);
+            break;
+        default:
+            usb_debug_printf("unsupported request type\n");
+            usb_dwc3_ep_set_stall(dev, 0, 1);
+            dev->ep0_state = USB_DWC3_EP0_STATE_IDLE;
+    }
+}
+
+static void usb_dwc3_ep0_handle_xfer_done(dwc3_dev_t *dev, const struct dwc3_event_depevt event)
+{
+    switch (dev->ep0_state) {
+        case USB_DWC3_EP0_STATE_SETUP_HANDLE:
+            usb_dwc3_ep0_handle_setup(dev);
+            break;
+
+        case USB_DWC3_EP0_STATE_DATA_RECV_STATUS_DONE:
+        case USB_DWC3_EP0_STATE_DATA_SEND_STATUS_DONE:
+            usb_dwc3_start_setup_phase(dev);
+            dev->ep0_state = USB_DWC3_EP0_STATE_SETUP_HANDLE;
+            break;
+
+        case USB_DWC3_EP0_STATE_DATA_SEND_DONE:
+            dev->ep0_state = USB_DWC3_EP0_STATE_DATA_RECV_STATUS;
+            break;
+
+        case USB_DWC3_EP0_STATE_DATA_RECV_DONE:
+            memcpy(dev->ep0_read_buffer, dev->endpoints[event.endpoint_number].xfer_buffer,
+                   dev->ep0_read_buffer_len);
+            dev->ep0_state = USB_DWC3_EP0_STATE_DATA_SEND_STATUS;
+            break;
+
+        case USB_DWC3_EP0_STATE_IDLE:
+        default:
+            usb_debug_printf("invalid state in usb_dwc3_ep0_handle_xfer_done: %d, %s\n",
+                             dev->ep0_state, ep0_state_names[dev->ep0_state]);
+            usb_dwc3_ep_set_stall(dev, 0, 1);
+            dev->ep0_state = USB_DWC3_EP0_STATE_IDLE;
+    }
+}
+
+static void usb_dwc3_ep0_handle_xfer_not_ready(dwc3_dev_t *dev,
+                                               const struct dwc3_event_depevt event)
+{
+    switch (dev->ep0_state) {
+        case USB_DWC3_EP0_STATE_IDLE:
+            usb_dwc3_start_setup_phase(dev);
+            dev->ep0_state = USB_DWC3_EP0_STATE_SETUP_HANDLE;
+            break;
+
+        case USB_DWC3_EP0_STATE_DATA_SEND:
+            if (usb_dwc3_ep0_start_data_send_phase(dev))
+                usb_debug_printf("cannot start xtrl xfer data phase for EP 1.\n");
+            dev->ep0_state = USB_DWC3_EP0_STATE_DATA_SEND_DONE;
+            break;
+
+        case USB_DWC3_EP0_STATE_DATA_RECV:
+            if (usb_dwc3_ep0_start_data_recv_phase(dev))
+                usb_debug_printf("cannot start xtrl xfer data phase for EP 0.\n");
+            dev->ep0_state = USB_DWC3_EP0_STATE_DATA_RECV_DONE;
+            break;
+
+        case USB_DWC3_EP0_STATE_DATA_RECV_STATUS:
+            usb_dwc3_start_status_phase(dev, USB_LEP_CTRL_OUT);
+            dev->ep0_state = USB_DWC3_EP0_STATE_DATA_RECV_STATUS_DONE;
+            break;
+
+        case USB_DWC3_EP0_STATE_DATA_SEND_STATUS:
+            usb_dwc3_start_status_phase(dev, USB_LEP_CTRL_IN);
+            dev->ep0_state = USB_DWC3_EP0_STATE_DATA_SEND_STATUS_DONE;
+            break;
+
+        default:
+            usb_debug_printf(
+                "invalid state in usb_dwc3_ep0_handle_xfer_not_ready: %d, %s for ep %d (%x)\n",
+                dev->ep0_state, ep0_state_names[dev->ep0_state], event.endpoint_number,
+                event.endpoint_event);
+            usb_dwc3_ep_set_stall(dev, 0, 1);
+            dev->ep0_state = USB_DWC3_EP0_STATE_IDLE;
+    }
+}
+
+static void usb_dwc3_cdc_handle_bulk_out_xfer_not_ready(dwc3_dev_t *dev,
+                                                        const struct dwc3_event_depevt event)
+{
+    struct dwc3_trb *trb;
+    uintptr_t trb_iova;
+
+    size_t len = min(ringbuffer_get_free(dev->host2device), 512);
+    memset(dev->endpoints[event.endpoint_number].xfer_buffer, 0xaa, 512);
+    trb_iova = usb_dwc3_init_trb(dev, event.endpoint_number, &trb);
+    trb->ctrl |= DWC3_TRBCTL_NORMAL;
+    trb->size = DWC3_TRB_SIZE_LENGTH(len);
+
+    usb_dwc3_ep_start_transfer(dev, event.endpoint_number, trb_iova);
+    dev->endpoints[event.endpoint_number].xfer_in_progress = 1;
+}
+
+static void usb_dwc3_cdc_handle_bulk_in_xfer_not_ready(dwc3_dev_t *dev,
+                                                       const struct dwc3_event_depevt event)
+{
+    struct dwc3_trb *trb;
+    uintptr_t trb_iova;
+
+    size_t len =
+        ringbuffer_read(dev->endpoints[event.endpoint_number].xfer_buffer, 512, dev->device2host);
+    trb_iova = usb_dwc3_init_trb(dev, event.endpoint_number, &trb);
+    trb->ctrl |= DWC3_TRBCTL_NORMAL;
+    trb->size = DWC3_TRB_SIZE_LENGTH(len);
+
+    usb_dwc3_ep_start_transfer(dev, event.endpoint_number, trb_iova);
+    dev->endpoints[event.endpoint_number].xfer_in_progress = 1;
+}
+
+static void usb_dwc3_cdc_handle_bulk_out_xfer_done(dwc3_dev_t *dev,
+                                                   const struct dwc3_event_depevt event)
+{
+    size_t len = min(512, ringbuffer_get_free(dev->host2device));
+    ringbuffer_write(dev->endpoints[event.endpoint_number].xfer_buffer,
+                     len - dev->endpoints[event.endpoint_number].trb->size, dev->host2device);
+}
+
+static void usb_dwc3_handle_event_ep(dwc3_dev_t *dev, const struct dwc3_event_depevt event)
+{
+    if (event.endpoint_event == DWC3_DEPEVT_XFERCOMPLETE) {
+        dev->endpoints[event.endpoint_number].xfer_in_progress = 0;
+
+        switch (event.endpoint_number) {
+            case USB_LEP_CTRL_IN:
+            case USB_LEP_CTRL_OUT:
+                return usb_dwc3_ep0_handle_xfer_done(dev, event);
+            case USB_LEP_CDC_BULK_IN:
+                return;
+            case USB_LEP_CDC_BULK_OUT:
+                return usb_dwc3_cdc_handle_bulk_out_xfer_done(dev, event);
+        }
+    } else if (event.endpoint_event == DWC3_DEPEVT_XFERNOTREADY) {
+        /*
+         * this might be a bug, we sometimes get spurious events like these here.
+         * ignoring them works just fine though
+         */
+        if (dev->endpoints[event.endpoint_number].xfer_in_progress)
+            return;
+
+        switch (event.endpoint_number) {
+            case USB_LEP_CTRL_IN:
+            case USB_LEP_CTRL_OUT:
+                return usb_dwc3_ep0_handle_xfer_not_ready(dev, event);
+            case USB_LEP_CDC_BULK_IN:
+                return usb_dwc3_cdc_handle_bulk_in_xfer_not_ready(dev, event);
+            case USB_LEP_CDC_BULK_OUT:
+                return usb_dwc3_cdc_handle_bulk_out_xfer_not_ready(dev, event);
+        }
+    }
+
+    usb_debug_printf("unhandled EP %02x event: %s (0x%02x) (%d)\n", event.endpoint_number,
+                     depvt_names[event.endpoint_event], event.endpoint_event,
+                     dev->endpoints[event.endpoint_number].xfer_in_progress);
+    usb_dwc3_ep_set_stall(dev, event.endpoint_event, 1);
+}
+
+static void usb_dwc3_handle_event_usbrst(dwc3_dev_t *dev)
+{
+    /* clear STALL mode for all endpoints */
+    dev->endpoints[0].xfer_in_progress = 0;
+    for (int i = 1; i < MAX_ENDPOINTS; ++i) {
+        dev->endpoints[i].xfer_in_progress = 0;
+        memset(dev->endpoints[i].xfer_buffer, 0, XFER_BUFFER_BYTES_PER_EP);
+        memset(dev->endpoints[i].trb, 0, TRBS_PER_EP * sizeof(struct dwc3_trb));
+        usb_dwc3_ep_set_stall(dev, i, 0);
+    }
+
+    /* set device address back to zero */
+    mask32(dev->regs + DWC3_DCFG, DWC3_DCFG_DEVADDR_MASK, DWC3_DCFG_DEVADDR(0));
+
+    /* only keep control endpoints enabled */
+    write32(dev->regs + DWC3_DALEPENA, DWC3_DALEPENA_EP(0) | DWC3_DALEPENA_EP(1));
+}
+
+static void usb_dwc3_handle_event_connect_done(dwc3_dev_t *dev)
+{
+    u32 speed = read32(dev->regs + DWC3_DSTS) & DWC3_DSTS_CONNECTSPD;
+
+    if (speed != DWC3_DSTS_HIGHSPEED) {
+        usb_debug_printf(
+            "WARNING: we only support high speed right now but %02x was requested in DSTS\n",
+            speed);
+    }
+
+    usb_dwc3_start_setup_phase(dev);
+    dev->ep0_state = USB_DWC3_EP0_STATE_SETUP_HANDLE;
+}
+
+static void usb_dwc3_handle_event_dev(dwc3_dev_t *dev, const struct dwc3_event_devt event)
+{
+    usb_debug_printf("device event: %s (0x%02x)\n", devt_names[event.type], event.type);
+    switch (event.type) {
+        case DWC3_DEVT_USBRST:
+            usb_dwc3_handle_event_usbrst(dev);
+            break;
+        case DWC3_DEVT_CONNECTDONE:
+            usb_dwc3_handle_event_connect_done(dev);
+            break;
+        default:
+            usb_debug_printf("unhandled device event: %s (0x%02x)\n", devt_names[event.type],
+                             event.type);
+    }
+}
+
+static void usb_dwc3_handle_event(dwc3_dev_t *dev, const union dwc3_event event)
+{
+    if (!event.type.is_devspec)
+        usb_dwc3_handle_event_ep(dev, event.depevt);
+    else if (event.type.type == DWC3_EVENT_TYPE_DEV)
+        usb_dwc3_handle_event_dev(dev, event.devt);
+    else
+        usb_debug_printf("unknown event %08x\n", event.raw);
+}
+
+void usb_dwc3_handle_events(dwc3_dev_t *dev)
+{
+    u32 n_events = read32(dev->regs + DWC3_GEVNTCOUNT(0)) / sizeof(union dwc3_event);
+    if (n_events == 0)
+        return;
+
+    dma_rmb();
+
+    const union dwc3_event *evtbuffer = dev->evtbuffer;
+    for (u32 i = 0; i < n_events; ++i) {
+        usb_dwc3_handle_event(dev, evtbuffer[dev->evt_buffer_offset]);
+
+        dev->evt_buffer_offset =
+            (dev->evt_buffer_offset + 1) % (DWC3_EVENT_BUFFERS_SIZE / sizeof(union dwc3_event));
+    }
+
+    write32(dev->regs + DWC3_GEVNTCOUNT(0), sizeof(union dwc3_event) * n_events);
+}
+
+dwc3_dev_t *usb_dwc3_init(uintptr_t regs, dart_dev_t *dart)
+{
+    /* sanity check */
+    u32 snpsid = read32(regs + DWC3_GSNPSID);
+    if ((snpsid & DWC3_GSNPSID_MASK) != 0x33310000) {
+        debug_printf("no DWC3 core found at %p: %08x\n", regs, snpsid);
+        return NULL;
+    }
+
+    dwc3_dev_t *dev = malloc(sizeof(*dev));
+    if (!dev)
+        return NULL;
+
+    memset(dev, 0, sizeof(*dev));
+    memcpy(dev->cdc_line_coding, cdc_default_line_coding, sizeof(cdc_default_line_coding));
+    dev->regs = regs;
+    dev->dart = dart;
+
+    dev->host2device = ringbuffer_alloc(CDC_BUFFER_SIZE);
+    if (!dev->host2device)
+        goto error;
+    dev->device2host = ringbuffer_alloc(CDC_BUFFER_SIZE);
+    if (!dev->device2host)
+        goto error;
+
+    /* allocate and map dma buffers */
+    dev->evtbuffer = memalign(SZ_16K, max(DWC3_EVENT_BUFFERS_SIZE, SZ_16K));
+    if (!dev->evtbuffer)
+        goto error;
+
+    dev->scratchpad = memalign(SZ_16K, max(DWC3_SCRATCHPAD_SIZE, SZ_16K));
+    if (!dev->scratchpad)
+        goto error;
+
+    dev->trbs = memalign(SZ_16K, TRB_BUFFER_SIZE);
+    if (!dev->trbs)
+        goto error;
+
+    dev->xferbuffer = memalign(SZ_16K, XFER_BUFFER_SIZE);
+    if (!dev->xferbuffer)
+        goto error;
+
+    memset(dev->evtbuffer, 0xaa, max(DWC3_EVENT_BUFFERS_SIZE, SZ_16K));
+    memset(dev->scratchpad, 0, max(DWC3_SCRATCHPAD_SIZE, SZ_16K));
+    memset(dev->xferbuffer, 0, XFER_BUFFER_SIZE);
+    memset(dev->trbs, 0, TRB_BUFFER_SIZE);
+
+    if (dart_map(dev->dart, EVENT_BUFFER_IOVA, dev->evtbuffer,
+                 max(DWC3_EVENT_BUFFERS_SIZE, SZ_16K)))
+        goto error;
+    if (dart_map(dev->dart, SCRATCHPAD_IOVA, dev->scratchpad, max(DWC3_SCRATCHPAD_SIZE, SZ_16K)))
+        goto error;
+    if (dart_map(dev->dart, TRB_BUFFER_IOVA, dev->trbs, TRB_BUFFER_SIZE))
+        goto error;
+    if (dart_map(dev->dart, XFER_BUFFER_IOVA, dev->xferbuffer, XFER_BUFFER_SIZE))
+        goto error;
+
+    /* prepare endpoint buffers */
+    for (int i = 0; i < MAX_ENDPOINTS; ++i) {
+        u32 xferbuffer_offset = i * XFER_BUFFER_BYTES_PER_EP;
+        dev->endpoints[i].xfer_buffer = dev->xferbuffer + xferbuffer_offset;
+        dev->endpoints[i].xfer_buffer_iova = XFER_BUFFER_IOVA + xferbuffer_offset;
+
+        u32 trb_offset = i * TRBS_PER_EP;
+        dev->endpoints[i].trb = &dev->trbs[i * TRBS_PER_EP];
+        dev->endpoints[i].trb_iova = TRB_BUFFER_IOVA + trb_offset * sizeof(struct dwc3_trb);
+    }
+
+    /* reset the device side of the controller */
+    set32(dev->regs + DWC3_DCTL, DWC3_DCTL_CSFTRST);
+    if (poll32(dev->regs + DWC3_DCTL, DWC3_DCTL_CSFTRST, 0, 1000)) {
+        usb_debug_printf("timeout while waiting for DWC3_DCTL_CSFTRST to clear.\n");
+        goto error;
+    }
+
+    /* soft reset the core and phy */
+    set32(dev->regs + DWC3_GCTL, DWC3_GCTL_CORESOFTRESET);
+    set32(dev->regs + DWC3_GUSB3PIPECTL(0), DWC3_GUSB3PIPECTL_PHYSOFTRST);
+    set32(dev->regs + DWC3_GUSB2PHYCFG(0), DWC3_GUSB2PHYCFG_PHYSOFTRST);
+    mdelay(100);
+    clear32(dev->regs + DWC3_GUSB3PIPECTL(0), DWC3_GUSB3PIPECTL_PHYSOFTRST);
+    clear32(dev->regs + DWC3_GUSB2PHYCFG(0), DWC3_GUSB2PHYCFG_PHYSOFTRST);
+    mdelay(100);
+    clear32(dev->regs + DWC3_GCTL, DWC3_GCTL_CORESOFTRESET);
+    mdelay(100);
+
+    /* disable unused features */
+    clear32(dev->regs + DWC3_GCTL, DWC3_GCTL_SCALEDOWN_MASK | DWC3_GCTL_DISSCRAMBLE);
+
+    /* switch to device-only mode */
+    mask32(dev->regs + DWC3_GCTL, DWC3_GCTL_PRTCAPDIR(DWC3_GCTL_PRTCAP_OTG),
+           DWC3_GCTL_PRTCAPDIR(DWC3_GCTL_PRTCAP_DEVICE));
+
+    /* stick to USB 2.0 high speed for now */
+    mask32(dev->regs + DWC3_DCFG, DWC3_DCFG_SPEED_MASK, DWC3_DCFG_HIGHSPEED);
+
+    /* setup scratchpad at SCRATCHPAD_IOVA */
+    if (usb_dwc3_command(dev, DWC3_DGCMD_SET_SCRATCHPAD_ADDR_LO, SCRATCHPAD_IOVA)) {
+        usb_debug_printf("DWC3_DGCMD_SET_SCRATCHPAD_ADDR_LO failed.");
+        goto error;
+    }
+    if (usb_dwc3_command(dev, DWC3_DGCMD_SET_SCRATCHPAD_ADDR_HI, 0)) {
+        usb_debug_printf("DWC3_DGCMD_SET_SCRATCHPAD_ADDR_HI failed.");
+        goto error;
+    }
+
+    /* setup a single event buffer at EVENT_BUFFER_IOVA */
+    write32(dev->regs + DWC3_GEVNTADRLO(0), EVENT_BUFFER_IOVA);
+    write32(dev->regs + DWC3_GEVNTADRHI(0), 0);
+    write32(dev->regs + DWC3_GEVNTSIZ(0), DWC3_EVENT_BUFFERS_SIZE);
+    write32(dev->regs + DWC3_GEVNTCOUNT(0), 0);
+
+    /* enable connect, disconnect and reset events */
+    write32(dev->regs + DWC3_DEVTEN,
+            DWC3_DEVTEN_DISCONNEVTEN | DWC3_DEVTEN_USBRSTEN | DWC3_DEVTEN_CONNECTDONEEN);
+
+    if (usb_dwc3_ep_command(dev, 0, DWC3_DEPCMD_DEPSTARTCFG, 0, 0, 0)) {
+        usb_debug_printf("cannot issue initial DWC3_DEPCMD_DEPSTARTCFG.\n");
+        goto error;
+    }
+
+    /* prepare control endpoint 0 IN and OUT */
+    if (usb_dwc3_ep_configure(dev, USB_LEP_CTRL_OUT, DWC3_DEPCMD_TYPE_CONTROL, 64))
+        goto error;
+    if (usb_dwc3_ep_configure(dev, USB_LEP_CTRL_IN, DWC3_DEPCMD_TYPE_CONTROL, 64))
+        goto error;
+
+    /* prepare BULK endpoints so that we don't have to reconfigure this device later */
+    if (usb_dwc3_ep_configure(dev, USB_LEP_CDC_BULK_OUT, DWC3_DEPCMD_TYPE_BULK, 512))
+        goto error;
+    if (usb_dwc3_ep_configure(dev, USB_LEP_CDC_BULK_IN, DWC3_DEPCMD_TYPE_BULK, 512))
+        goto error;
+
+    /* prepare first control transfer */
+    dev->ep0_state = USB_DWC3_EP0_STATE_IDLE;
+
+    /* only enable control endpoints for now */
+    write32(dev->regs + DWC3_DALEPENA,
+            DWC3_DALEPENA_EP(USB_LEP_CTRL_IN) | DWC3_DALEPENA_EP(USB_LEP_CTRL_OUT));
+
+    /* and finally kick the device controller to go live! */
+    set32(dev->regs + DWC3_DCTL, DWC3_DCTL_RUN_STOP);
+
+    return dev;
+
+error:
+    usb_dwc3_shutdown(dev);
+    return NULL;
+}
+
+void usb_dwc3_shutdown(dwc3_dev_t *dev)
+{
+    /* stop all ongoing transfers */
+    for (int i = 1; i < MAX_ENDPOINTS; ++i) {
+        if (!dev->endpoints[i].xfer_in_progress)
+            continue;
+
+        if (usb_dwc3_ep_command(dev, i, DWC3_DEPCMD_ENDTRANSFER, 0, 0, 0))
+            usb_debug_printf("cannot issue DWC3_DEPCMD_ENDTRANSFER for EP %02x.\n", i);
+    }
+
+    /* disable events and all endpoints and stop the device controller */
+    write32(dev->regs + DWC3_DEVTEN, 0);
+    write32(dev->regs + DWC3_DALEPENA, 0);
+    clear32(dev->regs + DWC3_DCTL, DWC3_DCTL_RUN_STOP);
+
+    /* wait until the controller is shut down */
+    if (poll32(dev->regs + DWC3_DSTS, DWC3_DSTS_DEVCTRLHLT, DWC3_DSTS_DEVCTRLHLT, 1000))
+        usb_debug_printf("timeout while waiting for DWC3_DSTS_DEVCTRLHLT during shutdown.\n");
+
+    /* reset the device side of the controller just to be safe */
+    set32(dev->regs + DWC3_DCTL, DWC3_DCTL_CSFTRST);
+    if (poll32(dev->regs + DWC3_DCTL, DWC3_DCTL_CSFTRST, 0, 1000))
+        usb_debug_printf("timeout while waiting for DWC3_DCTL_CSFTRST to clear during shutdown.\n");
+
+    /* unmap and free dma buffers */
+    dart_unmap(dev->dart, TRB_BUFFER_IOVA, TRB_BUFFER_SIZE);
+    dart_unmap(dev->dart, XFER_BUFFER_IOVA, XFER_BUFFER_SIZE);
+    dart_unmap(dev->dart, SCRATCHPAD_IOVA, max(DWC3_SCRATCHPAD_SIZE, SZ_16K));
+    dart_unmap(dev->dart, EVENT_BUFFER_IOVA, max(DWC3_EVENT_BUFFERS_SIZE, SZ_16K));
+
+    free(dev->evtbuffer);
+    free(dev->scratchpad);
+    free(dev->xferbuffer);
+    free(dev->trbs);
+    ringbuffer_free(dev->host2device);
+    ringbuffer_free(dev->device2host);
+    free(dev);
+}
+
+u8 usb_dwc3_getbyte(dwc3_dev_t *dev)
+{
+    u8 c;
+    while (ringbuffer_read(&c, 1, dev->host2device) < 1)
+        usb_dwc3_handle_events(dev);
+    return c;
+}
+
+void usb_dwc3_putbyte(dwc3_dev_t *dev, u8 byte)
+{
+    while (ringbuffer_write(&byte, 1, dev->device2host) < 1)
+        usb_dwc3_handle_events(dev);
+}
+
+void usb_dwc3_write(dwc3_dev_t *dev, const void *buf, size_t count)
+{
+    const u8 *p = buf;
+
+    while (count--)
+        usb_dwc3_putbyte(dev, *p++);
+}
+
+size_t usb_dwc3_read(dwc3_dev_t *dev, void *buf, size_t count)
+{
+    u8 *p = buf;
+    size_t recvd = 0;
+
+    while (count--) {
+        *p++ = usb_dwc3_getbyte(dev);
+        recvd++;
+    }
+
+    return recvd;
+}

--- a/src/usb_dwc3.h
+++ b/src/usb_dwc3.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: MIT */
+
+#ifndef USB_DWC3_H
+#define USB_DWC3_H
+
+#include "dart.h"
+#include "types.h"
+
+typedef struct dwc3_dev dwc3_dev_t;
+
+dwc3_dev_t *usb_dwc3_init(uintptr_t regs, dart_dev_t *dart);
+void usb_dwc3_shutdown(dwc3_dev_t *dev);
+
+void usb_dwc3_handle_events(dwc3_dev_t *dev);
+
+int usb_dwc3_can_read(dwc3_dev_t *dev);
+int usb_dwc3_can_write(dwc3_dev_t *dev);
+
+u8 usb_dwc3_getbyte(dwc3_dev_t *dev);
+void usb_dwc3_putbyte(dwc3_dev_t *dev, u8 byte);
+
+void usb_dwc3_write(dwc3_dev_t *dev, const void *buf, size_t count);
+size_t usb_dwc3_read(dwc3_dev_t *dev, void *buf, size_t count);
+
+#endif

--- a/src/usb_dwc3_regs.h
+++ b/src/usb_dwc3_regs.h
@@ -375,26 +375,6 @@
 /* This last one is specific to EP0 */
 #define DWC3_EP0_DIR_IN (1 << 31)
 
-enum dwc3_phy {
-    DWC3_PHY_UNKNOWN = 0,
-    DWC3_PHY_USB3,
-    DWC3_PHY_USB2,
-};
-
-enum dwc3_ep0_next {
-    DWC3_EP0_UNKNOWN = 0,
-    DWC3_EP0_COMPLETE,
-    DWC3_EP0_NRDY_DATA,
-    DWC3_EP0_NRDY_STATUS,
-};
-
-enum dwc3_ep0_state {
-    EP0_UNCONNECTED = 0,
-    EP0_SETUP_PHASE,
-    EP0_DATA_PHASE,
-    EP0_STATUS_PHASE,
-};
-
 enum dwc3_link_state {
     /* In SuperSpeed */
     DWC3_LINK_STATE_U0 = 0x00, /* in HS, means ON */

--- a/src/usb_dwc3_regs.h
+++ b/src/usb_dwc3_regs.h
@@ -540,6 +540,18 @@ struct dwc3_event_depevt {
     u32 parameters : 16;
 } PACKED;
 
+#define DWC3_DEVT_DISCONN         0x00
+#define DWC3_DEVT_USBRST          0x01
+#define DWC3_DEVT_CONNECTDONE     0x02
+#define DWC3_DEVT_ULSTCHNG        0x03
+#define DWC3_DEVT_WKUPEVT         0x04
+#define DWC3_DEVT_EOPF            0x06
+#define DWC3_DEVT_SOF             0x07
+#define DWC3_DEVT_ERRTICERR       0x09
+#define DWC3_DEVT_CMDCMPLT        0x0a
+#define DWC3_DEVT_EVNTOVERFLOW    0x0b
+#define DWC3_DEVT_VNDRDEVTSTRCVED 0x0c
+
 /**
  * struct dwc3_event_devt - Device Events
  * @one_bit: indicates this is a non-endpoint event (not used)
@@ -584,5 +596,30 @@ struct dwc3_event_gevt {
     u32 phy_port_number : 4;
     u32 reserved31_12 : 20;
 } PACKED;
+
+union dwc3_event {
+    u32 raw;
+    struct dwc3_event_type type;
+    struct dwc3_event_depevt depevt;
+    struct dwc3_event_devt devt;
+    struct dwc3_event_gevt gevt;
+};
+
+#define DWC3_DEPCFG_EP_TYPE(n)         (((n)&0x3) << 1)
+#define DWC3_DEPCFG_EP_NUMBER(n)       (((n)&0x1f) << 25)
+#define DWC3_DEPCFG_FIFO_NUMBER(n)     (((n)&0xf) << 17)
+#define DWC3_DEPCFG_MAX_PACKET_SIZE(n) (((n)&0x7ff) << 3)
+
+#define DWC3_DEPCFG_INT_NUM(n)          (((n)&0x1f) << 0)
+#define DWC3_DEPCFG_XFER_COMPLETE_EN    BIT(8)
+#define DWC3_DEPCFG_XFER_IN_PROGRESS_EN BIT(9)
+#define DWC3_DEPCFG_XFER_NOT_READY_EN   BIT(10)
+#define DWC3_DEPCFG_FIFO_ERROR_EN       BIT(11)
+#define DWC3_DEPCFG_STREAM_EVENT_EN     BIT(13)
+#define DWC3_DEPCFG_BINTERVAL_M1(n)     (((n)&0xff) << 16)
+#define DWC3_DEPCFG_STREAM_CAPABLE      BIT(24)
+#define DWC3_DEPCFG_EP_NUMBER(n)        (((n)&0x1f) << 25)
+#define DWC3_DEPCFG_BULK_BASED          BIT(30)
+#define DWC3_DEPCFG_FIFO_BASED          BIT(31)
 
 #endif /* __DRIVERS_USB_DWC3_CORE_H */

--- a/src/usb_dwc3_regs.h
+++ b/src/usb_dwc3_regs.h
@@ -1,0 +1,608 @@
+/**
+ * core.h - DesignWare USB3 DRD Core Header
+ * linux commit 7bc5a6ba369217e0137833f5955cf0b0f08b0712 before
+ * the switch to GPLv2 only
+ *
+ * Copyright (C) 2010-2011 Texas Instruments Incorporated - http://www.ti.com
+ *
+ * Authors: Felipe Balbi <balbi@ti.com>,
+ *	    Sebastian Andrzej Siewior <bigeasy@linutronix.de>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions, and the following disclaimer,
+ *    without modification.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The names of the above-listed copyright holders may not be used
+ *    to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * ALTERNATIVELY, this software may be distributed under the terms of the
+ * GNU General Public License ("GPL") version 2, as published by the Free
+ * Software Foundation.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __DRIVERS_USB_DWC3_CORE_H
+#define __DRIVERS_USB_DWC3_CORE_H
+
+#include "types.h"
+
+/* Global constants */
+#define DWC3_EP0_BOUNCE_SIZE    512
+#define DWC3_ENDPOINTS_NUM      32
+#define DWC3_XHCI_RESOURCES_NUM 2
+
+#define DWC3_EVENT_SIZE         4  /* bytes */
+#define DWC3_EVENT_MAX_NUM      64 /* 2 events/endpoint */
+#define DWC3_EVENT_BUFFERS_SIZE (DWC3_EVENT_SIZE * DWC3_EVENT_MAX_NUM)
+#define DWC3_EVENT_TYPE_MASK    0xfe
+
+#define DWC3_EVENT_TYPE_DEV    0
+#define DWC3_EVENT_TYPE_CARKIT 3
+#define DWC3_EVENT_TYPE_I2C    4
+
+#define DWC3_DEVICE_EVENT_DISCONNECT         0
+#define DWC3_DEVICE_EVENT_RESET              1
+#define DWC3_DEVICE_EVENT_CONNECT_DONE       2
+#define DWC3_DEVICE_EVENT_LINK_STATUS_CHANGE 3
+#define DWC3_DEVICE_EVENT_WAKEUP             4
+#define DWC3_DEVICE_EVENT_HIBER_REQ          5
+#define DWC3_DEVICE_EVENT_EOPF               6
+#define DWC3_DEVICE_EVENT_SOF                7
+#define DWC3_DEVICE_EVENT_ERRATIC_ERROR      9
+#define DWC3_DEVICE_EVENT_CMD_CMPL           10
+#define DWC3_DEVICE_EVENT_OVERFLOW           11
+
+#define DWC3_GEVNTCOUNT_MASK 0xfffc
+#define DWC3_GSNPSID_MASK    0xffff0000
+#define DWC3_GSNPSREV_MASK   0xffff
+
+/* DWC3 registers memory space boundries */
+#define DWC3_XHCI_REGS_START    0x0
+#define DWC3_XHCI_REGS_END      0x7fff
+#define DWC3_GLOBALS_REGS_START 0xc100
+#define DWC3_GLOBALS_REGS_END   0xc6ff
+#define DWC3_DEVICE_REGS_START  0xc700
+#define DWC3_DEVICE_REGS_END    0xcbff
+#define DWC3_OTG_REGS_START     0xcc00
+#define DWC3_OTG_REGS_END       0xccff
+
+/* Global Registers */
+#define DWC3_GSBUSCFG0     0xc100
+#define DWC3_GSBUSCFG1     0xc104
+#define DWC3_GTXTHRCFG     0xc108
+#define DWC3_GRXTHRCFG     0xc10c
+#define DWC3_GCTL          0xc110
+#define DWC3_GEVTEN        0xc114
+#define DWC3_GSTS          0xc118
+#define DWC3_GSNPSID       0xc120
+#define DWC3_GGPIO         0xc124
+#define DWC3_GUID          0xc128
+#define DWC3_GUCTL         0xc12c
+#define DWC3_GBUSERRADDR0  0xc130
+#define DWC3_GBUSERRADDR1  0xc134
+#define DWC3_GPRTBIMAP0    0xc138
+#define DWC3_GPRTBIMAP1    0xc13c
+#define DWC3_GHWPARAMS0    0xc140
+#define DWC3_GHWPARAMS1    0xc144
+#define DWC3_GHWPARAMS2    0xc148
+#define DWC3_GHWPARAMS3    0xc14c
+#define DWC3_GHWPARAMS4    0xc150
+#define DWC3_GHWPARAMS5    0xc154
+#define DWC3_GHWPARAMS6    0xc158
+#define DWC3_GHWPARAMS7    0xc15c
+#define DWC3_GDBGFIFOSPACE 0xc160
+#define DWC3_GDBGLTSSM     0xc164
+#define DWC3_GPRTBIMAP_HS0 0xc180
+#define DWC3_GPRTBIMAP_HS1 0xc184
+#define DWC3_GPRTBIMAP_FS0 0xc188
+#define DWC3_GPRTBIMAP_FS1 0xc18c
+
+#define DWC3_GUSB2PHYCFG(n) (0xc200 + (n * 0x04))
+#define DWC3_GUSB2I2CCTL(n) (0xc240 + (n * 0x04))
+
+#define DWC3_GUSB2PHYACC(n) (0xc280 + (n * 0x04))
+
+#define DWC3_GUSB3PIPECTL(n) (0xc2c0 + (n * 0x04))
+
+#define DWC3_GTXFIFOSIZ(n) (0xc300 + (n * 0x04))
+#define DWC3_GRXFIFOSIZ(n) (0xc380 + (n * 0x04))
+
+#define DWC3_GEVNTADRLO(n) (0xc400 + (n * 0x10))
+#define DWC3_GEVNTADRHI(n) (0xc404 + (n * 0x10))
+#define DWC3_GEVNTSIZ(n)   (0xc408 + (n * 0x10))
+#define DWC3_GEVNTCOUNT(n) (0xc40c + (n * 0x10))
+
+#define DWC3_GHWPARAMS8 0xc600
+
+/* Device Registers */
+#define DWC3_DCFG          0xc700
+#define DWC3_DCTL          0xc704
+#define DWC3_DEVTEN        0xc708
+#define DWC3_DSTS          0xc70c
+#define DWC3_DGCMDPAR      0xc710
+#define DWC3_DGCMD         0xc714
+#define DWC3_DALEPENA      0xc720
+#define DWC3_DEPCMDPAR2(n) (0xc800 + (n * 0x10))
+#define DWC3_DEPCMDPAR1(n) (0xc804 + (n * 0x10))
+#define DWC3_DEPCMDPAR0(n) (0xc808 + (n * 0x10))
+#define DWC3_DEPCMD(n)     (0xc80c + (n * 0x10))
+
+/* OTG Registers */
+#define DWC3_OCFG   0xcc00
+#define DWC3_OCTL   0xcc04
+#define DWC3_OEVT   0xcc08
+#define DWC3_OEVTEN 0xcc0C
+#define DWC3_OSTS   0xcc10
+
+/* Bit fields */
+
+/* Global Configuration Register */
+#define DWC3_GCTL_PWRDNSCALE(n) ((n) << 19)
+#define DWC3_GCTL_U2RSTECN      (1 << 16)
+#define DWC3_GCTL_RAMCLKSEL(x)  (((x)&DWC3_GCTL_CLK_MASK) << 6)
+#define DWC3_GCTL_CLK_BUS       (0)
+#define DWC3_GCTL_CLK_PIPE      (1)
+#define DWC3_GCTL_CLK_PIPEHALF  (2)
+#define DWC3_GCTL_CLK_MASK      (3)
+
+#define DWC3_GCTL_PRTCAP(n)     (((n) & (3 << 12)) >> 12)
+#define DWC3_GCTL_PRTCAPDIR(n)  ((n) << 12)
+#define DWC3_GCTL_PRTCAP_HOST   1
+#define DWC3_GCTL_PRTCAP_DEVICE 2
+#define DWC3_GCTL_PRTCAP_OTG    3
+
+#define DWC3_GCTL_CORESOFTRESET    (1 << 11)
+#define DWC3_GCTL_SCALEDOWN(n)     ((n) << 4)
+#define DWC3_GCTL_SCALEDOWN_MASK   DWC3_GCTL_SCALEDOWN(3)
+#define DWC3_GCTL_DISSCRAMBLE      (1 << 3)
+#define DWC3_GCTL_GBLHIBERNATIONEN (1 << 1)
+#define DWC3_GCTL_DSBLCLKGTNG      (1 << 0)
+
+/* Global USB2 PHY Configuration Register */
+#define DWC3_GUSB2PHYCFG_PHYSOFTRST (1 << 31)
+#define DWC3_GUSB2PHYCFG_SUSPHY     (1 << 6)
+
+/* Global USB3 PIPE Control Register */
+#define DWC3_GUSB3PIPECTL_PHYSOFTRST (1 << 31)
+#define DWC3_GUSB3PIPECTL_SUSPHY     (1 << 17)
+
+/* Global TX Fifo Size Register */
+#define DWC3_GTXFIFOSIZ_TXFDEF(n)    ((n)&0xffff)
+#define DWC3_GTXFIFOSIZ_TXFSTADDR(n) ((n)&0xffff0000)
+
+/* Global HWPARAMS1 Register */
+#define DWC3_GHWPARAMS1_EN_PWROPT(n)  (((n) & (3 << 24)) >> 24)
+#define DWC3_GHWPARAMS1_EN_PWROPT_NO  0
+#define DWC3_GHWPARAMS1_EN_PWROPT_CLK 1
+#define DWC3_GHWPARAMS1_EN_PWROPT_HIB 2
+#define DWC3_GHWPARAMS1_PWROPT(n)     ((n) << 24)
+#define DWC3_GHWPARAMS1_PWROPT_MASK   DWC3_GHWPARAMS1_PWROPT(3)
+
+/* Global HWPARAMS4 Register */
+#define DWC3_GHWPARAMS4_HIBER_SCRATCHBUFS(n) (((n) & (0x0f << 13)) >> 13)
+#define DWC3_MAX_HIBER_SCRATCHBUFS           15
+
+/* Device Configuration Register */
+#define DWC3_DCFG_LPM_CAP       (1 << 22)
+#define DWC3_DCFG_DEVADDR(addr) ((addr) << 3)
+#define DWC3_DCFG_DEVADDR_MASK  DWC3_DCFG_DEVADDR(0x7f)
+
+#define DWC3_DCFG_SPEED_MASK (7 << 0)
+#define DWC3_DCFG_SUPERSPEED (4 << 0)
+#define DWC3_DCFG_HIGHSPEED  (0 << 0)
+#define DWC3_DCFG_FULLSPEED2 (1 << 0)
+#define DWC3_DCFG_LOWSPEED   (2 << 0)
+#define DWC3_DCFG_FULLSPEED1 (3 << 0)
+
+#define DWC3_DCFG_LPM_CAP (1 << 22)
+
+/* Device Control Register */
+#define DWC3_DCTL_RUN_STOP (1 << 31)
+#define DWC3_DCTL_CSFTRST  (1 << 30)
+#define DWC3_DCTL_LSFTRST  (1 << 29)
+
+#define DWC3_DCTL_HIRD_THRES_MASK (0x1f << 24)
+#define DWC3_DCTL_HIRD_THRES(n)   ((n) << 24)
+
+#define DWC3_DCTL_APPL1RES (1 << 23)
+
+/* These apply for core versions 1.87a and earlier */
+#define DWC3_DCTL_TRGTULST_MASK     (0x0f << 17)
+#define DWC3_DCTL_TRGTULST(n)       ((n) << 17)
+#define DWC3_DCTL_TRGTULST_U2       (DWC3_DCTL_TRGTULST(2))
+#define DWC3_DCTL_TRGTULST_U3       (DWC3_DCTL_TRGTULST(3))
+#define DWC3_DCTL_TRGTULST_SS_DIS   (DWC3_DCTL_TRGTULST(4))
+#define DWC3_DCTL_TRGTULST_RX_DET   (DWC3_DCTL_TRGTULST(5))
+#define DWC3_DCTL_TRGTULST_SS_INACT (DWC3_DCTL_TRGTULST(6))
+
+/* These apply for core versions 1.94a and later */
+#define DWC3_DCTL_KEEP_CONNECT (1 << 19)
+#define DWC3_DCTL_L1_HIBER_EN  (1 << 18)
+#define DWC3_DCTL_CRS          (1 << 17)
+#define DWC3_DCTL_CSS          (1 << 16)
+
+#define DWC3_DCTL_INITU2ENA    (1 << 12)
+#define DWC3_DCTL_ACCEPTU2ENA  (1 << 11)
+#define DWC3_DCTL_INITU1ENA    (1 << 10)
+#define DWC3_DCTL_ACCEPTU1ENA  (1 << 9)
+#define DWC3_DCTL_TSTCTRL_MASK (0xf << 1)
+
+#define DWC3_DCTL_ULSTCHNGREQ_MASK (0x0f << 5)
+#define DWC3_DCTL_ULSTCHNGREQ(n)   (((n) << 5) & DWC3_DCTL_ULSTCHNGREQ_MASK)
+
+#define DWC3_DCTL_ULSTCHNG_NO_ACTION   (DWC3_DCTL_ULSTCHNGREQ(0))
+#define DWC3_DCTL_ULSTCHNG_SS_DISABLED (DWC3_DCTL_ULSTCHNGREQ(4))
+#define DWC3_DCTL_ULSTCHNG_RX_DETECT   (DWC3_DCTL_ULSTCHNGREQ(5))
+#define DWC3_DCTL_ULSTCHNG_SS_INACTIVE (DWC3_DCTL_ULSTCHNGREQ(6))
+#define DWC3_DCTL_ULSTCHNG_RECOVERY    (DWC3_DCTL_ULSTCHNGREQ(8))
+#define DWC3_DCTL_ULSTCHNG_COMPLIANCE  (DWC3_DCTL_ULSTCHNGREQ(10))
+#define DWC3_DCTL_ULSTCHNG_LOOPBACK    (DWC3_DCTL_ULSTCHNGREQ(11))
+
+/* Device Event Enable Register */
+#define DWC3_DEVTEN_VNDRDEVTSTRCVEDEN   (1 << 12)
+#define DWC3_DEVTEN_EVNTOVERFLOWEN      (1 << 11)
+#define DWC3_DEVTEN_CMDCMPLTEN          (1 << 10)
+#define DWC3_DEVTEN_ERRTICERREN         (1 << 9)
+#define DWC3_DEVTEN_SOFEN               (1 << 7)
+#define DWC3_DEVTEN_EOPFEN              (1 << 6)
+#define DWC3_DEVTEN_HIBERNATIONREQEVTEN (1 << 5)
+#define DWC3_DEVTEN_WKUPEVTEN           (1 << 4)
+#define DWC3_DEVTEN_ULSTCNGEN           (1 << 3)
+#define DWC3_DEVTEN_CONNECTDONEEN       (1 << 2)
+#define DWC3_DEVTEN_USBRSTEN            (1 << 1)
+#define DWC3_DEVTEN_DISCONNEVTEN        (1 << 0)
+
+/* Device Status Register */
+#define DWC3_DSTS_DCNRD (1 << 29)
+
+/* This applies for core versions 1.87a and earlier */
+#define DWC3_DSTS_PWRUPREQ (1 << 24)
+
+/* These apply for core versions 1.94a and later */
+#define DWC3_DSTS_RSS (1 << 25)
+#define DWC3_DSTS_SSS (1 << 24)
+
+#define DWC3_DSTS_COREIDLE   (1 << 23)
+#define DWC3_DSTS_DEVCTRLHLT (1 << 22)
+
+#define DWC3_DSTS_USBLNKST_MASK (0x0f << 18)
+#define DWC3_DSTS_USBLNKST(n)   (((n)&DWC3_DSTS_USBLNKST_MASK) >> 18)
+
+#define DWC3_DSTS_RXFIFOEMPTY (1 << 17)
+
+#define DWC3_DSTS_SOFFN_MASK (0x3fff << 3)
+#define DWC3_DSTS_SOFFN(n)   (((n)&DWC3_DSTS_SOFFN_MASK) >> 3)
+
+#define DWC3_DSTS_CONNECTSPD (7 << 0)
+
+#define DWC3_DSTS_SUPERSPEED (4 << 0)
+#define DWC3_DSTS_HIGHSPEED  (0 << 0)
+#define DWC3_DSTS_FULLSPEED2 (1 << 0)
+#define DWC3_DSTS_LOWSPEED   (2 << 0)
+#define DWC3_DSTS_FULLSPEED1 (3 << 0)
+
+/* Device Generic Command Register */
+#define DWC3_DGCMD_SET_LMP          0x01
+#define DWC3_DGCMD_SET_PERIODIC_PAR 0x02
+#define DWC3_DGCMD_XMIT_FUNCTION    0x03
+
+/* These apply for core versions 1.94a and later */
+#define DWC3_DGCMD_SET_SCRATCHPAD_ADDR_LO 0x04
+#define DWC3_DGCMD_SET_SCRATCHPAD_ADDR_HI 0x05
+
+#define DWC3_DGCMD_SELECTED_FIFO_FLUSH  0x09
+#define DWC3_DGCMD_ALL_FIFO_FLUSH       0x0a
+#define DWC3_DGCMD_SET_ENDPOINT_NRDY    0x0c
+#define DWC3_DGCMD_RUN_SOC_BUS_LOOPBACK 0x10
+
+#define DWC3_DGCMD_STATUS(n) (((n) >> 15) & 1)
+#define DWC3_DGCMD_CMDACT    (1 << 10)
+#define DWC3_DGCMD_CMDIOC    (1 << 8)
+
+/* Device Generic Command Parameter Register */
+#define DWC3_DGCMDPAR_FORCE_LINKPM_ACCEPT (1 << 0)
+#define DWC3_DGCMDPAR_FIFO_NUM(n)         ((n) << 0)
+#define DWC3_DGCMDPAR_RX_FIFO             (0 << 5)
+#define DWC3_DGCMDPAR_TX_FIFO             (1 << 5)
+#define DWC3_DGCMDPAR_LOOPBACK_DIS        (0 << 0)
+#define DWC3_DGCMDPAR_LOOPBACK_ENA        (1 << 0)
+
+/* Device Endpoint Command Register */
+#define DWC3_DEPCMD_PARAM_SHIFT    16
+#define DWC3_DEPCMD_PARAM(x)       ((x) << DWC3_DEPCMD_PARAM_SHIFT)
+#define DWC3_DEPCMD_GET_RSC_IDX(x) (((x) >> DWC3_DEPCMD_PARAM_SHIFT) & 0x7f)
+#define DWC3_DEPCMD_STATUS(x)      (((x) >> 15) & 1)
+#define DWC3_DEPCMD_HIPRI_FORCERM  (1 << 11)
+#define DWC3_DEPCMD_CMDACT         (1 << 10)
+#define DWC3_DEPCMD_CMDIOC         (1 << 8)
+
+#define DWC3_DEPCMD_DEPSTARTCFG    (0x09 << 0)
+#define DWC3_DEPCMD_ENDTRANSFER    (0x08 << 0)
+#define DWC3_DEPCMD_UPDATETRANSFER (0x07 << 0)
+#define DWC3_DEPCMD_STARTTRANSFER  (0x06 << 0)
+#define DWC3_DEPCMD_CLEARSTALL     (0x05 << 0)
+#define DWC3_DEPCMD_SETSTALL       (0x04 << 0)
+/* This applies for core versions 1.90a and earlier */
+#define DWC3_DEPCMD_GETSEQNUMBER (0x03 << 0)
+/* This applies for core versions 1.94a and later */
+#define DWC3_DEPCMD_GETEPSTATE        (0x03 << 0)
+#define DWC3_DEPCMD_SETTRANSFRESOURCE (0x02 << 0)
+#define DWC3_DEPCMD_SETEPCONFIG       (0x01 << 0)
+
+/* The EP number goes 0..31 so ep0 is always out and ep1 is always in */
+#define DWC3_DALEPENA_EP(n) (1 << n)
+
+#define DWC3_DEPCMD_TYPE_CONTROL 0
+#define DWC3_DEPCMD_TYPE_ISOC    1
+#define DWC3_DEPCMD_TYPE_BULK    2
+#define DWC3_DEPCMD_TYPE_INTR    3
+
+#define DWC3_EVENT_PENDING BIT(0)
+
+#define DWC3_EP_FLAG_STALLED (1 << 0)
+#define DWC3_EP_FLAG_WEDGED  (1 << 1)
+
+#define DWC3_EP_DIRECTION_TX true
+#define DWC3_EP_DIRECTION_RX false
+
+#define DWC3_TRB_NUM  32
+#define DWC3_TRB_MASK (DWC3_TRB_NUM - 1)
+
+#define DWC3_EP_ENABLED         (1 << 0)
+#define DWC3_EP_STALL           (1 << 1)
+#define DWC3_EP_WEDGE           (1 << 2)
+#define DWC3_EP_BUSY            (1 << 4)
+#define DWC3_EP_PENDING_REQUEST (1 << 5)
+#define DWC3_EP_MISSED_ISOC     (1 << 6)
+
+/* This last one is specific to EP0 */
+#define DWC3_EP0_DIR_IN (1 << 31)
+
+enum dwc3_phy {
+    DWC3_PHY_UNKNOWN = 0,
+    DWC3_PHY_USB3,
+    DWC3_PHY_USB2,
+};
+
+enum dwc3_ep0_next {
+    DWC3_EP0_UNKNOWN = 0,
+    DWC3_EP0_COMPLETE,
+    DWC3_EP0_NRDY_DATA,
+    DWC3_EP0_NRDY_STATUS,
+};
+
+enum dwc3_ep0_state {
+    EP0_UNCONNECTED = 0,
+    EP0_SETUP_PHASE,
+    EP0_DATA_PHASE,
+    EP0_STATUS_PHASE,
+};
+
+enum dwc3_link_state {
+    /* In SuperSpeed */
+    DWC3_LINK_STATE_U0 = 0x00, /* in HS, means ON */
+    DWC3_LINK_STATE_U1 = 0x01,
+    DWC3_LINK_STATE_U2 = 0x02, /* in HS, means SLEEP */
+    DWC3_LINK_STATE_U3 = 0x03, /* in HS, means SUSPEND */
+    DWC3_LINK_STATE_SS_DIS = 0x04,
+    DWC3_LINK_STATE_RX_DET = 0x05, /* in HS, means Early Suspend */
+    DWC3_LINK_STATE_SS_INACT = 0x06,
+    DWC3_LINK_STATE_POLL = 0x07,
+    DWC3_LINK_STATE_RECOV = 0x08,
+    DWC3_LINK_STATE_HRESET = 0x09,
+    DWC3_LINK_STATE_CMPLY = 0x0a,
+    DWC3_LINK_STATE_LPBK = 0x0b,
+    DWC3_LINK_STATE_RESET = 0x0e,
+    DWC3_LINK_STATE_RESUME = 0x0f,
+    DWC3_LINK_STATE_MASK = 0x0f,
+};
+
+/* TRB Length, PCM and Status */
+#define DWC3_TRB_SIZE_MASK      (0x00ffffff)
+#define DWC3_TRB_SIZE_LENGTH(n) ((n)&DWC3_TRB_SIZE_MASK)
+#define DWC3_TRB_SIZE_PCM1(n)   (((n)&0x03) << 24)
+#define DWC3_TRB_SIZE_TRBSTS(n) (((n) & (0x0f << 28)) >> 28)
+
+#define DWC3_TRBSTS_OK            0
+#define DWC3_TRBSTS_MISSED_ISOC   1
+#define DWC3_TRBSTS_SETUP_PENDING 2
+#define DWC3_TRB_STS_XFER_IN_PROG 4
+
+/* TRB Control */
+#define DWC3_TRB_CTRL_HWO         (1 << 0)
+#define DWC3_TRB_CTRL_LST         (1 << 1)
+#define DWC3_TRB_CTRL_CHN         (1 << 2)
+#define DWC3_TRB_CTRL_CSP         (1 << 3)
+#define DWC3_TRB_CTRL_TRBCTL(n)   (((n)&0x3f) << 4)
+#define DWC3_TRB_CTRL_ISP_IMI     (1 << 10)
+#define DWC3_TRB_CTRL_IOC         (1 << 11)
+#define DWC3_TRB_CTRL_SID_SOFN(n) (((n)&0xffff) << 14)
+
+#define DWC3_TRBCTL_NORMAL            DWC3_TRB_CTRL_TRBCTL(1)
+#define DWC3_TRBCTL_CONTROL_SETUP     DWC3_TRB_CTRL_TRBCTL(2)
+#define DWC3_TRBCTL_CONTROL_STATUS2   DWC3_TRB_CTRL_TRBCTL(3)
+#define DWC3_TRBCTL_CONTROL_STATUS3   DWC3_TRB_CTRL_TRBCTL(4)
+#define DWC3_TRBCTL_CONTROL_DATA      DWC3_TRB_CTRL_TRBCTL(5)
+#define DWC3_TRBCTL_ISOCHRONOUS_FIRST DWC3_TRB_CTRL_TRBCTL(6)
+#define DWC3_TRBCTL_ISOCHRONOUS       DWC3_TRB_CTRL_TRBCTL(7)
+#define DWC3_TRBCTL_LINK_TRB          DWC3_TRB_CTRL_TRBCTL(8)
+
+/**
+ * struct dwc3_trb - transfer request block (hw format)
+ * @bpl: DW0-3
+ * @bph: DW4-7
+ * @size: DW8-B
+ * @trl: DWC-F
+ */
+struct dwc3_trb {
+    u32 bpl;
+    u32 bph;
+    u32 size;
+    u32 ctrl;
+} PACKED;
+
+/* HWPARAMS0 */
+#define DWC3_MODE(n) ((n)&0x7)
+
+#define DWC3_MODE_DEVICE 0
+#define DWC3_MODE_HOST   1
+#define DWC3_MODE_DRD    2
+#define DWC3_MODE_HUB    3
+
+#define DWC3_MDWIDTH(n) (((n)&0xff00) >> 8)
+
+/* HWPARAMS1 */
+#define DWC3_NUM_INT(n) (((n) & (0x3f << 15)) >> 15)
+
+/* HWPARAMS3 */
+#define DWC3_NUM_IN_EPS_MASK (0x1f << 18)
+#define DWC3_NUM_EPS_MASK    (0x3f << 12)
+#define DWC3_NUM_EPS(p)      (((p)->hwparams3 & (DWC3_NUM_EPS_MASK)) >> 12)
+#define DWC3_NUM_IN_EPS(p)   (((p)->hwparams3 & (DWC3_NUM_IN_EPS_MASK)) >> 18)
+
+/* HWPARAMS7 */
+#define DWC3_RAM1_DEPTH(n) ((n)&0xffff)
+
+#define DWC3_REVISION_173A 0x5533173a
+#define DWC3_REVISION_175A 0x5533175a
+#define DWC3_REVISION_180A 0x5533180a
+#define DWC3_REVISION_183A 0x5533183a
+#define DWC3_REVISION_185A 0x5533185a
+#define DWC3_REVISION_187A 0x5533187a
+#define DWC3_REVISION_188A 0x5533188a
+#define DWC3_REVISION_190A 0x5533190a
+#define DWC3_REVISION_194A 0x5533194a
+#define DWC3_REVISION_200A 0x5533200a
+#define DWC3_REVISION_202A 0x5533202a
+#define DWC3_REVISION_210A 0x5533210a
+#define DWC3_REVISION_220A 0x5533220a
+#define DWC3_REVISION_230A 0x5533230a
+#define DWC3_REVISION_240A 0x5533240a
+#define DWC3_REVISION_250A 0x5533250a
+
+/* -------------------------------------------------------------------------- */
+
+/* -------------------------------------------------------------------------- */
+
+struct dwc3_event_type {
+    u32 is_devspec : 1;
+    u32 type : 7;
+    u32 reserved8_31 : 24;
+} PACKED;
+
+#define DWC3_DEPEVT_XFERCOMPLETE   0x01
+#define DWC3_DEPEVT_XFERINPROGRESS 0x02
+#define DWC3_DEPEVT_XFERNOTREADY   0x03
+#define DWC3_DEPEVT_RXTXFIFOEVT    0x04
+#define DWC3_DEPEVT_STREAMEVT      0x06
+#define DWC3_DEPEVT_EPCMDCMPLT     0x07
+
+/**
+ * struct dwc3_event_depvt - Device Endpoint Events
+ * @one_bit: indicates this is an endpoint event (not used)
+ * @endpoint_number: number of the endpoint
+ * @endpoint_event: The event we have:
+ *	0x00	- Reserved
+ *	0x01	- XferComplete
+ *	0x02	- XferInProgress
+ *	0x03	- XferNotReady
+ *	0x04	- RxTxFifoEvt (IN->Underrun, OUT->Overrun)
+ *	0x05	- Reserved
+ *	0x06	- StreamEvt
+ *	0x07	- EPCmdCmplt
+ * @reserved11_10: Reserved, don't use.
+ * @status: Indicates the status of the event. Refer to databook for
+ *	more information.
+ * @parameters: Parameters of the current event. Refer to databook for
+ *	more information.
+ */
+struct dwc3_event_depevt {
+    u32 one_bit : 1;
+    u32 endpoint_number : 5;
+    u32 endpoint_event : 4;
+    u32 reserved11_10 : 2;
+    u32 status : 4;
+
+/* Within XferNotReady */
+#define DEPEVT_STATUS_TRANSFER_ACTIVE (1 << 3)
+
+/* Within XferComplete */
+#define DEPEVT_STATUS_BUSERR (1 << 0)
+#define DEPEVT_STATUS_SHORT  (1 << 1)
+#define DEPEVT_STATUS_IOC    (1 << 2)
+#define DEPEVT_STATUS_LST    (1 << 3)
+
+/* Stream event only */
+#define DEPEVT_STREAMEVT_FOUND    1
+#define DEPEVT_STREAMEVT_NOTFOUND 2
+
+/* Control-only Status */
+#define DEPEVT_STATUS_CONTROL_DATA   1
+#define DEPEVT_STATUS_CONTROL_STATUS 2
+
+    u32 parameters : 16;
+} PACKED;
+
+/**
+ * struct dwc3_event_devt - Device Events
+ * @one_bit: indicates this is a non-endpoint event (not used)
+ * @device_event: indicates it's a device event. Should read as 0x00
+ * @type: indicates the type of device event.
+ *	0	- DisconnEvt
+ *	1	- USBRst
+ *	2	- ConnectDone
+ *	3	- ULStChng
+ *	4	- WkUpEvt
+ *	5	- Reserved
+ *	6	- EOPF
+ *	7	- SOF
+ *	8	- Reserved
+ *	9	- ErrticErr
+ *	10	- CmdCmplt
+ *	11	- EvntOverflow
+ *	12	- VndrDevTstRcved
+ * @reserved15_12: Reserved, not used
+ * @event_info: Information about this event
+ * @reserved31_24: Reserved, not used
+ */
+struct dwc3_event_devt {
+    u32 one_bit : 1;
+    u32 device_event : 7;
+    u32 type : 4;
+    u32 reserved15_12 : 4;
+    u32 event_info : 8;
+    u32 reserved31_24 : 8;
+} PACKED;
+
+/**
+ * struct dwc3_event_gevt - Other Core Events
+ * @one_bit: indicates this is a non-endpoint event (not used)
+ * @device_event: indicates it's (0x03) Carkit or (0x04) I2C event.
+ * @phy_port_number: self-explanatory
+ * @reserved31_12: Reserved, not used.
+ */
+struct dwc3_event_gevt {
+    u32 one_bit : 1;
+    u32 device_event : 7;
+    u32 phy_port_number : 4;
+    u32 reserved31_12 : 20;
+} PACKED;
+
+#endif /* __DRIVERS_USB_DWC3_CORE_H */

--- a/src/usb_types.h
+++ b/src/usb_types.h
@@ -1,0 +1,183 @@
+/* SPDX-License-Identifier: MIT */
+
+#ifndef USB_TYPES_H
+#define USB_TYPES_H
+
+#include "types.h"
+
+#define USB_REQUEST_TYPE_DIRECTION_SHIFT       7
+#define USB_REQUEST_TYPE_DIRECTION(d)          ((d) << USB_REQUEST_TYPE_DIRECTION_SHIFT)
+#define USB_REQUEST_TYPE_DIRECTION_HOST2DEVICE 0
+#define USB_REQUEST_TYPE_DIRECTION_DEVICE2HOST 1
+
+#define USB_REQUEST_TYPE_SHIFT    5
+#define USB_REQUEST_TYPE(t)       ((t) << USB_REQUEST_TYPE_SHIFT)
+#define USB_REQUEST_TYPE_STANDARD USB_REQUEST_TYPE(0b00)
+#define USB_REQUEST_TYPE_CLASS    USB_REQUEST_TYPE(0b01)
+#define USB_REQUEST_TYPE_VENDOR   USB_REQUEST_TYPE(0b10)
+#define USB_REQUEST_TYPE_MASK     USB_REQUEST_TYPE(0b11)
+
+#define USB_REQUEST_TYPE_RECIPIENT_DEVICE    0
+#define USB_REQUEST_TYPE_RECIPIENT_INTERFACE 1
+#define USB_REQUEST_TYPE_RECIPIENT_ENDPOINT  2
+#define USB_REQUEST_TYPE_RECIPIENT_OTHER     3
+#define USB_REQUEST_TYPE_RECIPIENT_MASK      0b11
+
+#define USB_REQUEST_GET_STATUS        0x00
+#define USB_REQUEST_CLEAR_FEATURE     0x01
+#define USB_REQUEST_SET_FEATURE       0x03
+#define USB_REQUEST_SET_ADDRESS       0x05
+#define USB_REQUEST_GET_DESCRIPTOR    0x06
+#define USB_REQUEST_SET_DESCRIPTOR    0x07
+#define USB_REQUEST_GET_CONFIGURATION 0x08
+#define USB_REQUEST_SET_CONFIGURATION 0x09
+
+#define USB_EP_REQUEST_CLEAR_FEATURE 0x01
+#define USB_EP_REQUEST_SET_FEATURE   0x03
+
+#define USB_REQUEST_CDC_SET_LINE_CODING     0x20
+#define USB_REQUEST_CDC_GET_LINE_CODING     0x21
+#define USB_REQUEST_CDC_SET_CTRL_LINE_STATE 0x22
+
+struct usb_setup_packet_raw {
+    u8 bmRequestType;
+    u8 bRequest;
+    u16 wValue;
+    u16 wIndex;
+    u16 wLength;
+} PACKED;
+
+struct usb_setup_packet_get_descriptor {
+    u8 bmRequestType;
+    u8 bRequest;
+    u8 index;
+    u8 type;
+    u16 language;
+    u16 wLength;
+} PACKED;
+
+struct usb_set_packet_set_address {
+    u8 bmRequestType;
+    u8 bRequest;
+    u16 address;
+    u16 zero0;
+    u16 zero1;
+} PACKED;
+
+struct usb_set_packet_set_configuration {
+    u8 bmRequestType;
+    u8 bRequest;
+    u16 configuration;
+    u16 zero0;
+    u16 zero1;
+} PACKED;
+
+union usb_setup_packet {
+    struct usb_setup_packet_raw raw;
+    struct usb_setup_packet_get_descriptor get_descriptor;
+    struct usb_set_packet_set_address set_address;
+    struct usb_set_packet_set_configuration set_configuration;
+};
+
+#define USB_DEVICE_DESCRIPTOR        0x01
+#define USB_CONFIGURATION_DESCRIPTOR 0x02
+#define USB_STRING_DESCRIPTOR        0x03
+#define USB_INTERFACE_DESCRIPTOR     0x04
+#define USB_ENDPOINT_DESCRIPTOR      0x05
+
+#define USB_CDC_INTERFACE_FUNCTIONAL_DESCRIPTOR 0x24
+#define USB_CDC_UNION_SUBTYPE                   0x06
+
+#define USB_CONFIGURATION_ATTRIBUTE_RES1 0x80
+
+#define USB_ENDPOINT_ADDR_IN(ep)  (0x00 | (ep))
+#define USB_ENDPOINT_ADDR_OUT(ep) (0x80 | (ep))
+
+#define USB_ENDPOINT_ATTR_TYPE_CONTROL     0b00
+#define USB_ENDPOINT_ATTR_TYPE_ISOCHRONOUS 0b01
+#define USB_ENDPOINT_ATTR_TYPE_BULK        0b10
+#define USB_ENDPOINT_ATTR_TYPE_INTERRUPT   0b11
+
+#define USB_LANGID_EN_US 0x0409
+
+struct usb_device_descriptor {
+    u8 bLength;
+    u8 bDescriptorType;
+    u16 bcdUSB;
+    u8 bDeviceClass;
+    u8 bDeviceSubClass;
+    u8 bDeviceProtocol;
+    u8 bMaxPacketSize0;
+    u16 idVendor;
+    u16 idProduct;
+    u16 bcdDevice;
+    u8 iManufacturer;
+    u8 iProduct;
+    u8 iSerialNumber;
+    u8 bNumConfigurations;
+} PACKED;
+
+struct usb_configuration_descriptor {
+    u8 bLength;
+    u8 bDescriptorType;
+    u16 wTotalLength;
+    u8 bNumInterfaces;
+    u8 bConfigurationValue;
+    u8 iConfiguration;
+    u8 bmAttributes;
+    u8 bMaxPower;
+} PACKED;
+
+struct usb_interface_descriptor {
+    u8 bLength;
+    u8 bDescriptorType;
+    u8 bInterfaceNumber;
+    u8 bAlternateSetting;
+    u8 bNumEndpoints;
+    u8 bInterfaceClass;
+    u8 bInterfaceSubClass;
+    u8 bInterfaceProtocol;
+    u8 iInterface;
+} PACKED;
+
+struct usb_endpoint_descriptor {
+    u8 bLength;
+    u8 bDescriptorType;
+    u8 bEndpointAddress;
+    u8 bmAttributes;
+    u16 wMaxPacketSize;
+    u8 bInterval;
+} PACKED;
+
+struct usb_string_descriptor {
+    u8 bLength;
+    u8 bDescriptorType;
+    u16 bString[];
+} PACKED;
+
+struct usb_string_descriptor_languages {
+    u8 bLength;
+    u8 bDescriptorType;
+    u16 wLANGID[];
+} PACKED;
+
+struct cdc_union_functional_descriptor {
+    u8 bFunctionLength;
+    u8 bDescriptorType;
+    u8 bDescriptorSubtype;
+    u8 bControlInterface;
+    u8 bDataInterface;
+} PACKED;
+
+/*
+ * this macro is required because we need to convert any string literals
+ * to UTF16 and because we need to calculate the correct total size of the
+ * string descriptor.
+ */
+#define make_usb_string_descriptor(str)                                                            \
+    {                                                                                              \
+        .bLength = sizeof(struct usb_string_descriptor) + sizeof(u##str),                          \
+        .bDescriptorType = USB_STRING_DESCRIPTOR, .bString = u##str                                \
+    }
+
+#endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -268,6 +268,10 @@ static inline u8 writeread8(u64 addr, u8 data)
 #define dc_cvau(p)   cacheop("dc cvau", p)
 #define dc_civac(p)  cacheop("dc civac", p)
 
+#define dma_mb()  sysop("dmb osh")
+#define dma_rmb() sysop("dmb oshld")
+#define dma_wmb() sysop("dmb oshst")
+
 static inline int is_ecore(void)
 {
     return !(mrs(MPIDR_EL1) & (1 << 16));

--- a/src/utils.h
+++ b/src/utils.h
@@ -321,6 +321,8 @@ int debug_printf(const char *fmt, ...);
 void udelay(u32 d);
 void reboot(void) __attribute__((noreturn));
 
+#define mdelay(m) udelay((m)*1000)
+
 #define panic(fmt, ...)                                                                            \
     do {                                                                                           \
         debug_printf(fmt, ##__VA_ARGS__);                                                          \

--- a/src/utils.h
+++ b/src/utils.h
@@ -119,6 +119,17 @@ static inline u32 mask32(u64 addr, u32 clear, u32 set)
     return data;
 }
 
+static inline int poll32(u64 addr, u32 mask, u32 target, u32 timeout)
+{
+    while (--timeout > 0) {
+        u32 value = read32(addr) & mask;
+        if (value == target)
+            return 0;
+    }
+
+    return -1;
+}
+
 static inline u16 read16(u64 addr)
 {
     u32 data;

--- a/src/utils.h
+++ b/src/utils.h
@@ -9,6 +9,9 @@
 
 #define BIT(x) (1L << (x))
 
+#define min(a, b) (((a) < (b)) ? (a) : (b))
+#define max(a, b) (((a) > (b)) ? (a) : (b))
+
 static inline u64 read64(u64 addr)
 {
     u64 data;

--- a/sysinc/malloc.h
+++ b/sysinc/malloc.h
@@ -3,6 +3,8 @@
 #ifndef MALLOC_H
 #define MALLOC_H
 
+#include <stddef.h>
+
 void *malloc(size_t);
 void free(void *);
 void *calloc(size_t, size_t);


### PR DESCRIPTION
This adds:

- DART IOMMU support
- power/clock gating support
- USB DWC3 device mode
- USB CDC ACM serial emulation

What's missing:

- USB PHY bringup because I can't sign that code off in good conscience
- uartproxy / console integration


I strongly recommend to review this commit by commit.