### PR TITLE
Cosmetic fixes, avoid relying on UTRSTAT_RXD == 1

### DIFF
--- a/src/iodev.c
+++ b/src/iodev.c
@@ -33,7 +33,7 @@ size_t con_rp[IODEV_MAX];
 ssize_t iodev_can_read(iodev_id_t id)
 {
     if (!iodevs[id]->ops->can_read)
-        return false;
+        return 0;
 
     return iodevs[id]->ops->can_read(iodevs[id]->opaque);
 }

--- a/src/uart.c
+++ b/src/uart.c
@@ -119,7 +119,7 @@ static bool uart_iodev_can_write(void *opaque)
 static ssize_t uart_iodev_can_read(void *opaque)
 {
     UNUSED(opaque);
-    return read32(UART_BASE + UTRSTAT) & UTRSTAT_RXD;
+    return (read32(UART_BASE + UTRSTAT) & UTRSTAT_RXD) ? 1 : 0;
 }
 
 static ssize_t uart_iodev_read(void *opaque, void *buf, size_t len)

--- a/src/usb_dwc3.c
+++ b/src/usb_dwc3.c
@@ -1368,11 +1368,11 @@ size_t usb_dwc3_read(dwc3_dev_t *dev, cdc_acm_pipe_id_t pipe, void *buf, size_t 
 ssize_t usb_dwc3_can_read(dwc3_dev_t *dev, cdc_acm_pipe_id_t pipe)
 {
     if (!dev || !dev->ready)
-        return false;
+        return 0;
 
     ringbuffer_t *host2device = dev->pipe[pipe].host2device;
     if (!host2device)
-        return false;
+        return 0;
 
     return ringbuffer_get_used(host2device);
 }


### PR DESCRIPTION
Tiny readability fixes. If you don't want this kind of fix, please let me know, but at least this hunk:

```
-    return read32(UART_BASE + UTRSTAT) & UTRSTAT_RXD;
+    return (read32(UART_BASE + UTRSTAT) & UTRSTAT_RXD) ? 1 : 0;
```

seems important to me to make the code more obviously correct.