### PR TITLE
chainload.py: reconnect after reboot (useful for USB)

### DIFF
--- a/proxyclient/chainload.py
+++ b/proxyclient/chainload.py
@@ -127,7 +127,15 @@ if args.el1:
 
 print(f"Jumping to stub at 0x{stub.addr:x}")
 
-p.reboot(stub.addr, new_base + bootargs_off, image_addr, new_base, image_size, el1=args.el1)
+try:
+    p.reboot(stub.addr, new_base + bootargs_off, image_addr, new_base, image_size, el1=args.el1)
+except:
+    # in case of USB interface, serial device will be lost
+    print("Got an exception,most likely USB disconnect => Reconnecting")
+    uart.close()
+    while (not os.path.exists(uartdev)):
+        time.sleep(2)
+    uart,iface,p,u,mon=setup_connect()
 
 iface.nop()
 print("Proxy is alive again")

--- a/proxyclient/chainload.py
+++ b/proxyclient/chainload.py
@@ -137,5 +137,16 @@ except:
         time.sleep(2)
     uart,iface,p,u,mon=setup_connect()
 
-iface.nop()
+try:
+    iface.nop()
+except:
+    # in case of USB interface, serial device will be lost
+    # for some reason when using --el1 argument,
+    # we do not get the exception on reboot but on iface.nop()
+    print("Got an exception,most likely USB disconnect => Reconnecting")
+    uart.close()
+    while (not os.path.exists(uartdev)):
+        time.sleep(2)
+    uart,iface,p,u,mon=setup_connect()
+
 print("Proxy is alive again")

--- a/proxyclient/setup.py
+++ b/proxyclient/setup.py
@@ -4,23 +4,31 @@ from tgtypes import *
 from utils import *
 
 uartdev = os.environ.get("M1N1DEVICE", "/dev/ttyUSB0")
-uart = serial.Serial(uartdev, 115200)
 
-iface = UartInterface(uart, debug=False)
-p = M1N1Proxy(iface, debug=False)
+def setup_connect():
+    this_uart = serial.Serial(uartdev, 115200)
 
-try:
-    uart.timeout = 0.15
-    iface.nop()
-    p.set_baud(1500000)
-except UartTimeout:
-    uart.baudrate = 1500000
-    iface.nop()
+    intf = UartInterface(this_uart, debug=False)
+    proxy = M1N1Proxy(intf, debug=False)
 
-uart.timeout = 3
+    try:
+        this_uart.timeout = 0.15
+        intf.nop()
+        proxy.set_baud(1500000)
+    except UartTimeout:
+        serial.baudrate = 1500000
+        intf.nop()
 
-u = ProxyUtils(p)
-mon = RegMonitor(u)
+    this_uart.timeout = 3
+
+
+    proxy_u = ProxyUtils(proxy)
+    regmon = RegMonitor(proxy_u)
+
+    return this_uart,intf,proxy,proxy_u,regmon
+
+uart,iface,p,u,mon=setup_connect()
+
 
 iface.nop()
 


### PR DESCRIPTION
Try to reconnect on exception: needed for USB link.

Note: not tested on UART.

Signed-off-by: Jean-Francois Bortolotti <jeff@borto.fr>