### PR TITLE
experiments/dcp.py: t600x support

### DIFF
--- a/proxyclient/experiments/dcp.py
+++ b/proxyclient/experiments/dcp.py
@@ -281,7 +281,11 @@ print(f"Dispaly {width}x{height}, fb size: {fb_size}")
 
 buf = u.memalign(0x4000, fb_size)
 
-iface.writemem(buf, open("asahi.bin", "rb").read())
+img = open("asahi.bin", "rb")
+
+block = 512 * 1024
+for off in range(0, fb_size, block):
+    iface.writemem(buf + off, img.read(min(block, fb_size - off)))
 
 iova = disp_dart.iomap(0, buf, fb_size)
 

--- a/proxyclient/experiments/dcp.py
+++ b/proxyclient/experiments/dcp.py
@@ -79,6 +79,7 @@ disp_dart.regs.dump_regs()
 
 dcp_addr = u.adt["arm-io/dcp"].get_reg(0)[0]
 dcp = DCPClient(u, dcp_addr, dart, disp_dart)
+dcp.dva_offset = getattr(u.adt["/arm-io/dcp"][0], "asc_dram_mask", 0)
 
 dcp.start()
 dcp.start_ep(0x37)

--- a/proxyclient/experiments/dcp.py
+++ b/proxyclient/experiments/dcp.py
@@ -15,55 +15,57 @@ from m1n1.fw.dcp.manager import DCPManager
 from m1n1.fw.dcp.ipc import ByRef
 from m1n1.proxyutils import RegMonitor
 
+is_t8103 = u.adt["arm-io"].compatible[0] == "arm-io,t8103"
 mon = RegMonitor(u)
 
