### PR TITLE
fw.dcp: Add some stubs needed for modesetting

### DIFF
--- a/proxyclient/hv/trace_dcp.py
+++ b/proxyclient/hv/trace_dcp.py
@@ -370,9 +370,9 @@ KNOWN_MSGS = {
     "D424": "void IOMFB::ServiceRelay::removeProperty(unsigned int, OSString<0x40> const*)",
 
     "D450": "bool IOMFB::MemDescRelay::from_id(unsigned int, unsigned long*, unsigned long*, unsigned long long*)",
-    "D451": "unsigned int IOMFB::MemDescRelay::allocate_buffer(unsigned int, unsigned long long, unsigned int, unsigned long*, unsigned long*, unsigned long long*)",
-    "D452": "unsigned int IOMFB::MemDescRelay::map_physical(unsigned long long, unsigned long long, unsigned int, unsigned long*, unsigned long long*)",
-    "D453": "unsigned int IOMFB::MemDescRelay::withAddressRange(unsigned long long, unsigned long long, unsigned int, task*, unsigned long*, unsigned long long*)",
+    "D451": "MemDescRelay::desc_id_t IOMFB::MemDescRelay::allocate_buffer(unsigned int, unsigned long long, unsigned int, unsigned long*, unsigned long*, unsigned long long*)",
+    "D452": "MemDescRelay::desc_id_t IOMFB::MemDescRelay::map_physical(unsigned long long, unsigned long long, unsigned int, unsigned long*, unsigned long long*)",
+    "D453": "MemDescRelay::desc_id_t IOMFB::MemDescRelay::withAddressRange(unsigned long long, unsigned long long, unsigned int, task*, unsigned long*, unsigned long long*)",
     "D454": "IOMFBStatus IOMFB::MemDescRelay::prepare(unsigned int, unsigned int)",
     "D455": "IOMFBStatus IOMFB::MemDescRelay::complete(unsigned int, unsigned int)",
     "D456": "bool IOMFB::MemDescRelay::release_descriptor(unsigned int)",

--- a/proxyclient/m1n1/fw/dcp/ipc.py
+++ b/proxyclient/m1n1/fw/dcp/ipc.py
@@ -682,9 +682,11 @@ class ServiceRelay(IPCObject):
     D414 = Callback(bool_, "sr_setProperty_int", obj=FourCC, key=string(0x40), value=InPtr(uint64_t))
     D415 = Callback(bool_, "sr_setProperty_bool", obj=FourCC, key=string(0x40), value=InPtr(Bool(uint32_t)))
 
+mem_desc_id = uint
+
 class MemDescRelay(IPCObject):
-    D451 = Callback(uint, "allocate_buffer", uint, ulong, uint, OutPtr(ulong), OutPtr(ulong), OutPtr(ulong))
-    D452 = Callback(uint, "map_physical", paddr=ulong, size=ulong, flags=uint, dva=OutPtr(ulong), dvasize=OutPtr(ulong))
+    D451 = Callback(mem_desc_id, "allocate_buffer", uint, ulong, uint, OutPtr(ulong), OutPtr(ulong), OutPtr(ulong))
+    D452 = Callback(mem_desc_id, "map_physical", paddr=ulong, size=ulong, flags=uint, dva=OutPtr(ulong), dvasize=OutPtr(ulong))
 
 ALL_CLASSES = [
     UPPipeAP_H13P,

--- a/proxyclient/m1n1/fw/dcp/manager.py
+++ b/proxyclient/m1n1/fw/dcp/manager.py
@@ -108,6 +108,11 @@ class DCPManager(DCPBaseManager):
         self.swaps += 1
         self.frame = arg0
 
+    def swap_complete_intent_gated(self, frame, arg1, arg2, width, height):
+        print(f"swap_complete_intent_gated({frame}, {arg1}, {arg2}, {width}, {height}")
+        self.swaps += 1
+        self.frame = frame
+
     ## UPPipeAP_H13P methods
 
     def did_boot_signal(self):
@@ -115,6 +120,9 @@ class DCPManager(DCPBaseManager):
 
     def did_power_on_signal(self):
         return True
+
+    def will_power_off_signal(self):
+        return
 
     def rt_bandwidth_setup_ap(self, config):
         print("rt_bandwidth_setup_ap(...)")
@@ -159,6 +167,19 @@ class DCPManager(DCPBaseManager):
         print(f"setDCPAVPropEnd({key!r})")
         return True
 
+    def set_boolean_property(self, key, value):
+        print(f"set {key!r} = {value}")
+
+    def removeProperty(self, key):
+        print(f"removeProperty({key!r})")
+
+    def powerstate_notify(self, unk1, unk2):
+        print(f"powerstate_notify({unk1}, {unk2})")
+
+    def powerUpDART(self, unk):
+        print(f"powerUpDART({unk})")
+        return 0
+
     def is_waking_from_hibernate(self):
         return False
 
@@ -169,6 +190,12 @@ class DCPManager(DCPBaseManager):
 
     def match_backlight_service(self):
         return True
+
+    def map_buf(self, buf, out1, out2, unkBool):
+        print(f"map buf {buf}, {unkBool}")
+        out1.val = 0xfffffe1667b9d0e0
+        out2.val = 0
+        return 0
 
     ## ServiceRelay methods
 
@@ -200,6 +227,17 @@ class DCPManager(DCPBaseManager):
         print(f"pr_publish({prop_id}, {value!r})")
 
     ## MemDescRelay methods:
+
+    def allocate_buffer(self, unk0, size, unk1, paddr, dva, dvasize):
+        print(f"allocate_buffer({unk0}, {size}, {unk1})")
+
+        dvasize.val = align_up(size, 4096)
+        paddr.val = self.dcp.u.memalign(0x4000, size)
+        dva.val = self.dcp.dart.iomap(0, paddr.val, size)
+
+        self.mapid += 1
+        print(f"Allocating {self.mapid} as {hex(paddr.val)} / {hex(dva.val)}")
+        return self.mapid
 
     def map_physical(self, paddr, size, flags, dva, dvasize):
         dvasize.val = align_up(size, 4096)


### PR DESCRIPTION
This isn't enough to set the video mode yet but it gets us further. I
think allocate_memory/map_buf/powerOnDART need real implementations,
otherwise setting a video mode crashes the DCP in an APIODMA interrupt
handler, whatever that is.

Yes, this a blatant attempt at nerdsniping marcan into debugging that.