### PR TITLE
linux.py: add missing serial import

### DIFF
--- a/proxyclient/tools/linux.py
+++ b/proxyclient/tools/linux.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT
 import sys, pathlib
+import serial
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 import argparse, pathlib


### PR DESCRIPTION
Signed-off-by: Sven Peter <sven@svenpeter.dev>