### PR TITLE
proxyclient/m1n1/utils.py: don't compact non-adjacent ranges

### DIFF
--- a/proxyclient/m1n1/utils.py
+++ b/proxyclient/m1n1/utils.py
@@ -400,7 +400,7 @@ class RangeMap(Reloadable):
             s, e, v = self.__start[pos], self.__end[pos], self.__value[pos]
             if empty(v):
                 continue
-            if new_v and equal(last, v):
+            if new_v and equal(last, v) and s == new_e[-1] + 1:
                 new_e[-1] = e
             else:
                 new_s.append(s)


### PR DESCRIPTION
This is not a major issue, so please feel free to close without further discussion.

`compact` currently merges ranges without checking they're actually adjacent. For example, this test fails:

```
    # BoolRangeMap test
    a = BoolRangeMap()
    a.set(range(0, 2))
    a.set(range(4, 6))
    a.compact()
    a.clear(range(3, 5))
    expect = [True, True, False, False, False, True, False]
    for i,j in enumerate(expect):
        assert a[i] == j
```

Also, tracing access to memory (not MMIO) ranges doesn't throw an error, but also fails to work, for this reason. I can provide examples if that would be considered helpful.