### PR TITLE
usb: disable tps6598x interrupts

### DIFF
--- a/proxyclient/m1n1/hv.py
+++ b/proxyclient/m1n1/hv.py
@@ -584,6 +584,12 @@ class HV:
         self.tba = self.u.ba.copy()
         self.device_addr_tbl = self.adt.build_addr_lookup()
 
+        # disable unused USB iodev early so interrupts can be reenabled in hv_init()
+        for iodev in (IODEV.USB0, IODEV.USB1):
+            if iodev != self.iodev:
+                print(f"Disable iodev {iodev!s}")
+                self.p.iodev_set_usage(iodev, 0)
+
         print("Initializing hypervisor over iodev %s" % self.iodev)
         self.p.hv_init()
 

--- a/proxyclient/m1n1/hv.py
+++ b/proxyclient/m1n1/hv.py
@@ -717,19 +717,19 @@ class HV:
                         del self.adt[name]
                     except KeyError:
                         pass
-            for name in ("/cpus/cpu1",
-                         "/cpus/cpu2",
-                         "/cpus/cpu3",
-                         "/cpus/cpu4",
-                         "/cpus/cpu5",
-                         "/cpus/cpu6",
-                         "/cpus/cpu7",
-                        ):
-                print(f"Removing ADT node {name}")
-                try:
-                    del self.adt[name]
-                except KeyError:
-                    pass
+        for name in ("/cpus/cpu1",
+                     "/cpus/cpu2",
+                     "/cpus/cpu3",
+                     "/cpus/cpu4",
+                     "/cpus/cpu5",
+                     "/cpus/cpu6",
+                     "/cpus/cpu7",
+                    ):
+            print(f"Removing ADT node {name}")
+            try:
+                del self.adt[name]
+            except KeyError:
+                pass
 
         #for cpu in list(self.adt["cpus"]):
             #if cpu.name != "cpu0":

--- a/proxyclient/m1n1/hv.py
+++ b/proxyclient/m1n1/hv.py
@@ -683,7 +683,12 @@ class HV:
             print(f"R {base:x}+{off:x}:{width} = 0x{data:x} -> 0x{ret:x}")
             return ret
 
-        for addr in (0x23b700420, 0x23d280098, 0x23d280088, 0x23d280090):
+        if self.iodev == IODEV.USB0:
+            pmgr_hooks = (0x23b700420, 0x23d280098, 0x23d280088)
+        elif self.iodev == IODEV.USB1:
+            pmgr_hooks = (0x23b700448, 0x23d2800a0, 0x23d280090)
+
+        for addr in pmgr_hooks:
             self.map_hook(addr, 4, write=wh, read=rh)
 
     def setup_adt(self):

--- a/proxyclient/m1n1/hv.py
+++ b/proxyclient/m1n1/hv.py
@@ -699,29 +699,28 @@ class HV:
 
         if self.iodev in (IODEV.USB0, IODEV.USB1):
             idx = int(str(self.iodev)[-1])
-            for idx in (0, 1):
-                for prefix in ("/arm-io/dart-usb%d",
-                            "/arm-io/atc-phy%d",
-                            "/arm-io/usb-drd%d",
-                            "/arm-io/acio%d",
-                            "/arm-io/acio-cpu%d",
-                            "/arm-io/dart-acio%d",
-                            "/arm-io/apciec%d",
-                            "/arm-io/dart-apciec%d",
-                            "/arm-io/apciec%d-piodma",
-                            "/arm-io/i2c0/hpmBusManager/hpm%d",
-                            "/arm-io/atc%d-dpxbar",
-                            "/arm-io/atc%d-dpphy",
-                            "/arm-io/atc%d-dpin0",
-                            "/arm-io/atc%d-dpin1",
-                            "/arm-io/atc-phy%d",
-                            ):
-                    name = prefix % idx
-                    print(f"Removing ADT node {name}")
-                    try:
-                        del self.adt[name]
-                    except KeyError:
-                        pass
+            for prefix in ("/arm-io/dart-usb%d",
+                           "/arm-io/atc-phy%d",
+                           "/arm-io/usb-drd%d",
+                           "/arm-io/acio%d",
+                           "/arm-io/acio-cpu%d",
+                           "/arm-io/dart-acio%d",
+                           "/arm-io/apciec%d",
+                           "/arm-io/dart-apciec%d",
+                           "/arm-io/apciec%d-piodma",
+                           "/arm-io/i2c0/hpmBusManager/hpm%d",
+                           "/arm-io/atc%d-dpxbar",
+                           "/arm-io/atc%d-dpphy",
+                           "/arm-io/atc%d-dpin0",
+                           "/arm-io/atc%d-dpin1",
+                           "/arm-io/atc-phy%d",
+                          ):
+                name = prefix % idx
+                print(f"Removing ADT node {name}")
+                try:
+                    del self.adt[name]
+                except KeyError:
+                    pass
         for name in ("/cpus/cpu1",
                      "/cpus/cpu2",
                      "/cpus/cpu3",

--- a/src/hv.c
+++ b/src/hv.c
@@ -6,6 +6,7 @@
 #include "gxf.h"
 #include "pcie.h"
 #include "smp.h"
+#include "usb.h"
 #include "utils.h"
 
 #define HV_TICK_RATE 1000
@@ -19,6 +20,8 @@ u64 hv_tick_interval;
 void hv_init(void)
 {
     pcie_shutdown();
+    // reenable hpm interrupts for the guest for unused iodevs
+    usb_hpm_restore_irqs(0);
     smp_start_secondaries();
     hv_wdt_init();
 

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -18,6 +18,7 @@
 #include "types.h"
 #include "uart.h"
 #include "uartproxy.h"
+#include "usb.h"
 #include "utils.h"
 #include "xnuboot.h"
 
@@ -82,6 +83,9 @@ int proxy_process(ProxyRequest *request, ProxyReply *reply)
                                      request->args[3], request->args[4]);
             break;
         case P_VECTOR:
+            // forcefully restore tps6598x IRQs
+            usb_hpm_restore_irqs(1);
+            iodev_console_flush();
             next_stage.entry = (generic_func *)request->args[0];
             memcpy(next_stage.args, &request->args[1], 4 * sizeof(u64));
             return 1;

--- a/src/tps6598x.h
+++ b/src/tps6598x.h
@@ -15,4 +15,14 @@ int tps6598x_command(tps6598x_dev_t *dev, const char *cmd, const u8 *data_in, si
                      u8 *data_out, size_t len_out);
 int tps6598x_powerup(tps6598x_dev_t *dev);
 
+#define CD3218B12_IRQ_WIDTH 9
+
+typedef struct tps6598x_irq_state {
+    u8 int_mask1[CD3218B12_IRQ_WIDTH];
+    bool valid;
+} tps6598x_irq_state_t;
+
+int tps6598x_disable_irqs(tps6598x_dev_t *dev, tps6598x_irq_state_t *state);
+int tps6598x_restore_irqs(tps6598x_dev_t *dev, tps6598x_irq_state_t *state);
+
 #endif

--- a/src/usb.h
+++ b/src/usb.h
@@ -9,6 +9,7 @@
 dwc3_dev_t *usb_bringup(u32 idx);
 
 void usb_init(void);
+void usb_hpm_restore_irqs(bool force);
 void usb_iodev_init(void);
 void usb_iodev_shutdown(void);
 


### PR DESCRIPTION
Restore the interrupt masks on transition to the next state. The masks
are not restored on the USB-C port used by the hypervisor. This prevents
an interrupt storm in the guest when the other USB-C port is exposed to
the guest. The tps6598x interrupt line is shared amoung both ports.

