### PR TITLE
proxyclient: Fix typo in LazyADT str implementation

### DIFF
--- a/proxyclient/m1n1/proxyutils.py
+++ b/proxyclient/m1n1/proxyutils.py
@@ -334,7 +334,7 @@ class LazyADT:
     def __delattr__(self, attr):
         return delattr(self._adt, attr)
     def __str__(self, t=""):
-        return gstr(self._adt)
+        return str(self._adt)
     def __iter__(self):
         return iter(self._adt)
 


### PR DESCRIPTION
Fix the `gstr` typo so that `print(hv.adt)` works as expected.