### PR TITLE
rtkit: add rtkit_{hibernate,sleep} and use them for DCP and ANS2

### DIFF
--- a/src/dcp.c
+++ b/src/dcp.c
@@ -45,7 +45,7 @@ dcp_dev_t *dcp_init(const char *dcp_path, const char *dcp_dart_path, const char 
 
     return dcp;
 
-    rtkit_shutdown(dcp->rtkit);
+    rtkit_hibernate(dcp->rtkit);
     rtkit_free(dcp->rtkit);
 out_iovad:
     iovad_shutdown(dcp->iovad_dcp);
@@ -59,7 +59,7 @@ out_free:
 
 int dcp_shutdown(dcp_dev_t *dcp)
 {
-    rtkit_shutdown(dcp->rtkit);
+    rtkit_hibernate(dcp->rtkit);
     rtkit_free(dcp->rtkit);
     dart_shutdown(dcp->dart_disp);
     dart_shutdown(dcp->dart_dcp);

--- a/src/nvme.c
+++ b/src/nvme.c
@@ -63,7 +63,7 @@ bool nvme_init(void)
     return true;
 
 out_shutdown:
-    rtkit_shutdown(nvme_rtkit);
+    rtkit_sleep(nvme_rtkit);
     pmgr_reset("ANS2");
 out_rtkit:
     rtkit_free(nvme_rtkit);
@@ -81,7 +81,7 @@ void nvme_shutdown(void)
         return;
     }
 
-    rtkit_shutdown(nvme_rtkit);
+    rtkit_sleep(nvme_rtkit);
     pmgr_reset("ANS2");
     rtkit_free(nvme_rtkit);
     sart_free(nvme_sart);

--- a/src/rtkit.h
+++ b/src/rtkit.h
@@ -24,7 +24,8 @@ struct rtkit_buffer {
 
 rtkit_dev_t *rtkit_init(const char *name, asc_dev_t *asc, dart_dev_t *dart,
                         iova_domain_t *dart_iovad, sart_dev_t *sart);
-bool rtkit_shutdown(rtkit_dev_t *rtk);
+bool rtkit_sleep(rtkit_dev_t *rtk);
+bool rtkit_hibernate(rtkit_dev_t *rtk);
 void rtkit_free(rtkit_dev_t *rtk);
 
 bool rtkit_start_ep(rtkit_dev_t *rtk, u8 ep);


### PR DESCRIPTION
ANS needs to be sent to power state 0x01, otherwise it can't be reset.
I'm pretty sure I saw the string "hibernate" in some DCP firmware (or maybe even in some kext) for the 0x10 state fwiw