### PR TITLE
pcie: Set correct link speed for 10gb ethernet

### DIFF
--- a/src/pcie.c
+++ b/src/pcie.c
@@ -308,6 +308,20 @@ int pcie_init(void)
 
         u32 max_speed;
         if (ADT_GETPROP(adt, bridge_offset, "maximum-link-speed", &max_speed) >= 0) {
+            /* Apple changed how they announce the link speed for the 10gb nic
+             * at the latest in MacOS 12.3. The "lan-10gb" subnode has now a
+             * "target-link-speed" property and "maximum-link-speed" remains
+             * at 1.
+             */
+            int lan_10gb = adt_subnode_offset(adt, bridge_offset, "lan-10gb");
+            if (lan_10gb > 0) {
+                int target_speed;
+                if (ADT_GETPROP(adt, lan_10gb, "target-link-speed", &target_speed) >= 0) {
+                    if (target_speed > 0)
+                        max_speed = target_speed;
+                }
+            }
+
             printf("pcie: Port %d max speed = %d\n", port, max_speed);
 
             if (max_speed == 0) {


### PR DESCRIPTION
The PCIe 4 link speed is only described as "target-link-speed" in the
"lan-10gb". This changed in macos 12.3 or earlier. Verified on Mac
Studio and with the template Mac Mini ADT.

Reported-by: Jeff Geerling <geerlingguy@mac.com>
Signed-off-by: Janne Grunau <j@jannau.net>