### PR TITLE
kboot: reload dt offset after dt_set_uboot_dm_preloc

### DIFF
--- a/src/kboot.c
+++ b/src/kboot.c
@@ -351,6 +351,11 @@ static void dt_set_uboot_dm_preloc(int node)
             continue;
         dt_set_uboot_dm_preloc(node);
 
+        // restore node offset after DT update
+        node = fdt_node_offset_by_phandle(dt, fdt32_ld(&phandles[i]));
+        if (node < 0)
+            continue;
+
         // And make sure the PMGR node is bound early too
         node = fdt_parent_offset(dt, node);
         if (node < 0)


### PR DESCRIPTION
Fixes adding "u-boot,dm-pre-reloc" to all required power-management
nodes on t600x.

Signed-off-by: Janne Grunau <j@jannau.net>