### PR TITLE
tunables: add initial version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ LIBFDT_OBJECTS := $(patsubst %,libfdt/%, \
 
 OBJECTS := adt.o bootlogo_128.o bootlogo_256.o chickens.o exception.o exception_asm.o fb.o \
 	heapblock.o kboot.o main.o memory.o memory_asm.o payload.o proxy.o smp.o start.o startup.o \
-	string.o uart.o uartproxy.o utils.o utils_asm.o vsprintf.o wdt.o $(MINILZLIB_OBJECTS) \
+	string.o tunables.o uart.o uartproxy.o utils.o utils_asm.o vsprintf.o wdt.o $(MINILZLIB_OBJECTS) \
 	$(TINF_OBJECTS) $(DLMALLOC_OBJECTS) $(LIBFDT_OBJECTS)
 
 DTS := t8103-j274.dts

--- a/proxyclient/proxy.py
+++ b/proxyclient/proxy.py
@@ -354,6 +354,9 @@ class M1N1Proxy:
     P_KBOOT_SET_INITRD = 0x702
     P_KBOOT_PREPARE_DT = 0x703
 
+    P_TUNABLES_APPLY_GLOBAL = 0xa00
+    P_TUNABLES_APPLY_LOCAL = 0xa01
+
     def __init__(self, iface, debug=False):
         self.debug = debug
         self.iface = iface
@@ -603,6 +606,11 @@ class M1N1Proxy:
         self.request(self.P_KBOOT_SET_INITRD, base, size)
     def kboot_prepare_dt(self, dt_addr):
         return self.request(self.P_KBOOT_PREPARE_DT, dt_addr)
+
+    def tunables_apply_global(self, path, prop):
+        return self.request(self.P_TUNABLES_APPLY_GLOBAL, path, prop)
+    def tunables_apply_local(self, path, prop, reg_offset):
+        return self.request(self.P_TUNABLES_APPLY_LOCAL, path, prop, reg_offset)
 
 if __name__ == "__main__":
     import serial

--- a/proxyclient/proxy.py
+++ b/proxyclient/proxy.py
@@ -611,6 +611,8 @@ class M1N1Proxy:
         return self.request(self.P_TUNABLES_APPLY_GLOBAL, path, prop)
     def tunables_apply_local(self, path, prop, reg_offset):
         return self.request(self.P_TUNABLES_APPLY_LOCAL, path, prop, reg_offset)
+    def tunables_apply_local_addr(self, path, prop, base):
+        return self.request(self.P_TUNABLES_APPLY_LOCAL, path, prop, base)
 
 if __name__ == "__main__":
     import serial

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -318,6 +318,10 @@ int proxy_process(ProxyRequest *request, ProxyReply *reply)
             reply->retval = tunables_apply_local((const char *)request->args[0],
                                                  (const char *)request->args[1], request->args[2]);
             break;
+        case P_TUNABLES_APPLY_LOCAL_ADDR:
+            reply->retval = tunables_apply_local_addr(
+                (const char *)request->args[0], (const char *)request->args[1], request->args[2]);
+            break;
 
         default:
             reply->status = S_BADCMD;

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -7,6 +7,7 @@
 #include "malloc.h"
 #include "memory.h"
 #include "smp.h"
+#include "tunables.h"
 #include "types.h"
 #include "uart.h"
 #include "utils.h"
@@ -307,6 +308,15 @@ int proxy_process(ProxyRequest *request, ProxyReply *reply)
             break;
         case P_KBOOT_PREPARE_DT:
             reply->retval = kboot_prepare_dt((void *)request->args[0]);
+            break;
+
+        case P_TUNABLES_APPLY_GLOBAL:
+            reply->retval = tunables_apply_global((const char *)request->args[0],
+                                                  (const char *)request->args[1]);
+            break;
+        case P_TUNABLES_APPLY_LOCAL:
+            reply->retval = tunables_apply_local((const char *)request->args[0],
+                                                 (const char *)request->args[1], request->args[2]);
             break;
 
         default:

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -82,6 +82,9 @@ typedef enum {
     P_KBOOT_SET_INITRD,
     P_KBOOT_PREPARE_DT,
 
+    P_TUNABLES_APPLY_GLOBAL = 0xa00,
+    P_TUNABLES_APPLY_LOCAL,
+
 } ProxyOp;
 
 #define S_OK     0

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -84,6 +84,7 @@ typedef enum {
 
     P_TUNABLES_APPLY_GLOBAL = 0xa00,
     P_TUNABLES_APPLY_LOCAL,
+    P_TUNABLES_APPLY_LOCAL_ADDR,
 
 } ProxyOp;
 

--- a/src/tunables.c
+++ b/src/tunables.c
@@ -1,0 +1,114 @@
+/* SPDX-License-Identifier: MIT */
+
+#include "adt.h"
+#include "tunables.h"
+#include "types.h"
+#include "utils.h"
+
+struct tunable_info {
+    int node_offset;
+    int node_path[8];
+    const u32 *tunable_raw;
+    u32 tunable_len;
+};
+
+static int tunables_adt_find(const char *path, const char *prop, struct tunable_info *info,
+                             u32 item_size)
+{
+    info->node_offset = adt_path_offset_trace(adt, path, info->node_path);
+    if (info->node_offset < 0) {
+        printf("tunable: unable to find ADT node %s.\n", path);
+        return -1;
+    }
+
+    info->tunable_raw = adt_getprop(adt, info->node_offset, prop, &info->tunable_len);
+    if (info->tunable_raw == NULL || info->tunable_len == 0) {
+        printf("tunable: Error getting ADT node %s property %s .\n", path, prop);
+        return -1;
+    }
+
+    if (info->tunable_len % item_size) {
+        printf("tunable: tunable length needs to be a multiply of %d but is %d\n", item_size,
+               info->tunable_len);
+        return -1;
+    }
+
+    info->tunable_len /= item_size;
+
+    return 0;
+}
+
+struct tunable_global {
+    u32 reg_idx;
+    u32 offset;
+    u32 mask;
+    u32 value;
+} PACKED;
+
+int tunables_apply_global(const char *path, const char *prop)
+{
+    struct tunable_info info;
+
+    if (tunables_adt_find(path, prop, &info, sizeof(struct tunable_global)) < 0)
+        return -1;
+
+    const struct tunable_global *tunables = (const struct tunable_global *)info.tunable_raw;
+    for (u32 i = 0; i < info.tunable_len; ++i) {
+        const struct tunable_global *tunable = &tunables[i];
+
+        u64 addr;
+        if (adt_get_reg(adt, info.node_path, "reg", tunable->reg_idx, &addr, NULL) < 0) {
+            printf("tunable: Error getting regs with index %d\n", tunable->reg_idx);
+            return -1;
+        }
+
+        mask32(addr + tunable->offset, tunable->mask, tunable->value);
+    }
+
+    return 0;
+}
+
+struct tunable_local {
+    u32 offset;
+    u32 size;
+    u64 mask;
+    u64 value;
+} PACKED;
+
+int tunables_apply_local(const char *path, const char *prop, u32 reg_offset)
+{
+    struct tunable_info info;
+
+    if (tunables_adt_find(path, prop, &info, sizeof(struct tunable_local)) < 0)
+        return -1;
+
+    u64 base;
+    if (adt_get_reg(adt, info.node_path, "reg", reg_offset, &base, NULL) < 0) {
+        printf("tunable: Error getting regs\n");
+        return -1;
+    }
+
+    const struct tunable_local *tunables = (const struct tunable_local *)info.tunable_raw;
+    for (u32 i = 0; i < info.tunable_len; ++i) {
+        const struct tunable_local *tunable = &tunables[i];
+
+        switch (tunable->size) {
+            case 1:
+                mask8(base + tunable->offset, tunable->mask, tunable->value);
+                break;
+            case 2:
+                mask16(base + tunable->offset, tunable->mask, tunable->value);
+                break;
+            case 4:
+                mask32(base + tunable->offset, tunable->mask, tunable->value);
+                break;
+            case 8:
+                mask64(base + tunable->offset, tunable->mask, tunable->value);
+                break;
+            default:
+                printf("tunable: unknown tunable size 0x%08x\n", tunable->size);
+                return -1;
+        }
+    }
+    return 0;
+}

--- a/src/tunables.c
+++ b/src/tunables.c
@@ -75,18 +75,12 @@ struct tunable_local {
     u64 value;
 } PACKED;
 
-int tunables_apply_local(const char *path, const char *prop, u32 reg_offset)
+int tunables_apply_local_addr(const char *path, const char *prop, uintptr_t base)
 {
     struct tunable_info info;
 
     if (tunables_adt_find(path, prop, &info, sizeof(struct tunable_local)) < 0)
         return -1;
-
-    u64 base;
-    if (adt_get_reg(adt, info.node_path, "reg", reg_offset, &base, NULL) < 0) {
-        printf("tunable: Error getting regs\n");
-        return -1;
-    }
 
     const struct tunable_local *tunables = (const struct tunable_local *)info.tunable_raw;
     for (u32 i = 0; i < info.tunable_len; ++i) {
@@ -111,4 +105,20 @@ int tunables_apply_local(const char *path, const char *prop, u32 reg_offset)
         }
     }
     return 0;
+}
+
+int tunables_apply_local(const char *path, const char *prop, u32 reg_offset)
+{
+    struct tunable_info info;
+
+    if (tunables_adt_find(path, prop, &info, sizeof(struct tunable_local)) < 0)
+        return -1;
+
+    u64 base;
+    if (adt_get_reg(adt, info.node_path, "reg", reg_offset, &base, NULL) < 0) {
+        printf("tunable: Error getting regs\n");
+        return -1;
+    }
+
+    return tunables_apply_local_addr(path, prop, base);
 }

