### PR TITLE
afk: propagate failures in afk_epic_rx correctly

### DIFF
--- a/src/afk.c
+++ b/src/afk.c
@@ -244,7 +244,7 @@ static int afk_epic_rx(afk_epic_ep_t *epic, struct afk_qe **qe)
         do {
             ret = afk_epic_poll(epic);
             if (ret < 0)
-                break;
+                return ret;
         } while (ret == 0);
         dma_rmb();
     }


### PR DESCRIPTION
probably even useful to not hang forever even if we require macOS >= 12.


If the co-processor crashes afk_epic_poll will always fail which results
in afk_epic_rx getting stuck in an infinite loop calling afk_epic_poll
again and again.
This happens with e.g. old/incompatible DCP firmware.
Make sure the m1n1 proxy still works in those cases by propagating the
error correctly.

Signed-off-by: Sven Peter <sven@svenpeter.dev>