-#mon.add(0x230000000, 0x18000)
-#mon.add(0x230018000, 0x4000)
-#mon.add(0x230068000, 0x8000)
-#mon.add(0x2300b0000, 0x8000)
-#mon.add(0x2300f0000, 0x4000)
-#mon.add(0x230100000, 0x10000)
-#mon.add(0x230170000, 0x10000)
-#mon.add(0x230180000, 0x1c000)
-#mon.add(0x2301a0000, 0x10000)
-#mon.add(0x2301d0000, 0x4000)
-#mon.add(0x230230000, 0x10000)
-#mon.add(0x23038c000, 0x10000)
-#mon.add(0x230800000, 0x10000)
-#mon.add(0x230840000, 0xc000)
-#mon.add(0x230850000, 0x2000)
-##mon.add(0x230852000, 0x5000) # big curve / gamma table
-#mon.add(0x230858000, 0x18000)
-#mon.add(0x230870000, 0x4000)
-#mon.add(0x230880000, 0x8000)
-#mon.add(0x230894000, 0x4000)
-#mon.add(0x2308a8000, 0x8000)
-#mon.add(0x2308b0000, 0x8000)
-#mon.add(0x2308f0000, 0x4000)
-##mon.add(0x2308fc000, 0x4000) # stats / RGB color histogram
-#mon.add(0x230900000, 0x10000)
-#mon.add(0x230970000, 0x10000)
-#mon.add(0x230980000, 0x10000)
-#mon.add(0x2309a0000, 0x10000)
-#mon.add(0x2309d0000, 0x4000)
-#mon.add(0x230a30000, 0x20000)
-#mon.add(0x230b8c000, 0x10000)
-#mon.add(0x231100000, 0x8000)
-#mon.add(0x231180000, 0x4000)
-#mon.add(0x2311bc000, 0x10000)
-#mon.add(0x231300000, 0x8000)
-##mon.add(0x23130c000, 0x4000) # - DCP dart
-#mon.add(0x231310000, 0x8000)
-#mon.add(0x231340000, 0x8000)
-##mon.add(0x231800000, 0x8000) # breaks DCP
-##mon.add(0x231840000, 0x8000) # breaks DCP
-##mon.add(0x231850000, 0x8000) # something DCP?
-##mon.add(0x231920000, 0x8000) # breaks DCP
-##mon.add(0x231960000, 0x8000) # breaks DCP
-##mon.add(0x231970000, 0x10000) # breaks DCP
-##mon.add(0x231c00000, 0x10000) # DCP mailbox
+if is_t8103:
+    #mon.add(0x230000000, 0x18000)
+    #mon.add(0x230018000, 0x4000)
+    #mon.add(0x230068000, 0x8000)
+    #mon.add(0x2300b0000, 0x8000)
+    #mon.add(0x2300f0000, 0x4000)
+    #mon.add(0x230100000, 0x10000)
+    #mon.add(0x230170000, 0x10000)
+    #mon.add(0x230180000, 0x1c000)
+    #mon.add(0x2301a0000, 0x10000)
+    #mon.add(0x2301d0000, 0x4000)
+    #mon.add(0x230230000, 0x10000)
+    #mon.add(0x23038c000, 0x10000)
+    #mon.add(0x230800000, 0x10000)
+    #mon.add(0x230840000, 0xc000)
+    #mon.add(0x230850000, 0x2000)
+    ##mon.add(0x230852000, 0x5000) # big curve / gamma table
+    #mon.add(0x230858000, 0x18000)
+    #mon.add(0x230870000, 0x4000)
+    #mon.add(0x230880000, 0x8000)
+    #mon.add(0x230894000, 0x4000)
+    #mon.add(0x2308a8000, 0x8000)
+    #mon.add(0x2308b0000, 0x8000)
+    #mon.add(0x2308f0000, 0x4000)
+    ##mon.add(0x2308fc000, 0x4000) # stats / RGB color histogram
+    #mon.add(0x230900000, 0x10000)
+    #mon.add(0x230970000, 0x10000)
+    #mon.add(0x230980000, 0x10000)
+    #mon.add(0x2309a0000, 0x10000)
+    #mon.add(0x2309d0000, 0x4000)
+    #mon.add(0x230a30000, 0x20000)
+    #mon.add(0x230b8c000, 0x10000)
+    #mon.add(0x231100000, 0x8000)
+    #mon.add(0x231180000, 0x4000)
+    #mon.add(0x2311bc000, 0x10000)
+    #mon.add(0x231300000, 0x8000)
+    ##mon.add(0x23130c000, 0x4000) # - DCP dart
+    #mon.add(0x231310000, 0x8000)
+    #mon.add(0x231340000, 0x8000)
+    ##mon.add(0x231800000, 0x8000) # breaks DCP
+    ##mon.add(0x231840000, 0x8000) # breaks DCP
+    ##mon.add(0x231850000, 0x8000) # something DCP?
+    ##mon.add(0x231920000, 0x8000) # breaks DCP
+    ##mon.add(0x231960000, 0x8000) # breaks DCP
+    ##mon.add(0x231970000, 0x10000) # breaks DCP
+    ##mon.add(0x231c00000, 0x10000) # DCP mailbox
 
-mon.add(0x230845840, 0x40) # error regs
+    mon.add(0x230845840, 0x40) # error regs
 
 mon.poll()
 
@@ -101,11 +103,17 @@ assert mgr.setPowerState(1, False, ByRef(0)) == 0
 
 mon.poll()
 
-assert mgr.set_display_device(2) == 0
+if is_t8103:
+    assert mgr.set_display_device(2) == 0
+else:
+    assert mgr.set_display_device(0) == 2
 assert mgr.set_parameter_dcp(14, [0], 1) == 0
 #mgr.set_digital_out_mode(86, 38)
 
-assert mgr.set_display_device(2) == 0
+if is_t8103:
+    assert mgr.set_display_device(2) == 0
+else:
+    assert mgr.set_display_device(0) == 2
 assert mgr.set_parameter_dcp(14, [0], 1) == 0
 #mgr.set_digital_out_mode(89, 38)
 
@@ -114,7 +122,10 @@ assert mgr.get_gamma_table(t) == 2
 assert mgr.set_contrast(0) == 0
 assert mgr.setBrightnessCorrection(65536) == 0
 
-assert mgr.set_display_device(2) == 0
+if is_t8103:
+    assert mgr.set_display_device(2) == 0
+else:
+    assert mgr.set_display_device(0) == 2
 assert mgr.set_parameter_dcp(14, [0], 1) == 0
 #mgr.set_digital_out_mode(89, 72)
 

--- a/proxyclient/m1n1/fw/dcp/dcpep.py
+++ b/proxyclient/m1n1/fw/dcp/dcpep.py
@@ -156,6 +156,7 @@ class DCPEndpoint(ASCBaseEndpoint):
 
     def initialize(self):
         self.shmem, self.shmem_dva = self.asc.ioalloc(0x100000)
