### PR TITLE
usb_dwc3: shutdown the DART as well when shutting down usb

### DIFF
--- a/src/usb_dwc3.c
+++ b/src/usb_dwc3.c
@@ -1265,6 +1265,9 @@ void usb_dwc3_shutdown(dwc3_dev_t *dev)
         ringbuffer_free(dev->pipe[i].device2host);
         ringbuffer_free(dev->pipe[i].host2device);
     }
+
+    if (dev->dart)
+        dart_shutdown(dev->dart);
     free(dev);
 }
 


### PR DESCRIPTION
Signed-off-by: Sven Peter <sven@svenpeter.dev>