### PR TITLE
Avoid reporting bytes in the RX buffer when it's empty.

### DIFF
--- a/src/hv_vuart.c
+++ b/src/hv_vuart.c
@@ -24,6 +24,7 @@ static void update_irq(void)
     utrstat |= UTRSTAT_TXBE | UTRSTAT_TXE;
     utrstat &= ~UTRSTAT_RXD;
 
+    ufstat = 0;
     if ((rx_queued = iodev_can_read(vuart_iodev))) {
         utrstat |= UTRSTAT_RXD;
         if (rx_queued > 15)


### PR DESCRIPTION
I believe this fix, or something like it, is necessary to avoid spurious NUL bytes being received over the vUART by the Linux driver.

(Unfortunately, I'm having a hard time testing the vUART right now. I'm using vanilla m1n1 on a machine that has never booted anything but vanilla m1n1 and macOS, and am booting straight from iBoot...)

Anyway, it's a pretty obvious fix :-)