### PR TITLE
hv: add interrupt tracing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ OBJECTS := \
 	fb.o font.o font_retina.o \
 	gxf.o gxf_asm.o \
 	heapblock.o \
-	hv.o hv_vm.o hv_exc.o hv_vuart.o hv_wdt.o hv_asm.o \
+	hv.o hv_vm.o hv_exc.o hv_vuart.o hv_wdt.o hv_asm.o hv_aic.o \
 	i2c.o \
 	iodev.o \
 	kboot.o \

--- a/proxyclient/adt.py
+++ b/proxyclient/adt.py
@@ -59,6 +59,12 @@ def parse_prop(node, path, name, v):
         st = Hex(Int64ul) if sc == 2 else Array(sc, Hex(Int32ul))
         t = GreedyRange(Struct("bus_addr" / pat, "parent_addr" / at, "size" / st))
 
+    elif name == "interrupts":
+        # parse "interrupts" as Array of Int32ul, wrong for nodes whose
+        # "interrupt-parent" has "interrupt-cells" = 2
+        # parsing this correctly would require a second pass
+        t = Array(len(v) // 4, Int32ul)
+
     if t is not None:
         v = Sequence(t, Terminated).parse(v)[0]
         return t, v
@@ -209,6 +215,10 @@ class ADTNode:
     @property
     def size_cells(self):
         return self._properties["#size-cells"]
+
+    @property
+    def interrupt_cells(self):
+        return self._properties["#interrupt-cells"]
 
     def _fmt_prop(self, v):
         if isinstance(v, ListContainer):

--- a/proxyclient/proxy.py
+++ b/proxyclient/proxy.py
@@ -102,6 +102,7 @@ class EXC(IntEnum):
 
 class EVENT(IntEnum):
     MMIOTRACE = 1
+    IRQTRACE = 2
 
 class EXC_RET(IntEnum):
     UNHANDLED = 1
@@ -584,6 +585,7 @@ class M1N1Proxy:
     P_HV_TRANSLATE = 0xc03
     P_HV_PT_WALK = 0xc04
     P_HV_MAP_VUART = 0xc05
+    P_HV_TRACE_IRQ = 0xc06
 
     P_FB_INIT = 0xd00
     P_FB_SHUTDOWN = 0xd01
@@ -945,6 +947,8 @@ class M1N1Proxy:
         return self.request(self.P_HV_PT_WALK, addr)
     def hv_map_vuart(self, base, iodev):
         return self.request(self.P_HV_MAP_VUART, base, iodev)
+    def hv_trace_irq(self, evt_type, num, count, flags):
+        return self.request(self.P_HV_TRACE_IRQ, evt_type, num, count, flags)
 
     def fb_init(self):
         return self.request(self.P_FB_INIT)

--- a/src/hv.h
+++ b/src/hv.h
@@ -21,6 +21,12 @@ struct hv_evt_mmiotrace {
     u64 data;
 };
 
+struct hv_evt_irqtrace {
+    u32 flags;
+    u16 type;
+    u16 num;
+};
+
 struct hv_vm_proxy_hook_data {
     u32 flags;
     u32 id;
@@ -46,6 +52,12 @@ int hv_map_proxy_hook(u64 from, u64 id, u64 size);
 u64 hv_translate(u64 addr, bool s1only, bool w);
 u64 hv_pt_walk(u64 addr);
 bool hv_handle_dabort(u64 *regs);
+bool hv_pa_write(u64 addr, u64 *val, int width);
+bool hv_pa_read(u64 addr, u64 *val, int width);
+bool hv_pa_rw(u64 addr, u64 *val, bool write, int width);
+
+/* AIC events through tracing the MMIO event address */
+bool hv_trace_irq(u32 type, u32 num, u32 count, u32 flags);
 
 /* Virtual peripherals */
 void hv_map_vuart(u64 base, iodev_id_t iodev);

--- a/src/hv_aic.c
+++ b/src/hv_aic.c
@@ -1,0 +1,119 @@
+/* SPDX-License-Identifier: MIT */
+
+#include "adt.h"
+#include "hv.h"
+#include "uartproxy.h"
+#include "utils.h"
+
+#define AIC_INFO       0x0004
+#define AIC_INFO_NR_HW GENMASK(15, 0)
+
+#define AIC_EVENT      0x2004
+#define AIC_EVENT_TYPE GENMASK(31, 16)
+#define AIC_EVENT_NUM  GENMASK(15, 0)
+
+#define AIC_EVENT_TYPE_HW   1
+#define AIC_EVENT_TYPE_IPI  4
+#define AIC_EVENT_IPI_OTHER 1
+#define AIC_EVENT_IPI_SELF  2
+
+#define AIC_MAX_HW_NUM (28 * 32)
+
+#define IRQTRACE_IRQ BIT(0)
+
+static u64 aic_base;
+
+static u32 trace_hw_num[AIC_MAX_HW_NUM / 32];
+
+static void emit_irqtrace(u16 type, u16 num)
+{
+    struct hv_evt_irqtrace evt = {
+        .flags = IRQTRACE_IRQ,
+        .type = type,
+        .num = num,
+    };
+
+    hv_wdt_suspend();
+    uartproxy_send_event(EVT_IRQTRACE, &evt, sizeof(evt));
+    hv_wdt_resume();
+}
+
+static bool trace_aic_event(u64 addr, u64 *val, bool write, int width)
+{
+    if (!hv_pa_rw(addr, val, write, width))
+        return false;
+
+    if (addr != (aic_base + AIC_EVENT) || write || width != 2) {
+        return true;
+    }
+
+    u16 type = (*val & AIC_EVENT_TYPE) >> 16;
+    u16 num = *val & AIC_EVENT_NUM;
+
+    switch (type) {
+        case AIC_EVENT_TYPE_HW:
+            if (trace_hw_num[num / 32] & BIT(num & 31)) {
+                emit_irqtrace(type, num);
+            }
+            break;
+        default:
+            // ignore
+            break;
+    }
+
+    return true;
+}
+
+bool hv_trace_irq(u32 type, u32 num, u32 count, u32 flags)
+{
+    dprintf("HV: hv_trace_irq type: %u start: %u num: %u flags: 0x%x\n", type, num, count, flags);
+    if (type == AIC_EVENT_TYPE_HW) {
+        if (num >= AIC_MAX_HW_NUM || count > AIC_MAX_HW_NUM - num) {
+            printf("HV: invalid IRQ range: (%u, %u)\n", num, num + count);
+            return false;
+        }
+        for (u32 n = num; n < num + count; n++) {
+            switch (flags) {
+                case IRQTRACE_IRQ:
+                    trace_hw_num[n / 32] |= BIT(n & 31);
+                    break;
+                default:
+                    trace_hw_num[n / 32] &= ~(BIT(n & 31));
+                    break;
+            }
+        }
+    } else {
+        printf("HV: not handling AIC event type: 0x%02x num: %u\n", type, num);
+        return false;
+    }
+
+    if (!aic_base) {
+        static const char path[] = "/arm-io/aic";
+        int adt_path[8];
+
+        int node = adt_path_offset_trace(adt, path, adt_path);
+        if (node < 0) {
+            printf("HV: Error getting %s node\n", path);
+            return false;
+        }
+
+        if (adt_get_reg(adt, adt_path, "reg", 0, &aic_base, NULL) < 0) {
+            printf("HV: Error getting AIC base address.\n");
+            return false;
+        }
+    }
+
+    static bool hooked = false;
+
+    if (aic_base && !hooked) {
+        u32 nr_hw = FIELD_GET(AIC_INFO_NR_HW, read32(aic_base + AIC_INFO));
+        if (nr_hw > AIC_MAX_HW_NUM) {
+            printf("HV: AIC supports more IRQs than expected! nr_hw: %u\n", nr_hw);
+            return false;
+        }
+        hv_map_hook(aic_base, trace_aic_event, 0x4000);
+        hooked = true;
+    }
+
+    return true;
+}

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -427,6 +427,10 @@ int proxy_process(ProxyRequest *request, ProxyReply *reply)
         case P_HV_MAP_VUART:
             hv_map_vuart(request->args[0], request->args[1]);
             break;
+        case P_HV_TRACE_IRQ:
+            reply->retval = hv_trace_irq(request->args[0], request->args[1], request->args[2],
+                                         request->args[3]);
+            break;
 
         case P_FB_INIT:
             fb_init();

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -118,6 +118,7 @@ typedef enum {
     P_HV_TRANSLATE,
     P_HV_PT_WALK,
     P_HV_MAP_VUART,
+    P_HV_TRACE_IRQ,
 
     P_FB_INIT = 0xd00,
     P_FB_SHUTDOWN,

--- a/src/uartproxy.h
+++ b/src/uartproxy.h
@@ -30,6 +30,7 @@ typedef enum _uartproxy_exc_ret_t {
 
 typedef enum _uartproxy_event_type_t {
     EVT_MMIOTRACE = 1,
+    EVT_IRQTRACE = 2,
 } uartproxy_event_type_t;
 
 struct uartproxy_exc_info {


### PR DESCRIPTION
Implemented by MMIO tracing of AIC's event register. Proposed by pipcet.

Would be nice if we could hook just the event register at offset 0x2004.