### PR TITLE
Display configuration: Multiple fixes

### DIFF
--- a/src/display.h
+++ b/src/display.h
@@ -12,6 +12,7 @@ typedef enum _dcp_shutdown_mode {
 int display_init(void);
 int display_start_dcp(void);
 int display_configure(const char *config);
+void display_finish_config(void);
 void display_shutdown(dcp_shutdown_mode mode);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -101,9 +101,11 @@ void run_actions(void)
 
     if (payload_run() == 0) {
         printf("Valid payload found\n");
+        display_finish_config();
         return;
     }
 
+    display_finish_config();
     fb_set_active(true);
 
     printf("No valid payload found\n");
@@ -138,9 +140,6 @@ void m1n1_main(void)
 
 #ifdef USE_FB
     display_init();
-    // Kick DCP to sleep, so dodgy monitors which cause reconnect cycles don't cause us to lose the
-    // framebuffer.
-    display_shutdown(DCP_SLEEP_IF_EXTERNAL);
     fb_init(false);
     fb_display_logo();
 #ifdef FB_SILENT_MODE
@@ -167,7 +166,6 @@ void m1n1_main(void)
     nvme_shutdown();
     exception_shutdown();
     usb_iodev_shutdown();
-    display_shutdown(DCP_SLEEP_IF_EXTERNAL);
 #ifdef USE_FB
     fb_shutdown(next_stage.restore_logo);
 #endif


### PR DESCRIPTION
 * Improve parsing of display options so they work without specifying a resolution (i. e. `display=retina` works).
 * Fix handling of framebuffer reset when switching between non-retina and retina modes without changing resolution.
 * Change display init/config code to only initialize external displays, and only configure them once.