--- a/src/tunables.h
+++ b/src/tunables.h
@@ -26,4 +26,15 @@ int tunables_apply_global(const char *path, const char *prop);
  */
 int tunables_apply_local(const char *path, const char *prop, u32 reg_idx);
 
+/*
+ * This functions does the same as tunables_apply_local except that it allows
+ * to specify the base address to which the tunables will be applied to instead
+ * of extracting it from the "regs" property.
+ *
+ * Example usage for two tunables for the USB DRD DART node:
+ *  tunables_apply_local_addr("/arm-io/dart-usb0", "dart-tunables-instance-0", 0x382f00000);
+ *  tunables_apply_local_addr("/arm-io/dart-usb0", "dart-tunables-instance-1", 0x382f80000);
+ */
+int tunables_apply_local_addr(const char *path, const char *prop, uintptr_t base);
+
 #endif

--- a/src/tunables.h
+++ b/src/tunables.h
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: MIT */
+
+#ifndef TUNABLES_H
+#define TUNABLES_H
+
+#include "types.h"
+
+/*
+ * This function applies the tunables usually passed in the node "tunable".
+ * They usually apply to multiple entries from the "reg" node.
+ *
+ * Example usage for the USB DRD node:
+ *  tunables_apply_global("/arm-io/usb-drd0", "tunable");
+ */
+int tunables_apply_global(const char *path, const char *prop);
+
+/*
+ * This function applies the tunables specified in device-specific tunable properties.
+ * These only apply to a single MMIO region from the "reg" node which needs to
+ * be specified.
+ *
+ * Example usage for two tunables from the USB DRD DART node:
+ *  tunables_apply_local("/arm-io/dart-usb0", "dart-tunables-instance-0", 0);
+ *  tunables_apply_local("/arm-io/dart-usb0", "dart-tunables-instance-1", 1);
+ *
+ */
+int tunables_apply_local(const char *path, const char *prop, u32 reg_idx);
+
+#endif


### PR DESCRIPTION
There are at least two types in the ADT related to USB,
but there's a decent chance that there are even more
required for other devices:

 * A simple tunable that applies to a whole device node
   and all it's MMIO ranges specified in the "reg" property.
   This one seems to just be mask32.

 * A slightly more complex tunable that applies to a single
   MMIO range specified in the "reg" property. So far I've
   only seen 32 bit masks but the format looks like it should
   also support 8,16 and 64 bit masks.


Open question: How do we expose proxyclient ops for these? Unlike everything else they take a string as an argument and right now there's no way to easily serialize those.

Signed-off-by: Sven Peter <sven@svenpeter.dev>