### PR TITLE
Fix aic1 reg size

### DIFF
--- a/src/aic_regs.h
+++ b/src/aic_regs.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: MIT */
 
-#define AIC_REG_SIZE     0x4000
+#define AIC_REG_SIZE     0x8000
 #define AIC_INFO         0x0004
 #define AIC_WHOAMI       0x2000
 #define AIC_EVENT        0x2004


### PR DESCRIPTION
Change aic1 reg size from 0x4000 to 0x8000 for macos to boot under the hv when doing irq tracing to avoid hypervisor IPA unmapped error.

Signed-off-by: Jean-Francois Bortolotti <jeff@borto.fr>