### PR TITLE
m1n1.asm: make it work again with gcc

### DIFF
--- a/proxyclient/m1n1/asm.py
+++ b/proxyclient/m1n1/asm.py
@@ -108,7 +108,10 @@ class BaseAsm(object):
 class ARMAsm(BaseAsm):
     ARCH = os.path.join(os.environ.get("ARCH", DEFAULT_ARCH))
     CFLAGS = "-pipe -Wall -march=armv8.4-a"
-    LDFLAGS = "-maarch64elf"
+    if use_clang:
+        LDFLAGS = "-maarch64elf"
+    else:
+        LDFLAGS = "-maarch64linux"
     HEADER = """
     .text
     .globl _start


### PR DESCRIPTION
https://github.com/AsahiLinux/m1n1/commit/e19e74be8b7d5f3643cbb4237ee6b8ba2a7d8578 added support for clang, but unfortunately it also broke gcc on Linux, as I'd get:

```
$ ./chainload.py ../../build/m1n1.macho 
m1n1 base: 0x10002750000
LOAD: _HDR 16384 bytes from 0 to 0
LOAD: TEXT 163840 bytes from 4000 to 4000
LOAD: RODA 49152 bytes from 2c000 to 2c000
LOAD: DATA 393216 bytes from 38000 to 38000
ZERO: 196608 bytes from 0x98000 to 0xc8000
LOAD: PYLD 0 bytes from 98000 to c8000
SKIP: 67108864 bytes from 0xc8000 to 0x40c8000
Fetching ADT (0x00070000 bytes)...
Total region size: 0x80c000 bytes
Loading kernel image (0xc8004 bytes)...
...............
Copying SEPFW (0x73c000 bytes)...
Adjusting addresses in ADT...
Pushing ADT (445900 bytes)...
Setting secondary CPU RVBARs...
  cpu1: [0x210150000] = 0x10002754000
  cpu2: [0x211050000] = 0x10002754000
  cpu3: [0x211150000] = 0x10002754000
  cpu4: [0x211250000] = 0x10002754000
  cpu6: [0x212050000] = 0x10002754000
  cpu7: [0x212150000] = 0x10002754000
  cpu8: [0x212250000] = 0x10002754000
Setting up bootargs...
Copying stub...
aarch64-linux-gnu-ld: cannot open linker script file ldscripts/aarch64elf.xc: No such file or directory
Traceback (most recent call last):
  File "/home/davide/fedora-wip/asahi/m1n1/proxyclient/tools/./chainload.py", line 93, in <module>
    stub = asm.ARMAsm(f"""
  File "/home/davide/fedora-wip/asahi/m1n1/proxyclient/m1n1/asm.py", line 43, in __init__
    self.compile(source)
  File "/home/davide/fedora-wip/asahi/m1n1/proxyclient/m1n1/asm.py", line 64, in compile
    self._call(LD, f"{self.LDFLAGS} --Ttext={self.addr:#x} -o {self.elffile} {self.ofile}")
  File "/home/davide/fedora-wip/asahi/m1n1/proxyclient/m1n1/asm.py", line 46, in _call
    subprocess.check_call(program.replace("%ARCH", self.ARCH) + " " + args, shell=True)
  File "/usr/lib64/python3.10/subprocess.py", line 369, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command 'aarch64-linux-gnu-ld -maarch64elf --Ttext=0x1000dda0200 -o /tmp/tmpiyaa_3mf/b.elf /tmp/tmpiyaa_3mf/b.o' returned non-zero exit status 1.
```

This restores the previous logic when using gcc and makes it work again.