### PR TITLE
Shell: do not access properties on startup

### DIFF
--- a/proxyclient/shell.py
+++ b/proxyclient/shell.py
@@ -65,13 +65,19 @@ def run_shell(locals, msg=None, exitmsg=None):
         if "utils" in locals and "u" not in locals:
             locals["u"] = locals["utils"]
 
-        for obj in ("iface", "p", "u"):
-            if obj in locals:
-                for attr in dir(locals[obj]):
-                    if attr not in locals:
-                        v = getattr(locals[obj], attr)
-                        if callable(v):
-                            locals[attr] = v
+        for obj_name in ("iface", "p", "u"):
+            obj = locals.get(obj_name)
+            obj_class = type(obj)
+            if obj is None:
+                continue
+
+            for attr in dir(obj_class):
+                if attr in locals or attr.startswith('_'):
+                    continue
+
+                member = getattr(obj_class, attr)
+                if callable(member) and not isinstance(member, property):
+                    locals[attr] = getattr(obj, attr)
 
         for attr in dir(sysreg):
             locals[attr] = getattr(sysreg, attr)


### PR DESCRIPTION
* Use the object’s class to find methods to import into the shell namespace rather than the object itself, to avoid invoking properties on the object.
* Prevent importing of members whose name starts with `_` (private methods and Python magic methods).

This removes the following items from the shell namespace (as checked by `dir()`):
```
__class__
__delattr__
__dir__
__eq__
__format__
__ge__
__getattribute__
__gt__
__hash__
__init__
__init_subclass__
__le__
__lt__
__ne__
__new__
__reduce__
__reduce_ex__
__repr__
__setattr__
__sizeof__
__str__
__subclasshook__
_request
```
If I’m not mistaken, they are not actually useful.