### PR TITLE
m1n1 dart fixes

### DIFF
--- a/proxyclient/m1n1/hw/dart.py
+++ b/proxyclient/m1n1/hw/dart.py
@@ -45,14 +45,14 @@ class PTE_T8020(Register64):
     SP_START = 63, 52
     SP_END = 51, 40
     OFFSET = 39, 14
-    VALID2 = 1
+    SP_PROT_DIS = 1
     VALID = 0
 
 class PTE_T6000(Register64):
     SP_START = 63, 52
     SP_END = 51, 40
     OFFSET = 39, 10
-    VALID2 = 1
+    SP_PROT_DIS = 1
     VALID = 0
 
 class R_CONFIG(Register32):
@@ -198,7 +198,7 @@ class DART(Reloadable):
                 l2addr = self.u.memalign(self.PAGE_SIZE, self.PAGE_SIZE)
                 self.pt_cache[l2addr] = [0] * self.Lx_SIZE
                 l1pte = self.ptecls(
-                    OFFSET=l2addr >> self.PAGE_BITS, VALID=1, VALID2=1)
+                    OFFSET=l2addr >> self.PAGE_BITS, VALID=1, SP_PROT_DIS=1)
                 l1[l1idx] = l1pte.value
                 dirty.add(ttbr.ADDR << 12)
             else:
@@ -209,7 +209,7 @@ class DART(Reloadable):
             l2idx = (page >> self.L2_OFF) & self.IDX_MASK
             self.pt_cache[l2addr][l2idx] = self.ptecls(
                 SP_START=0, SP_END=0xfff,
-                OFFSET=paddr >> self.PAGE_BITS, VALID=1, VALID2=1).value
+                OFFSET=paddr >> self.PAGE_BITS, VALID=1, SP_PROT_DIS=1).value
 
         for page in dirty:
             self.flush_pt(page)
@@ -343,7 +343,7 @@ class DART(Reloadable):
 
             print("    page (%d): %08x ... %08x -> %016x [%d%d]" % (
                 i, base + i*0x4000, base + (i+1)*0x4000,
-                pte.OFFSET << self.PAGE_BITS, pte.VALID2, pte.VALID))
+                pte.OFFSET << self.PAGE_BITS, pte.SP_PROT_DIS, pte.VALID))
             print(hex(pte.value))
 
     def dump_table(self, base, l1_addr):
@@ -362,7 +362,7 @@ class DART(Reloadable):
 
             print("  table (%d): %08x ... %08x -> %016x [%d%d]" % (
                 i, base + i*0x2000000, base + (i+1)*0x2000000,
-                pte.OFFSET << self.PAGE_BITS, pte.VALID2, pte.VALID))
+                pte.OFFSET << self.PAGE_BITS, pte.SP_PROT_DIS, pte.VALID))
             self.dump_table2(base + i*0x2000000, pte.OFFSET << self.PAGE_BITS)
 
     def dump_ttbr(self, idx, ttbr):

--- a/proxyclient/m1n1/hw/dart.py
+++ b/proxyclient/m1n1/hw/dart.py
@@ -95,7 +95,7 @@ class DART(Reloadable):
     Lx_SIZE = (1 << IDX_BITS)
     IDX_MASK = Lx_SIZE - 1
 
-    def __init__(self, iface, regs, util=None, iova_range=(0x80000000, 0x90000000)):
+    def __init__(self, iface, regs, util=None, compat="dart,t8020", iova_range=(0x80000000, 0x90000000)):
         self.iface = iface
         self.regs = regs
         self.u = util
@@ -103,7 +103,7 @@ class DART(Reloadable):
         self.enabled_streams = regs.ENABLED_STREAMS.val
         self.iova_allocator = [Heap(iova_range[0], iova_range[1], self.PAGE_SIZE)
                                for i in range(16)]
-        self.ptecls = PTE_T8020
+        self.ptecls = PTE_TYPES[compat]
 
     @classmethod
     def from_adt(cls, u, path):

--- a/proxyclient/m1n1/trace/dart.py
+++ b/proxyclient/m1n1/trace/dart.py
@@ -21,7 +21,7 @@ class DARTTracer(ADTDevTracer):
 
     def start(self):
         super().start()
-        self.dart = DART(self.hv.iface, self.regs.cached)
+        self.dart = DART(self.hv.iface, self.regs.cached, compat=self.dev.compatible[0])
 
     def w_STREAM_COMMAND(self, stream_command):
         if stream_command.INVALIDATE:


### PR DESCRIPTION
- update PTE.BIT(1) annotation to disable sub-page protection
- initialize the PTE type from compatible property in DARTTracer, fixes tracing on M1 Pro/Max