### PR TITLE
proxy/tools: add reboot.py

### DIFF
--- a/proxyclient/tools/reboot.py
+++ b/proxyclient/tools/reboot.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from m1n1.setup import *
+
+p.reboot()


### PR DESCRIPTION
An alternative could be adding a command parameter to shell.py but `./tools/shell.py -c 'p.reboot()'` is a little annoying to type