### PR TITLE
exception: Fix silent mode

### DIFF
--- a/src/exception.c
+++ b/src/exception.c
@@ -182,13 +182,9 @@ void print_regs(u64 *regs, int el12)
     const char *ec_desc = ec_table[(esr >> 26) & 0x3f];
     printf("ESR_EL1:  0x%lx (%s)\n", esr, ec_desc ? ec_desc : "?");
 
-    u64 l2c_err_sts = mrs(SYS_IMP_APL_L2C_ERR_STS);
-
-    printf("L2C_ERR_STS: 0x%lx\n", l2c_err_sts);
+    printf("L2C_ERR_STS: 0x%lx\n", mrs(SYS_IMP_APL_L2C_ERR_STS));
     printf("L2C_ERR_ADR: 0x%lx\n", mrs(SYS_IMP_APL_L2C_ERR_ADR));
     printf("L2C_ERR_INF: 0x%lx\n", mrs(SYS_IMP_APL_L2C_ERR_INF));
-
-    msr(SYS_IMP_APL_L2C_ERR_STS, l2c_err_sts); // Clear the flag bits
 
     if (is_ecore()) {
         printf("E_LSU_ERR_STS: 0x%lx\n", mrs(SYS_IMP_APL_E_LSU_ERR_STS));
@@ -250,6 +246,9 @@ void exc_sync(u64 *regs)
 
     if (!(exc_guard & GUARD_SILENT))
         print_regs(regs, el12);
+
+    u64 l2c_err_sts = mrs(SYS_IMP_APL_L2C_ERR_STS);
+    msr(SYS_IMP_APL_L2C_ERR_STS, l2c_err_sts); // Clear the L2C_ERR flag bits
 
     switch (exc_guard & GUARD_TYPE_MASK) {
         case GUARD_SKIP:


### PR DESCRIPTION
Do not forget to clear the L2C_ERR flags in silent mode also. This is
necessary for proper recovery.

Signed-off-by: Martin Povišer <povik@protonmail.com>