### PR TITLE
Fix typos

### DIFF
--- a/proxyclient/m1n1/fw/agx/cmdqueue.py
+++ b/proxyclient/m1n1/fw/agx/cmdqueue.py
@@ -48,7 +48,7 @@ class WorkCommandInitBM(ConstructClass):
 
 class WorkCommandComputeUnk10(ConstructClass):
     """
-        occassionally sent before WorkCommandCP on the SubmitCP queue.
+        occasionally sent before WorkCommandCP on the SubmitCP queue.
     """
     subcon = Struct(
         "magic" / Const(0xa, Hex(Int32ul)),
@@ -57,7 +57,7 @@ class WorkCommandComputeUnk10(ConstructClass):
 
 class WorkCommandComputeUnk11(ConstructClass):
     """
-        occassionally sent before WorkCommandCP on the SubmitCP queue.
+        occasionally sent before WorkCommandCP on the SubmitCP queue.
     """
     subcon = Struct(
         "magic" / Const(0xb, Hex(Int32ul)),

--- a/proxyclient/m1n1/fw/agx/microsequence.py
+++ b/proxyclient/m1n1/fw/agx/microsequence.py
@@ -914,7 +914,7 @@ class TimestampCmd(ConstructClass):
         "unk_1" / Int8ul,
         "unk_2" / Int8ul,
         "unk_3" / Int8ul, # Sometimes 0x80
-        # all these pointers point to 0xfa0... addresses. Might be where the timestamp should be writen?
+        # all these pointers point to 0xfa0... addresses. Might be where the timestamp should be written?
         "ts0_addr" / Int64ul,
         "ts0" / ROPointer(this.ts0_addr, TimeStamp),
         "ts_pointers_addr" / Int64ul,

--- a/proxyclient/m1n1/fw/dcp/manager.py
+++ b/proxyclient/m1n1/fw/dcp/manager.py
@@ -122,7 +122,7 @@ class DCPManager(DCPBaseManager):
     def enable_backlight_message_ap_gated(self, unkB):
         print(f"enable_backlight_message_ap_gated({unkB})")
 
-    # wrapper for set_digital_out_mode to print information on the setted modes
+    # wrapper for set_digital_out_mode to print information on the set modes
     def SetDigitalOutMode(self, color_id, timing_id):
         color_mode = [x for x in self.dcpav_prop['ColorElements'] if x['ID'] == color_id][0]
         timing_mode = [x for x in self.dcpav_prop['TimingElements'] if x['ID'] == timing_id][0]

--- a/proxyclient/m1n1/hw/aes.py
+++ b/proxyclient/m1n1/hw/aes.py
@@ -90,7 +90,7 @@ class AESControlReg(Register32):
     START = 0, 0
     STOP = 1, 1
     CLEAR_FIFO = 2, 2
-    # TOOD: not convinced about RESET anymore, I remember this un-broke the engine once but I can't reproduce that anymore
+    # TODO: not convinced about RESET anymore, I remember this un-broke the engine once but I can't reproduce that anymore
     RESET = 3, 3
 
 

--- a/proxyclient/m1n1/hw/ane.py
+++ b/proxyclient/m1n1/hw/ane.py
@@ -146,7 +146,7 @@ class ANETaskManager:
 
 		# transfer to main queue (now in in TM range)
 		self.regs.REQ_ADDR.val = self.tq.REQ_ADDR1[qid].val
-		# doesnt go through if 0
+		# doesn't go through if 0
 		self.regs.REQ_INFO.val = self.tq.REQ_SIZE1[qid].val | req.td_count
 		# let's do magic
 		self.regs.REQ_PUSH.val = self.tq_prty[qid] | (qid & 7) << 8

--- a/proxyclient/m1n1/hw/i2c.py
+++ b/proxyclient/m1n1/hw/i2c.py
@@ -65,7 +65,7 @@ class R_SMSTA(Register32):
     XIP     = 28            # Xaction in progress
     XEN     = 27            # Xaction ended
     UJF     = 26            # UnJam failure
-    JMD     = 25            # Jam ocurred
+    JMD     = 25            # Jam occurred
     JAM     = 24            # Currently jammed
     MTO     = 23            # Master timeout
     MTA     = 22            # Master arb lost

--- a/proxyclient/m1n1/proxy.py
+++ b/proxyclient/m1n1/proxy.py
@@ -471,7 +471,7 @@ REGION_RW_EL0 = 0xa0000000000
 REGION_RX_EL1 = 0xc0000000000
 
 # Uses UartInterface.proxyreq() to send requests to M1N1 and process
-# reponses sent back.
+# responses sent back.
 class M1N1Proxy(Reloadable):
     S_OK = 0
     S_BADCMD = -1

--- a/src/chickens.c
+++ b/src/chickens.c
@@ -51,7 +51,7 @@ const char *init_cpu(void)
     printf("  CPU part: 0x%x rev: 0x%x\n", part, rev);
 
     if (part >= MIDR_PART_T8015_MONSOON) {
-        /* Enable NEX powergating, the reset cycles might be overriden by chickens */
+        /* Enable NEX powergating, the reset cycles might be overridden by chickens */
         if (!is_ecore()) {
             reg_mask(SYS_IMP_APL_HID13, HID13_RESET_CYCLES_MASK, HID13_RESET_CYCLES(12));
             reg_set(SYS_IMP_APL_HID14, HID14_ENABLE_NEX_POWER_GATING);

--- a/src/dlmalloc/malloc.c
+++ b/src/dlmalloc/malloc.c
@@ -1680,7 +1680,7 @@ static FORCEINLINE void* win32direct_mmap(size_t size) {
   return (ptr != 0)? ptr: MFAIL;
 }
 
-/* This function supports releasing coalesed segments */
+/* This function supports releasing coalesced segments */
 static FORCEINLINE int win32munmap(void* ptr, size_t size) {
   MEMORY_BASIC_INFORMATION minfo;
   char* cptr = (char*)ptr;
@@ -1768,7 +1768,7 @@ static FORCEINLINE int win32munmap(void* ptr, size_t size) {
     #define CALL_MREMAP(addr, osz, nsz, mv)     MFAIL
 #endif /* HAVE_MMAP && HAVE_MREMAP */
 
-/* mstate bit set if continguous morecore disabled or failed */
+/* mstate bit set if contiguous morecore disabled or failed */
 #define USE_NONCONTIGUOUS_BIT (4U)
 
 /* segment bit set in create_mspace_with_base */
@@ -4682,7 +4682,7 @@ void* dlmalloc(size_t bytes) {
 
 void dlfree(void* mem) {
   /*
-     Consolidate freed chunks with preceeding or succeeding bordering
+     Consolidate freed chunks with preceding or succeeding bordering
      free chunks, if they exist, and then place in a bin.  Intermixed
      with special cases for top, dv, mmapped chunks, and usage errors.
   */
@@ -6216,10 +6216,10 @@ History:
         Wolfram Gloger (Gloger@lrz.uni-muenchen.de).
       * Use last_remainder in more cases.
       * Pack bins using idea from  colin@nyx10.cs.du.edu
-      * Use ordered bins instead of best-fit threshhold
+      * Use ordered bins instead of best-fit threshold
       * Eliminate block-local decls to simplify tracing and debugging.
       * Support another case of realloc via move into top
-      * Fix error occuring when initial sbrk_base not word-aligned.
+      * Fix error occurring when initial sbrk_base not word-aligned.
       * Rely on page size for units instead of SBRK_UNIT to
         avoid surprises about sbrk alignment conventions.
       * Add mallinfo, mallopt. Thanks to Raymond Nijssen

--- a/src/kboot.c
+++ b/src/kboot.c
@@ -1818,7 +1818,7 @@ static int dt_set_display(void)
     dart_lock_adt("/arm-io/dart-disp0", 0);
 
     /* Add "/reserved-memory" nodes with iommu mapping and link them to their
-     * devices. The memory is already excluded from useable RAM so these nodes
+     * devices. The memory is already excluded from usable RAM so these nodes
      * are only required to inform the OS about the existing mappings.
      * Required for disp0, dcp and all dcpext.
      * Checks for dcp* / disp*_piodma / disp* aliases and fails silently if
@@ -2525,7 +2525,7 @@ int kboot_prepare_dt(void *fdt)
     if (fdt_add_mem_rsv(dt, (u64)_base, ((u64)_end) - ((u64)_base)))
         bail("FDT: couldn't add reservation for m1n1\n");
 
-    /* setup console log buffer early to cpature as much log as possible */
+    /* setup console log buffer early to capture as much log as possible */
     dt_setup_mtd_phram();
 
     if (dt_set_chosen())

--- a/src/libfdt/libfdt.h
+++ b/src/libfdt/libfdt.h
@@ -711,7 +711,7 @@ static inline struct fdt_property *fdt_get_property_w(void *fdt, int nodeoffset,
  * to within the device blob itself, not a copy of the value).  If
  * lenp is non-NULL, the length of the property value is also
  * returned, in the integer pointed to by lenp.  If namep is non-NULL,
- * the property's namne will also be returned in the char * pointed to
+ * the property's name will also be returned in the char * pointed to
  * by namep (this will be a pointer to within the device tree's string
  * block, not a new copy of the name).
  *

--- a/src/minilzlib/rangedec.c
+++ b/src/minilzlib/rangedec.c
@@ -18,7 +18,7 @@ Abstract:
     50%. Probabilities are stored using 11-bits (2048 \=\= 100%), and thus use 16
     bits of storage. Finally, the range decoder is adaptive, meaning that each
     time a bit is decoded, the probabilities are updated: each 0 increases the
-    probability of another 0, and each 1 decrases it. The algorithm adapts the
+    probability of another 0, and each 1 decreases it. The algorithm adapts the
     probabilities using an exponential moving average with a shift ratio of 5.
 
 Author:

--- a/src/sio.c
+++ b/src/sio.c
@@ -105,7 +105,7 @@ struct copy_rule copy_rules[] = {
         .fw_param = PARAM_PANIC_BUFFER,
     },
     {
-        // peformance endpoint? FIFO?
+        // performance endpoint? FIFO?
         .blobsize = 0x4000,
         .fw_param = PARAM_UNK_030d,
     },


### PR DESCRIPTION
Found via `codespell -q 3 -S ./rust,./artwork -L ans,ba,blong,busses,clen,crate,inout,ro,sart,ser,statics`