### PR TITLE
m1n1.hw.pmu: Add SPMI PMU support for resetting the panic counter

### DIFF
--- a/proxyclient/experiments/agx_1tri.py
+++ b/proxyclient/experiments/agx_1tri.py
@@ -7,11 +7,9 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 from m1n1.setup import *
 from m1n1.shell import run_shell
 
-from m1n1.hw.spmi import SPMI
+from m1n1.hw.pmu import PMU
 
-s = SPMI(u, "/arm-io/nub-spmi")
-leg_scrpad = 0x9f00
-s.write8(15, leg_scrpad + 2, 0) # error counts
+PMU(u).reset_panic_counter()
 
 from m1n1.agx import AGX
 from m1n1.agx.context import *

--- a/proxyclient/m1n1/hw/pmu.py
+++ b/proxyclient/m1n1/hw/pmu.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MIT
+import struct
+
+from ..utils import *
+from .spmi import SPMI
+
+__all__ = ["PMU"]
+
+class PMU:
+
+    def __init__(self, u, adt_path=None):
+        self.u = u
+        if adt_path is None:
+            adt_path = PMU.find_primary_pmu(u.adt)
+
+        self.spmi = SPMI(u, adt_path.rpartition('/')[0])
+        self.adt_path = adt_path
+        self.primary = getattr(u.adt[adt_path], "is-primary") == 1
+
+    def reset_panic_counter(self):
+        if self.primary:
+            leg_scrpad = self.u.adt[self.adt_path].info_leg__scrpad[0]
+            self.spmi.write8(15, leg_scrpad + 2, 0) # error counts
+
+    @staticmethod
+    def find_primary_pmu(adt):
+        for child in adt["/arm-io"]:
+            if child.name.startswith("nub-spmi"):
+                for pmu in child:
+                    compat = getattr(pmu, "compatible")[0] if hasattr(pmu, "compatible") else "unset"
+                    primary = (getattr(pmu, "is-primary") == 1) if hasattr(pmu, "is-primary")  else False
+                    if compat == "pmu,spmi" and primary:
+                        return pmu._path.removeprefix('/device-tree')
+        raise KeyError(f"primary 'pmu,spmi' node not found")

--- a/proxyclient/m1n1/hw/spmi.py
+++ b/proxyclient/m1n1/hw/spmi.py
@@ -3,6 +3,8 @@ import struct
 
 from ..utils import *
 
+__all__ = ["SPMI"]
+
 CMD_EXT_WRITE   = 0x00
 CMD_EXT_READ    = 0x20
 CMD_EXT_WRITEL  = 0x30

--- a/proxyclient/tools/reboot.py
+++ b/proxyclient/tools/reboot.py
@@ -4,5 +4,8 @@ import sys, pathlib
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 from m1n1.setup import *
+from m1n1.hw.pmu import PMU
+
+PMU(u).reset_panic_counter()
 
 p.reboot()

--- a/proxyclient/tools/reset_panic_counter.py
+++ b/proxyclient/tools/reset_panic_counter.py
@@ -4,18 +4,6 @@ import sys, pathlib
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 from m1n1.setup import *
-from m1n1.hw.spmi import SPMI
+from m1n1.hw.pmu import PMU
 
-compatible = u.adt["/arm-io"].compatible[0]
-
-if compatible == "arm-io,t6000":
-    s = SPMI(u, "/arm-io/nub-spmi0")
-    leg_scrpad = u.adt["/arm-io/nub-spmi0/spmi-mpmu"].info_leg__scrpad[0]
-elif compatible == "arm-io,t8103":
-    s = SPMI(u, "/arm-io/nub-spmi")
-    leg_scrpad = u.adt["/arm-io/nub-spmi/spmi-pmu"].info_leg__scrpad[0]
-else:
-    print(f"Unknown SoC comaptible '{compatible}'")
-    exit()
-
-s.write8(15, leg_scrpad + 2, 0) # error counts
+PMU(u).reset_panic_counter()

--- a/proxyclient/tools/run_guest.py
+++ b/proxyclient/tools/run_guest.py
@@ -23,6 +23,7 @@ from m1n1.proxyutils import *
 from m1n1.utils import *
 from m1n1.shell import run_shell
 from m1n1.hv import HV
+from m1n1.hw.pmu import PMU
 
 iface = UartInterface()
 p = M1N1Proxy(iface, debug=False)
@@ -61,6 +62,8 @@ symfile = None
 if args.symbols:
     symfile = args.symbols.open("rb")
 hv.load_macho(args.payload.open("rb"), symfile=symfile)
+
+PMU(u).reset_panic_counter()
 
 for i in args.script:
     try:


### PR DESCRIPTION
Replace the handrolled implementation in experiments/agx_1tri.py and
tools/reset_panic_counter.py.
In addition reset the panic counter in reboot.py and run_guest.py. If
can reboot or start guests the boot process works fine and macOS
recovery needs to leave us alone.

Signed-off-by: Janne Grunau <j@jannau.net>