### PR TITLE
m1n1.proxy: increase p.call max args to 5 to match proxy.c

### DIFF
--- a/proxyclient/m1n1/proxy.py
+++ b/proxyclient/m1n1/proxy.py
@@ -678,7 +678,7 @@ class M1N1Proxy(Reloadable):
     def exit(self, retval=0):
         self.request(self.P_EXIT, retval)
     def call(self, addr, *args, reboot=False):
-        if len(args) > 4:
+        if len(args) > 5:
             raise ValueError("Too many arguments")
         return self.request(self.P_CALL, addr, *args, reboot=reboot)
     def reload(self, addr, *args, el1=False):


### PR DESCRIPTION
Commit 6a1a9bfc3c942e33142754f323078fd838c72def raised the limit in proxy.c but not in the Python code.