### PR TITLE
Add display framebuffer allocation

### DIFF
--- a/src/dart.c
+++ b/src/dart.c
@@ -277,7 +277,8 @@ static void *dart_translate_internal(dart_dev_t *dart, uintptr_t iova, int silen
     u32 l1_index = (iova >> 25) & 0x7ff;
 
     if (!(dart->l1[ttbr][l1_index] & DART_PTE_VALID) && !silent) {
-        printf("dart: l1 translation failure %x %lx\n", l1_index, iova);
+        printf("dart[%lx %u]: l1 translation failure %x %lx\n", dart->regs, dart->device, l1_index,
+               iova);
         return NULL;
     }
 
@@ -286,7 +287,8 @@ static void *dart_translate_internal(dart_dev_t *dart, uintptr_t iova, int silen
         (u64 *)(FIELD_GET(dart->offset_mask, dart->l1[ttbr][l1_index]) << DART_PTE_OFFSET_SHIFT);
 
     if (!(l2[l2_index] & DART_PTE_VALID) && !silent) {
-        printf("dart: l2 translation failure\n");
+        printf("dart[%lx %u]: l2 translation failure %x:%x %lx\n", dart->regs, dart->device,
+               l1_index, l2_index, iova);
         return NULL;
     }
 

--- a/src/dart.h
+++ b/src/dart.h
@@ -9,6 +9,7 @@ typedef struct dart_dev dart_dev_t;
 
 dart_dev_t *dart_init(uintptr_t base, u8 device, bool keep_pts);
 dart_dev_t *dart_init_adt(const char *path, int instance, int device, bool keep_pts);
+int dart_setup_pt_region(dart_dev_t *dart, const char *path, int device);
 int dart_map(dart_dev_t *dart, uintptr_t iova, void *bfr, size_t len);
 void dart_unmap(dart_dev_t *dart, uintptr_t iova, size_t len);
 void dart_free_l2(dart_dev_t *dart, uintptr_t iova);

--- a/src/dart.h
+++ b/src/dart.h
@@ -11,6 +11,7 @@ dart_dev_t *dart_init(uintptr_t base, u8 device, bool keep_pts);
 dart_dev_t *dart_init_adt(const char *path, int instance, int device, bool keep_pts);
 int dart_map(dart_dev_t *dart, uintptr_t iova, void *bfr, size_t len);
 void dart_unmap(dart_dev_t *dart, uintptr_t iova, size_t len);
+void dart_free_l2(dart_dev_t *dart, uintptr_t iova);
 void *dart_translate(dart_dev_t *dart, uintptr_t iova);
 u64 dart_search(dart_dev_t *dart, void *paddr);
 s64 dart_find_iova(dart_dev_t *dart, s64 start, size_t len);

--- a/src/dcp.c
+++ b/src/dcp.c
@@ -24,7 +24,7 @@ dcp_dev_t *dcp_init(const char *dcp_path, const char *dcp_dart_path, const char 
         goto out_dart_dcp;
     }
 
-    dcp->iovad_dcp = iovad_init(0x10000000, 0xf0000000);
+    dcp->iovad_dcp = iovad_init(0x10000000, 0x20000000);
 
     dcp->asc = asc_init(dcp_path);
     if (!dcp->asc) {

--- a/src/dcp.c
+++ b/src/dcp.c
@@ -17,12 +17,14 @@ dcp_dev_t *dcp_init(const char *dcp_path, const char *dcp_dart_path, const char 
         printf("dcp: failed to initialize DCP DART\n");
         goto out_free;
     }
+    dart_setup_pt_region(dcp->dart_dcp, dcp_dart_path, 0);
 
     dcp->dart_disp = dart_init_adt(disp_dart_path, 0, 0, true);
     if (!dcp->dart_disp) {
         printf("dcp: failed to initialize DISP DART\n");
         goto out_dart_dcp;
     }
+    dart_setup_pt_region(dcp->dart_disp, disp_dart_path, 0);
 
     dcp->iovad_dcp = iovad_init(0x10000000, 0x20000000);
 

--- a/src/dcp.c
+++ b/src/dcp.c
@@ -48,7 +48,7 @@ dcp_dev_t *dcp_init(const char *dcp_path, const char *dcp_dart_path, const char 
     rtkit_hibernate(dcp->rtkit);
     rtkit_free(dcp->rtkit);
 out_iovad:
-    iovad_shutdown(dcp->iovad_dcp);
+    iovad_shutdown(dcp->iovad_dcp, dcp->dart_dcp);
     dart_shutdown(dcp->dart_disp);
 out_dart_dcp:
     dart_shutdown(dcp->dart_dcp);
@@ -62,6 +62,7 @@ int dcp_shutdown(dcp_dev_t *dcp)
     rtkit_hibernate(dcp->rtkit);
     rtkit_free(dcp->rtkit);
     dart_shutdown(dcp->dart_disp);
+    iovad_shutdown(dcp->iovad_dcp, dcp->dart_dcp);
     dart_shutdown(dcp->dart_dcp);
     free(dcp);
 

--- a/src/iova.h
+++ b/src/iova.h
@@ -3,12 +3,13 @@
 #ifndef IOVA_H
 #define IOVA_H
 
+#include "dart.h"
 #include "types.h"
 
 typedef struct iova_domain iova_domain_t;
 
 iova_domain_t *iovad_init(u64 base, u64 limit);
-void iovad_shutdown(iova_domain_t *iovad);
+void iovad_shutdown(iova_domain_t *iovad, dart_dev_t *dart);
 
 bool iova_reserve(iova_domain_t *iovad, u64 iova, size_t sz);
 u64 iova_alloc(iova_domain_t *iovad, size_t sz);

--- a/src/memory.c
+++ b/src/memory.c
@@ -379,6 +379,13 @@ static void mmu_remap_ranges(void)
     }
 }
 
+void mmu_map_framebuffer(u64 addr, size_t size)
+{
+    printf("MMU: Adding UC mapping at 0x%lx (0x%zx) for framebuffer\n", addr, size);
+    dc_civac_range((void *)addr, size);
+    mmu_add_mapping(addr, addr, size, MAIR_IDX_FRAMEBUFFER, PERM_RW_EL0);
+}
+
 static void mmu_add_default_mappings(void)
 {
     mmu_map_mmio();

--- a/src/memory.h
+++ b/src/memory.h
@@ -71,6 +71,7 @@ void mmu_init_secondary(int cpu);
 void mmu_shutdown(void);
 void mmu_add_mapping(u64 from, u64 to, size_t size, u8 attribute_index, u64 perms);
 void mmu_rm_mapping(u64 from, size_t size);
+void mmu_map_framebuffer(u64 addr, size_t size);
 
 u64 mmu_disable(void);
 void mmu_restore(u64 state);

--- a/src/types.h
+++ b/src/types.h
@@ -47,6 +47,7 @@ typedef s64 ssize_t;
 #define SZ_4K  (1 << 12)
 #define SZ_16K (1 << 14)
 #define SZ_1M  (1 << 20)
+#define SZ_32M (1 << 25)
 
 #ifdef __ASSEMBLER__
 


### PR DESCRIPTION
The iboot allocated framebuffer might not be large enough for the user selected display resolution. The Mac Mini is limited to 2560x1440 and the Mac Studio to 1920x1080 (common display resolutions which still fit the framebuffer, actual size is larger).
A larger framebuffer is only allocated when a mode was specified with a `display=WIDTHxHEIGHT…` variable.

Note: macOS 12.3 panics on my Mac Studio with an reallocated framebuffer.
