### PR TITLE
usb: support more than 2 usb-c ports

### DIFF
--- a/proxyclient/m1n1/hv.py
+++ b/proxyclient/m1n1/hv.py
@@ -983,8 +983,8 @@ class HV(Reloadable):
         self.print_tracer = trace.PrintTracer(self, self.device_addr_tbl)
 
         # disable unused USB iodev early so interrupts can be reenabled in hv_init()
-        for iodev in (IODEV.USB0, IODEV.USB1):
-            if iodev != self.iodev:
+        for iodev in IODEV:
+            if iodev >= IODEV.USB0 and iodev != self.iodev:
                 print(f"Disable iodev {iodev!s}")
                 self.p.iodev_set_usage(iodev, 0)
 
@@ -1086,10 +1086,7 @@ class HV(Reloadable):
             self.log(f"PMGR R {base:x}+{off:x}:{width} = 0x{data:x} -> 0x{ret:x}")
             return ret
 
-        if self.iodev == IODEV.USB0:
-            atc = "ATC0_USB"
-        elif self.iodev == IODEV.USB1:
-            atc = "ATC1_USB"
+        atc = f"ATC{self.iodev - IODEV.USB0}_USB"
 
         hook_devs = ["UART0", atc]
 
@@ -1166,8 +1163,8 @@ class HV(Reloadable):
         soc_name = "Virtual " + self.adt["product"].product_soc_name + " on m1n1 hypervisor"
         self.adt["product"].product_soc_name = soc_name
 
-        if self.iodev in (IODEV.USB0, IODEV.USB1):
-            idx = int(str(self.iodev)[-1])
+        if self.iodev >= IODEV.USB0:
+            idx = self.iodev - IODEV.USB0
             for prefix in ("/arm-io/dart-usb%d",
                            "/arm-io/atc-phy%d",
                            "/arm-io/usb-drd%d",

--- a/proxyclient/m1n1/hv.py
+++ b/proxyclient/m1n1/hv.py
@@ -1068,7 +1068,7 @@ class HV(Reloadable):
 
         zone = irange(base, 0x4000)
         irq = node.interrupts[0]
-        self.p.hv_map_vuart(base, irq, getattr(IODEV, self.iodev.name + "_SEC"))
+        self.p.hv_map_vuart(base, irq, self.iodev)
         self.add_tracer(zone, "VUART", TraceMode.RESERVED)
 
     def map_essential(self):

--- a/proxyclient/m1n1/proxy.py
+++ b/proxyclient/m1n1/proxy.py
@@ -83,7 +83,7 @@ ExcInfo = Struct(
 )
 # Sends 56+ byte Commands and Expects 36 Byte Responses
 # Commands are format <I48sI
-#   4 byte command, 48 byte null padded data + 4 byte checksum 
+#   4 byte command, 48 byte null padded data + 4 byte checksum
 # Responses are of the format: struct format <Ii24sI
 #   4byte Response , 4 byte status, 24 byte string,  4 byte Checksum
 #    Response must start 0xff55aaXX where XX distiguishes between them

--- a/proxyclient/m1n1/proxy.py
+++ b/proxyclient/m1n1/proxy.py
@@ -423,10 +423,9 @@ class AlignmentError(Exception):
 class IODEV(IntEnum):
     UART = 0
     FB = 1
-    USB0 = 2
-    USB1 = 3
-    USB0_SEC = 4
-    USB1_SEC = 5
+    USB_VUART = 2
+    USB0 = 3
+    USB1 = 4
 
 class USAGE(IntFlag):
     CONSOLE = (1 << 0)

--- a/proxyclient/m1n1/proxy.py
+++ b/proxyclient/m1n1/proxy.py
@@ -426,6 +426,12 @@ class IODEV(IntEnum):
     USB_VUART = 2
     USB0 = 3
     USB1 = 4
+    USB2 = 5
+    USB3 = 6
+    USB4 = 7
+    USB5 = 8
+    USB6 = 9
+    USB7 = 10
 
 class USAGE(IntFlag):
     CONSOLE = (1 << 0)

--- a/src/iodev.c
+++ b/src/iodev.c
@@ -19,12 +19,12 @@
 extern struct iodev iodev_uart;
 extern struct iodev iodev_fb;
 extern struct iodev iodev_usb[];
-extern struct iodev iodev_usb_sec[];
+extern struct iodev iodev_usb_vuart;
 
 struct iodev *iodevs[IODEV_MAX] = {
     [IODEV_UART] = &iodev_uart,           [IODEV_FB] = &iodev_fb,
-    [IODEV_USB0] = &iodev_usb[0],         [IODEV_USB1] = &iodev_usb[1],
-    [IODEV_USB0_SEC] = &iodev_usb_sec[0], [IODEV_USB1_SEC] = &iodev_usb_sec[1],
+    [IODEV_USB_VUART] = &iodev_usb_vuart, [IODEV_USB0] = &iodev_usb[0],
+    [IODEV_USB1] = &iodev_usb[1],
 };
 
 char con_buf[CONSOLE_BUFFER_SIZE];

--- a/src/iodev.c
+++ b/src/iodev.c
@@ -254,3 +254,13 @@ void iodev_console_flush(void)
         iodev_flush(id);
     }
 }
