### PR TITLE
Add nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1641205782,
+        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1643119265,
+        "narHash": "sha256-mmDEctIkHSWcC/HRpeaw6QOe+DbNOSzc0wsXAHOZWwo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b05d2077ebe219f6a47825767f8bab5c6211d200",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,63 @@
+{
+  description = "an experimentation playground for Apple Silicon";
+
+  inputs.flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+
+  outputs = { self, nixpkgs, ... }: let
+    version = self.shortRev or (toString self.lastModifiedDate);
+
+    systems = [ "aarch64-darwin" "aarch64-linux" ];
+
+    forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
+
+    # Memoize nixpkgs for different platforms for efficiency.
+    nixpkgsFor = forAllSystems (system:
+      import nixpkgs {
+        inherit system;
+        overlays = [ self.overlay ];
+      });
+
+    cleanSrc = (src: with nixpkgs.lib; cleanSourceWith {
+        filter = name: type: cleanSourceFilter name type
+          && !(hasInfix "/node_modules/" name)
+          && !(hasInfix "/nix/" name && hasSuffix ".nix" name)
+        ;
+        inherit src;
+      }) ./.;
+  in {
+    overlay = final: prev: {
+      m1n1 = final.callPackage (
+        { lib, imagemagick, llvmPackages_13, dtc }:
+        llvmPackages_13.stdenv.mkDerivation {
+          pname = "m1n1";
+          inherit version;
+
+          src = cleanSrc;
+
+          outputs = [ "out" ];
+
+          TOOLCHAIN = "";
+          USE_CLANG = 1;
+
+          nativeBuildInputs = [ imagemagick llvmPackages_13.llvm llvmPackages_13.bintools dtc ];
+
+          installPhase = ''
+          mkdir -p "$out/"
+          cp build/m1n1.macho "$out/"
+          cp build/m1n1-raw.elf "$out/"
+          cp build/m1n1.bin "$out/"
+          '';
+        }
+      ) {};
+    };
+
+    packages =
+      forAllSystems (system: { inherit (nixpkgsFor.${system}) m1n1; });
+
+    defaultPackage = forAllSystems (system: self.packages.${system}.m1n1);
+
+  };
+}


### PR DESCRIPTION
This adds a nix flake as a second way to build it. [Nix](https://nixos.org) works on linux and macOS.

Currently it does not build on macOS, as clang there complains about the unknown directive `.type` in asm.