### PR TITLE
rtkit/dcp: Ensure the AP -> IOP channel is ready for shutdown

### DIFF
--- a/src/rtkit.h
+++ b/src/rtkit.h
@@ -33,6 +33,7 @@ bool rtkit_boot(rtkit_dev_t *rtk);
 
 int rtkit_recv(rtkit_dev_t *rtk, struct rtkit_message *msg);
 bool rtkit_send(rtkit_dev_t *rtk, const struct rtkit_message *msg);
+int rtkit_drain(rtkit_dev_t *rtk, int timeout);
 
 bool rtkit_map(rtkit_dev_t *rtk, void *phys, size_t sz, u64 *dva);
 bool rtkit_unmap(rtkit_dev_t *rtk, u64 dva, size_t sz);


### PR DESCRIPTION
Pending syslog messages delivered during shutdown can not be
acked since shutdown command is still in the mailbox. The missing ack
blocks the mailbox communication.
Draining any pending messages before shutting down fixes this.

The issue is reproducible on the Mac Studio with a Dell UP2414Q display.
If the display is in power save mode when the mode is set it resets the
link ~400ms. The reset produces syslog messages which are not read
before shutdown.

Signed-off-by: Janne Grunau <j@jannau.net>