+        self.asc.p.memset32(self.shmem, 0, 0x100000)
         self.send(DCPEp_SetShmem(DVA=self.shmem_dva))
         while not self.init_complete:
             self.asc.work()

--- a/proxyclient/m1n1/fw/dcp/ipc.py
+++ b/proxyclient/m1n1/fw/dcp/ipc.py
@@ -615,6 +615,7 @@ class IOMobileFramebufferAP(IPCObject):
     D576 = Callback(void, "hotPlug_notify_gated", ulong)
     D577 = Callback(void, "powerstate_notify", bool_, bool_)
 
+    D582 = Callback(bool_, "create_default_fb_surface", uint, uint)
     D583 = Callback(bool_, "serializeDebugInfoCb", ulong, InPtr(uint64_t), uint)
 
     D589 = Callback(void, "swap_complete_ap_gated", uint, bool_, InPtr(SwapCompleteData), SwapInfoBlob, uint)
@@ -624,6 +625,8 @@ class IOMobileFramebufferAP(IPCObject):
 
 class ServiceRelay(IPCObject):
     D401 = Callback(bool_, "sr_get_uint_prop", obj=FourCC, key=string(0x40), value=InOutPtr(ulong))
+    D404 = Callback(void, "sr_set_uint_prop", obj=FourCC, key=string(0x40), value=uint)
+    D406 = Callback(void, "set_fx_prop", obj=FourCC, key=string(0x40), value=uint)
     D408 = Callback(uint64_t, "sr_getClockFrequency", obj=FourCC, arg=uint)
     D411 = Callback(IOMFBStatus, "sr_mapDeviceMemoryWithIndex", obj=FourCC, index=uint, flags=uint, addr=OutPtr(ulong), length=OutPtr(ulong))
     D413 = Callback(bool_, "sr_setProperty_dict", obj=FourCC, key=string(0x40), value=InPtr(Padded(0x1000, OSDictionary())))

--- a/proxyclient/m1n1/fw/dcp/manager.py
+++ b/proxyclient/m1n1/fw/dcp/manager.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 import pprint
-import struct, functools
+import struct, functools, time
 from dataclasses import dataclass
 from enum import IntEnum
 
@@ -188,9 +188,16 @@ class DCPManager(DCPBaseManager):
     def powerstate_notify(self, unk1, unk2):
         print(f"powerstate_notify({unk1}, {unk2})")
 
+    def create_default_fb_surface(self, width, height):
+        print(f"create_default_fb_surface({width}x{height})")
+        return True
+
     def powerUpDART(self, unk):
         print(f"powerUpDART({unk})")
         return 0
+
+    def hotPlug_notify_gated(self, unk):
+        print(f"hotPlug_notify_gated({unk})")
 
     def is_waking_from_hibernate(self):
         return False
@@ -202,6 +209,9 @@ class DCPManager(DCPBaseManager):
 
     def match_backlight_service(self):
         return True
+
+    def get_calendar_time_ms(self):
+        return time.time_ns() // 1000_000
 
     def map_buf(self, buf, vaddr, dva, unk):
         print(f"map buf {buf}, {unk}")
@@ -227,6 +237,12 @@ class DCPManager(DCPBaseManager):
     def sr_get_uint_prop(self, obj, key, value):
         value.val = 0
         return False
+
+    def sr_set_uint_prop(self, obj, key, value):
+        print(f"sr_set_uint_prop({obj}, {key} = {value})")
+
+    def set_fx_prop(self, obj, key, value):
+        print(f"set_fx_prop({obj}, {key} = {value})")
 
     def sr_mapDeviceMemoryWithIndex(self, obj, index, flags, addr, length):
         assert obj == "PROV"


### PR DESCRIPTION
Works currently via vUART under HV with dcp tracing. On bare metal dcp crashes immediately after rtkit start.This matches the behavior seen with the Linux driver although they fail with different messages in crashlog.
bare metal dcp.py: `Message 1: MMU out of tables: 200,200,0`
Linux: `Message (id=1): IOMFB int_handler_gated: failure: axi_wr_err [0x80000400]`