### PR TITLE
add raw binary support to HV scripts

### DIFF
--- a/proxyclient/tools/run_guest.py
+++ b/proxyclient/tools/run_guest.py
@@ -14,6 +14,7 @@ parser.add_argument('-e', '--hook-exceptions', action="store_true")
 parser.add_argument('-d', '--debug-xnu', action="store_true")
 parser.add_argument('-l', '--logfile', type=pathlib.Path)
 parser.add_argument('-C', '--cpus', default=None)
+parser.add_argument('-r', '--raw', action="store_true")
 parser.add_argument('payload', type=pathlib.Path)
 parser.add_argument('boot_args', default=[], nargs="*")
 args = parser.parse_args()
@@ -61,7 +62,10 @@ if len(args.boot_args) > 0:
 symfile = None
 if args.symbols:
     symfile = args.symbols.open("rb")
-hv.load_macho(args.payload.open("rb"), symfile=symfile)
+if args.raw:
+    hv.load_raw(args.payload.read_bytes())
+else:
+    hv.load_macho(args.payload.open("rb"), symfile=symfile)
 
 PMU(u).reset_panic_counter()
 


### PR DESCRIPTION
Hello!

Had to repost because the last pull request had issues, also cleaned up some code

As part of my efforts to boot Windows on Apple silicon Macs successfully, part of that meant adding raw binary support to the hypervisor scripts (This is to allow raw binary UEFI images to be executed directly using the run_guest.py script instead of being forced to wrap them in Mach-O headers or concatenate them to a Mach-O wrapped m1n1 payload, allowing for quicker build and test cycles)

I wanted to contribute this change back to mainline m1n1 as I feel that it'd be a really nice to have addition to the hypervisor so that everyone can benefit from being able to directly load raw binaries using the run_guest script.

Most of the code from the load_macho logic ended up working perfectly for the load_raw logic, albeit with some minor changes to account for lack of a Mach-O header and whatnot, so this was a fairly minor change albeit one that I felt would be really beneficial both in my work and in the community's hopefully. I did move out all the common code between Mach-O and raw binary code into a load_common method and have both load_macho and load_raw call that, this ended up working perfectly and helped reduce redundant code

Tested on an m1n1 payload, both raw and Mach-O wrapped, as well as a macOS kernelcache.

This is my first "official" contribution to the project, hopefully it helps the project!

Signed-off-by: amarioguy <arminders208@outlook.com>