### PR TITLE
rtkit.c: Add config.h include

### DIFF
--- a/src/rtkit.c
+++ b/src/rtkit.c
@@ -1,5 +1,7 @@
 /* SPDX-License-Identifier: MIT */
 
+#include "../config.h"
+
 #include "rtkit.h"
 #include "adt.h"
 #include "asc.h"


### PR DESCRIPTION
Needed for the `RTKIT_SYSLOG` optional define.