### PR TITLE
smp: Fix smp_call macros with fewer than 4 arguments

### DIFF
--- a/src/smp.h
+++ b/src/smp.h
@@ -15,10 +15,10 @@ void smp_secondary_entry(void);
 
 void smp_start_secondaries(void);
 
-#define smp_call0(i, f)          smp_call(i, f, 0, 0, 0, 0)
-#define smp_call1(i, f, a)       smp_call(i, f, a, 0, 0, 0)
-#define smp_call2(i, f, a, b)    smp_call(i, f, a, b, 0, 0)
-#define smp_call3(i, f, a, b, c) smp_call(i, f, a, b, c, 0)
+#define smp_call0(i, f)          smp_call4(i, f, 0, 0, 0, 0)
+#define smp_call1(i, f, a)       smp_call4(i, f, a, 0, 0, 0)
+#define smp_call2(i, f, a, b)    smp_call4(i, f, a, b, 0, 0)
+#define smp_call3(i, f, a, b, c) smp_call4(i, f, a, b, c, 0)
 
 void smp_call4(int cpu, void *func, u64 arg0, u64 arg1, u64 arg2, u64 arg3);
 


### PR DESCRIPTION
The full 4-argument version of smp_call is `smp_call4`; smp_call doesn't exist.