### PR TITLE
utils: Add 'sev' in spin_unlock()

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -168,8 +168,11 @@ void spin_unlock(spinlock_t *lock)
     s64 me = smp_id();
     assert(__atomic_load_n(&lock->lock, __ATOMIC_RELAXED) == me);
     assert(lock->count > 0);
-    if (!--lock->count)
+    if (!--lock->count) {
         __atomic_store_n(&lock->lock, -1L, __ATOMIC_RELEASE);
+        // the store doesn't trigger an event from the global monitor with the MMU disabled
+        sysop("sev");
+    }
 }
 
 bool is_heap(void *addr)


### PR DESCRIPTION
Using the global monitor to generate an event on unlock of a spinlock
does not work with the MMU disabled. This fixes a regression from
9c795fbdbf445d144d331ff2a19a0f42fe0fc190 and an incomplete fix from
816388325262e5c7dd681c8ac6392248b6ca9f0e.

Bisected and fix confirmed by Sven.

Signed-off-by: Janne Grunau <j@jannau.net>