### PR TITLE
Fix m1n1 wiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ $ docker-compose run m1n1 make
 
 ## Usage
 
-Our [developer quickstart](https://github.com/AsahiLinux/docs/wiki/Developer-Quickstart#using-m1n1)
-guide has more information on how to use m1n1.
+Our [wiki](https://github.com/AsahiLinux/docs/wiki/m1n1%3AUser-Guide) has more information on how to
+use m1n1.
 
 To install on an OS container based on macOS <12.1, use `m1n1.macho`:
 


### PR DESCRIPTION
As far as I can tell this is the best replacement for the (now dead) link. If there is a better wiki page to link to, let me know.