### PR TITLE
usb/hv: add second CDC ACM interface for virtualized UART

### DIFF
--- a/proxyclient/hv.py
+++ b/proxyclient/hv.py
@@ -443,7 +443,7 @@ class HV:
         self.u.msr(APVMKEYHI_EL2, 0x697665596F755570)
         self.u.msr(APSTS_EL12, 1)
 
-        #self.p.hv_map_vuart(0x2_35200000)
+        #self.p.hv_map_vuart(0x2_35200000, getattr(IODEV, self.iodev.name + "_SEC"))
 
         actlr = ACTLR(self.u.mrs(ACTLR_EL12))
         actlr.EnMDSB = 1

--- a/proxyclient/proxy.py
+++ b/proxyclient/proxy.py
@@ -370,6 +370,8 @@ class IODEV(IntEnum):
     FB = 1
     USB0 = 2
     USB1 = 3
+    USB0_SEC = 4
+    USB1_SEC = 5
 
 class USAGE(IntFlag):
     CONSOLE = (1 << 0)
@@ -850,8 +852,8 @@ class M1N1Proxy:
         return self.request(self.P_HV_TRANSLATE, addr, s1, w)
     def hv_pt_walk(self, addr):
         return self.request(self.P_HV_PT_WALK, addr)
-    def hv_map_vuart(self, base):
-        return self.request(self.P_HV_MAP_VUART, base)
+    def hv_map_vuart(self, base, iodev):
+        return self.request(self.P_HV_MAP_VUART, base, iodev)
 
     def fb_init(self):
         return self.request(self.P_FB_INIT)

--- a/src/hv.h
+++ b/src/hv.h
@@ -3,6 +3,7 @@
 #ifndef HV_H
 #define HV_H
 
+#include "iodev.h"
 #include "types.h"
 
 typedef bool(hv_hook_t)(u64 addr, u64 *val, bool write, int width);
@@ -19,7 +20,7 @@ u64 hv_pt_walk(u64 addr);
 bool hv_handle_dabort(u64 *regs);
 
 /* Virtual peripherals */
-void hv_map_vuart(u64 base);
+void hv_map_vuart(u64 base, iodev_id_t iodev);
 
 /* HV main */
 void hv_init(void);

--- a/src/iodev.c
+++ b/src/iodev.c
@@ -18,12 +18,12 @@
 extern struct iodev iodev_uart;
 extern struct iodev iodev_fb;
 extern struct iodev iodev_usb[];
+extern struct iodev iodev_usb_sec[];
 
 struct iodev *iodevs[IODEV_MAX] = {
-    &iodev_uart,
-    &iodev_fb,
-    &iodev_usb[0],
-    &iodev_usb[1],
+    [IODEV_UART] = &iodev_uart,           [IODEV_FB] = &iodev_fb,
+    [IODEV_USB0] = &iodev_usb[0],         [IODEV_USB1] = &iodev_usb[1],
+    [IODEV_USB0_SEC] = &iodev_usb_sec[0], [IODEV_USB1_SEC] = &iodev_usb_sec[1],
 };
 
 char con_buf[CONSOLE_BUFFER_SIZE];

--- a/src/iodev.h
+++ b/src/iodev.h
@@ -6,7 +6,15 @@
 #include "types.h"
 #include "utils.h"
 
-typedef enum _iodev_id_t { IODEV_UART, IODEV_FB, IODEV_USB0, IODEV_USB1, IODEV_MAX } iodev_id_t;
+typedef enum _iodev_id_t {
+    IODEV_UART,
+    IODEV_FB,
+    IODEV_USB0,
+    IODEV_USB1,
+    IODEV_USB0_SEC,
+    IODEV_USB1_SEC,
+    IODEV_MAX,
+} iodev_id_t;
 
 typedef enum _iodev_usage_t {
     USAGE_CONSOLE = BIT(0),

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -416,7 +416,7 @@ int proxy_process(ProxyRequest *request, ProxyReply *reply)
             reply->retval = hv_pt_walk(request->args[0]);
             break;
         case P_HV_MAP_VUART:
-            hv_map_vuart(request->args[0]);
+            hv_map_vuart(request->args[0], request->args[1]);
             break;
 
         case P_FB_INIT:

--- a/src/usb_dwc3.h
+++ b/src/usb_dwc3.h
@@ -8,18 +8,24 @@
 
 typedef struct dwc3_dev dwc3_dev_t;
 
+typedef enum _cdc_acm_pipe_id_t {
+    CDC_ACM_PIPE_0,
+    CDC_ACM_PIPE_1,
+    CDC_ACM_PIPE_MAX
+} cdc_acm_pipe_id_t;
+
 dwc3_dev_t *usb_dwc3_init(uintptr_t regs, dart_dev_t *dart);
 void usb_dwc3_shutdown(dwc3_dev_t *dev);
 
 void usb_dwc3_handle_events(dwc3_dev_t *dev);
 
-bool usb_dwc3_can_read(dwc3_dev_t *dev);
-bool usb_dwc3_can_write(dwc3_dev_t *dev);
+bool usb_dwc3_can_read(dwc3_dev_t *dev, cdc_acm_pipe_id_t pipe);
+bool usb_dwc3_can_write(dwc3_dev_t *dev, cdc_acm_pipe_id_t pipe);
 
-u8 usb_dwc3_getbyte(dwc3_dev_t *dev);
-void usb_dwc3_putbyte(dwc3_dev_t *dev, u8 byte);
+u8 usb_dwc3_getbyte(dwc3_dev_t *dev, cdc_acm_pipe_id_t pipe);
+void usb_dwc3_putbyte(dwc3_dev_t *dev, cdc_acm_pipe_id_t pipe, u8 byte);
 
-size_t usb_dwc3_write(dwc3_dev_t *dev, const void *buf, size_t count);
-size_t usb_dwc3_read(dwc3_dev_t *dev, void *buf, size_t count);
+size_t usb_dwc3_write(dwc3_dev_t *dev, cdc_acm_pipe_id_t pipe, const void *buf, size_t count);
+size_t usb_dwc3_read(dwc3_dev_t *dev, cdc_acm_pipe_id_t pipe, void *buf, size_t count);
 
 #endif


### PR DESCRIPTION
Signed-off-by: Janne Grunau <j@jannau.net>

Second ACM interface is always announced but will be only used for the virtualized uart. Depends on using the other interface of the same USB device as proxy/hv connection. No support in `proxy/`.

USB device/interface handling is awkward and probably not using the right abstraction.
Read support not implemented.