+
+void iodev_set_usage(iodev_id_t id, iodev_usage_t usage)
+{
+    iodevs[id]->usage = usage;
+}
+
+iodev_usage_t iodev_get_usage(iodev_id_t id)
+{
+    return iodevs[id]->usage;
+}

--- a/src/iodev.h
+++ b/src/iodev.h
@@ -9,10 +9,9 @@
 typedef enum _iodev_id_t {
     IODEV_UART,
     IODEV_FB,
+    IODEV_USB_VUART,
     IODEV_USB0,
     IODEV_USB1,
-    IODEV_USB0_SEC,
-    IODEV_USB1_SEC,
     IODEV_MAX,
 } iodev_id_t;
 

--- a/src/iodev.h
+++ b/src/iodev.h
@@ -6,13 +6,14 @@
 #include "types.h"
 #include "utils.h"
 
+#define USB_IODEV_COUNT 8
+
 typedef enum _iodev_id_t {
     IODEV_UART,
     IODEV_FB,
     IODEV_USB_VUART,
     IODEV_USB0,
-    IODEV_USB1,
-    IODEV_MAX,
+    IODEV_MAX = IODEV_USB0 + USB_IODEV_COUNT,
 } iodev_id_t;
 
 typedef enum _iodev_usage_t {

--- a/src/iodev.h
+++ b/src/iodev.h
@@ -38,6 +38,9 @@ struct iodev {
     void *opaque;
 };
 
+void iodev_register_device(iodev_id_t id, struct iodev *dev);
+struct iodev *iodev_unregister_device(iodev_id_t id);
+
 ssize_t iodev_can_read(iodev_id_t id);
 bool iodev_can_write(iodev_id_t id);
 ssize_t iodev_read(iodev_id_t id, void *buf, size_t length);
@@ -52,5 +55,6 @@ void iodev_console_flush(void);
 
 iodev_usage_t iodev_get_usage(iodev_id_t id);
 void iodev_set_usage(iodev_id_t id, iodev_usage_t usage);
+void *iodev_get_opaque(iodev_id_t id);
 
 #endif

--- a/src/iodev.h
+++ b/src/iodev.h
@@ -38,8 +38,6 @@ struct iodev {
     void *opaque;
 };
 
-extern struct iodev *iodevs[IODEV_MAX];
-
 ssize_t iodev_can_read(iodev_id_t id);
 bool iodev_can_write(iodev_id_t id);
 ssize_t iodev_read(iodev_id_t id, void *buf, size_t length);
@@ -52,9 +50,7 @@ void iodev_console_write(const void *buf, size_t length);
 void iodev_console_kick(void);
 void iodev_console_flush(void);
 
-static inline void iodev_set_usage(iodev_id_t id, iodev_usage_t usage)
-{
-    iodevs[id]->usage = usage;
-}
+iodev_usage_t iodev_get_usage(iodev_id_t id);
+void iodev_set_usage(iodev_id_t id, iodev_usage_t usage);
 
 #endif

--- a/src/kboot.c
+++ b/src/kboot.c
@@ -67,7 +67,7 @@ static int dt_set_chosen(void)
         u64 fbreg[2] = {cpu_to_fdt64(fb_base), cpu_to_fdt64(fb_size)};
         char fbname[32];
 
-        sprintf(fbname, "framebuffer@%lx", fb_base);
+        snprintf(fbname, sizeof(fbname), "framebuffer@%lx", fb_base);
 
         if (fdt_setprop(dt, fb, "reg", fbreg, sizeof(fbreg)))
             bail("FDT: couldn't set framebuffer.reg property\n");
@@ -263,7 +263,7 @@ static int dt_set_mac_addresses(void)
 
     for (size_t i = 0; i < sizeof(aliases) / sizeof(*aliases); i++) {
         char propname[32];
-        sprintf(propname, "mac-address-%s", aliases[i]);
+        snprintf(propname, sizeof(propname), "mac-address-%s", aliases[i]);
 
         uint8_t addr[6];
         if (ADT_GETPROP_ARRAY(adt, anode, propname, addr) < 0)

--- a/src/pcie.c
+++ b/src/pcie.c
@@ -215,7 +215,7 @@ int pcie_init(void)
          * Initialize RC port.
          */
 
-        sprintf(bridge, "/arm-io/apcie/pci-bridge%d", port);
+        snprintf(bridge, sizeof(bridge), "/arm-io/apcie/pci-bridge%d", port);
 
         if (adt_path_offset(adt, bridge) < 0)
             continue;

--- a/src/uartproxy.c
+++ b/src/uartproxy.c
@@ -151,7 +151,7 @@ int uartproxy_run(struct uartproxy_msg_start *start)
             // Look for commands from any iodev on startup
             for (iodev = 0; iodev < IODEV_MAX;) {
                 u8 b;
-                if ((iodevs[iodev]->usage & USAGE_UARTPROXY)) {
+                if ((iodev_get_usage(iodev) & USAGE_UARTPROXY)) {
                     iodev_handle_events(iodev);
                     if (iodev_can_read(iodev) && iodev_read(iodev, &b, 1) == 1) {
                         iodev_proxy_buffer[iodev] >>= 8;

--- a/src/usb.c
+++ b/src/usb.c
@@ -218,17 +218,10 @@ struct iodev iodev_usb[USB_INSTANCES] = {
     },
 };
 
-struct iodev iodev_usb_sec[USB_INSTANCES] = {
-    {
-        .ops = &iodev_usb_sec_ops,
-        .usage = 0,
-        .lock = SPINLOCK_INIT,
-    },
-    {
-        .ops = &iodev_usb_sec_ops,
-        .usage = 0,
-        .lock = SPINLOCK_INIT,
-    },
+struct iodev iodev_usb_vuart = {
+    .ops = &iodev_usb_sec_ops,
+    .usage = 0,
+    .lock = SPINLOCK_INIT,
 };
 
 static tps6598x_dev_t *hpm_init(i2c_dev_t *i2c, int idx)
@@ -338,8 +331,6 @@ void usb_iodev_init(void)
         if (!iodev_usb[i].opaque)
             continue;
 
-        iodev_usb_sec[i].opaque = iodev_usb[i].opaque;
-
         printf("USB%d: initialized at %p\n", i, iodev_usb[i].opaque);
     }
 }
@@ -354,7 +345,6 @@ void usb_iodev_shutdown(void)
         usb_dwc3_shutdown(iodev_usb[i].opaque);
 
         iodev_usb[i].opaque = NULL;
-        iodev_usb_sec[i].opaque = NULL;
     }
 }
 
@@ -368,4 +358,12 @@ int usb_idx_from_address(u64 drd_base)
             return i;
     }
     return -1;
+}
+
+void usb_iodev_vuart_setup(iodev_id_t iodev)
+{
+    if (iodev < IODEV_USB0 || iodev >= IODEV_USB0 + USB_INSTANCES)
+        return;
+
+    iodev_usb_vuart.opaque = iodev_usb[iodev - IODEV_USB0].opaque;
 }

