### PR TITLE
startup: Prettyify video depth dump

### DIFF
--- a/src/startup.c
+++ b/src/startup.c
@@ -59,7 +59,7 @@ void dump_boot_args(struct boot_args *ba)
     printf("    stride:     0x%lx\n", ba->video.stride);
     printf("    width:      %lu\n", ba->video.width);
     printf("    height:     %lu\n", ba->video.height);
-    printf("    depth:      0x%lx\n", ba->video.depth);
+    printf("    depth:      %lubpp\n", ba->video.depth);
     printf("  machine_type: %d\n", ba->machine_type);
     printf("  devtree:      %p\n", ba->devtree);
     printf("  devtree_size: 0x%x\n", ba->devtree_size);


### PR DESCRIPTION
Use the right unit. for rgb10x2, this prints "30bpp" instead of "0x1E".

Signed-off-by: Alyssa Rosenzweig <alyssa@rosenzweig.io>