### PR TITLE
proxyclient: tools: fix linux U-Boot support

### DIFF
--- a/proxyclient/tools/linux.py
+++ b/proxyclient/tools/linux.py
@@ -87,11 +87,12 @@ if args.u_boot:
     bootenv = list(filter(lambda x: not (x.startswith("baudrate") or x.startswith("boot_") or x.startswith("distro_bootcmd")), bootenv))
 
     if initramfs is not None:
-        bootcmd = "distro_bootcmd=booti 0x%x 0x%x:0x%x 0x%x" % (kernel_base, initramfs_base, initramfs_size, dtb_addr)
+        bootcmd = "distro_bootcmd=booti 0x%x 0x%x:0x%x $fdtcontroladdr" % (kernel_base, initramfs_base, initramfs_size)
     else:
-        bootcmd = "distro_bootcmd=booti 0x%x - 0x%x" % (kernel_base, dtb_addr)
+        bootcmd = "distro_bootcmd=booti 0x%x - $fdtcontroladdr" % (kernel_base)
 
-    bootenv.append("baudrate=%d" % tty_dev.baudrate)
+    if tty_dev is not None:
+        bootenv.append("baudrate=%d" % tty_dev.baudrate)
     bootenv.append(bootcmd)
     if args.bootargs is not None:
         bootenv.append("bootargs=" + args.bootargs)


### PR DESCRIPTION
-t is optional, we may not have a tty_dev, so we can avoid trying to
grab the baudrate from it if it's unspecified.

We don't want to use dtb_addr for booti; this is the unmodified payload.
m1n1 will load it and add bits to it at a separate address for passing
on to U-Boot.  For booti purposes, we actually want the augmented FDT
rather than the user-specified.

Signed-off-by: Kyle Evans <kevans@FreeBSD.org>