--- a/src/usb.h
+++ b/src/usb.h
@@ -3,6 +3,7 @@
 #ifndef USB_H
 #define USB_H
 
+#include "iodev.h"
 #include "types.h"
 #include "usb_dwc3.h"
 
@@ -13,5 +14,6 @@ void usb_hpm_restore_irqs(bool force);
 void usb_iodev_init(void);
 void usb_iodev_shutdown(void);
 int usb_idx_from_address(u64 drd_base);
+void usb_iodev_vuart_setup(iodev_id_t iodev);
 
 #endif

--- a/src/usb_dwc3.c
+++ b/src/usb_dwc3.c
@@ -1338,6 +1338,9 @@ size_t usb_dwc3_queue(dwc3_dev_t *dev, cdc_acm_pipe_id_t pipe, const void *buf, 
 
 size_t usb_dwc3_write(dwc3_dev_t *dev, cdc_acm_pipe_id_t pipe, const void *buf, size_t count)
 {
+    if (!dev)
+        return -1;
+
     u8 ep = dev->pipe[pipe].ep_in;
     size_t ret = usb_dwc3_queue(dev, pipe, buf, count);
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -55,13 +55,13 @@ void regdump(u64 addr, size_t len)
     }
 }
 
-int sprintf(char *buffer, const char *fmt, ...)
+int snprintf(char *buffer, size_t size, const char *fmt, ...)
 {
     va_list args;
     int i;
 
     va_start(args, fmt);
-    i = vsprintf(buffer, fmt, args);
+    i = vsnprintf(buffer, size, fmt, args);
     va_end(args);
     return i;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -360,7 +360,7 @@ void put_simd_state(void *state);
 
 void hexdump(const void *d, size_t len);
 void regdump(u64 addr, size_t len);
-int sprintf(char *str, const char *fmt, ...);
+int snprintf(char *str, size_t size, const char *fmt, ...);
 int debug_printf(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
 void udelay(u32 d);
 void reboot(void) __attribute__((noreturn));

--- a/src/utils.h
+++ b/src/utils.h
@@ -366,10 +366,12 @@ void udelay(u32 d);
 void reboot(void) __attribute__((noreturn));
 void flush_and_reboot(void) __attribute__((noreturn));
 
+#define SPINLOCK_ALIGN 64
+
 typedef struct {
     s64 lock;
     int count;
-} spinlock_t ALIGNED(64);
+} spinlock_t ALIGNED(SPINLOCK_ALIGN);
 
 #define SPINLOCK_INIT                                                                              \
     {                                                                                              \


### PR DESCRIPTION
Adds support for the 3rd USB-C on the 2021 Macbook Pro.
Tested on Macbook Pro 14" and Mac Mini.

Signed-off-by: Janne Grunau <j@jannau.net>