### PR TITLE
hv_exc: Add s3_7_c15_c3_1 sysreg passthroughs for t8112/macos 12.4

### DIFF
--- a/src/hv_exc.c
+++ b/src/hv_exc.c
@@ -206,6 +206,7 @@ static bool hv_handle_msr(struct exc_info *ctx, u64 iss)
     switch (reg) {
         /* Some kind of timer */
         SYSREG_PASS(sys_reg(3, 7, 15, 1, 1));
+        SYSREG_PASS(sys_reg(3, 7, 15, 3, 1));
         /* Spammy stuff seen on t600x p-cores */
         SYSREG_PASS(sys_reg(3, 2, 15, 12, 0));
         SYSREG_PASS(sys_reg(3, 2, 15, 13, 0));


### PR DESCRIPTION
Boot panics due to what appears a timeout without ignoring this sys_reg
in m1n1.

Signed-off-by: Janne Grunau <j@jannau.net>