### PR TITLE
AFK: limit number of tries in start_interface

### DIFF
--- a/src/afk.c
+++ b/src/afk.c
@@ -483,11 +483,11 @@ int afk_epic_shutdown(afk_epic_ep_t *epic)
 
 int afk_epic_start_interface(afk_epic_ep_t *epic, char *name, size_t txsize, size_t rxsize)
 {
-    int channel;
+    int channel = -1;
     struct afk_qe *msg;
     struct epic_announce *announce;
 
-    while (true) {
+    for (int tries = 0; tries < 20; tries += 1) {
 
         int ret = afk_epic_rx(epic, &msg);
         if (ret < 0)
@@ -515,10 +515,14 @@ int afk_epic_start_interface(afk_epic_ep_t *epic, char *name, size_t txsize, siz
             continue;
         }
 
+        channel = msg->channel;
         break;
     }
 
-    channel = msg->channel;
+    if (channel == -1) {
+        printf("EPIC: too many unexpected messages, giving up\n");
+        return -1;
+    }
 
     if (!rtkit_alloc_buffer(epic->rtk, &epic->rxbuf, rxsize)) {
         printf("EPIC: failed to allocate rx buffer\n");


### PR DESCRIPTION
The previous code loops infinitely when m1n1 is installed on a macOS 13 stub, with the message:
```
EPIC: got unexpected message 00:0032 during iface start
```
This patch doesn’t fix the underlying problem but allows m1n1 to successfully start.