### PR TITLE
Fix bug preventing XNU symbols from working

### DIFF
--- a/proxyclient/m1n1/hv/__init__.py
+++ b/proxyclient/m1n1/hv/__init__.py
@@ -1526,7 +1526,7 @@ class HV(Reloadable):
         self.p.hv_set_time_stealing(False)
 
 
-    def load_raw(self, image, entryoffset=0x800):
+    def load_raw(self, image, entryoffset=0x800, use_xnu_symbols=False, vmin=0):
         sepfw_start, sepfw_length = self.u.adt["chosen"]["memory-map"].SEPFW
         tc_start, tc_size = self.u.adt["chosen"]["memory-map"].TrustCache
         if hasattr(self.u.adt["chosen"]["memory-map"], "preoslog"):
@@ -1598,6 +1598,9 @@ class HV(Reloadable):
         self.tba.devtree = self.adt_base - phys_base + self.tba.virt_base
         self.tba.top_of_kernel_data = guest_base + image_size
 
+        if use_xnu_symbols == True:
+            self.sym_offset = vmin - guest_base + self.tba.phys_base - self.tba.virt_base
+
         self.iface.writemem(guest_base + self.bootargs_off, BootArgs.build(self.tba))
 
         print("Setting secondary CPU RVBARs...")
@@ -1653,7 +1656,7 @@ class HV(Reloadable):
 
         #image = macho.prepare_image(load_hook)
         image = macho.prepare_image()
-        self.load_raw(image, entryoffset=(macho.entry - macho.vmin))
+        self.load_raw(image, entryoffset=(macho.entry - macho.vmin), use_xnu_symbols=self.xnu_mode, vmin=macho.vmin)
 
 
     def update_pac_mask(self):


### PR DESCRIPTION
Hello,

As @svenpeter42 indicated to me recently, my initial patch enabling raw binaries to be loaded inside the m1n1 hypervisor (original pull request #225) had a bug/omission in it which caused XNU symbols to no longer work properly as sym_offset was defaulting to 0.

This pull request fixes that issue/errata and XNU symbols should work properly now as they did prior to #225, and all raw binary loading functionality should also work as it does in #225.

Technical details:
The fix did require me to add two parameters to load_raw, use_xnu_symbols (whose value comes from self.xnu_mode, defaults to False in the raw binary case and the case where symbols are not loaded with XNU kernels, it's only true if symbols are specified with an XNU kernel), and vmin (only used if use_xnu_symbols is true, defaults to 0 in the raw binary case), but both these values have no effect in the raw binary case so functionality should be exactly the same apart from the XNU symbol bug fix.

Tested with a 12.5 (development and kasan) kernel and 13.0 development kernel with their respective symbols on an M2 MacBook Air.

Signed-off-by: amarioguy (Arminder Singh) <arminders208@outlook.com>