### PR TITLE
preserve iommu mappings for DCP/disp0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ OBJECTS := \
 	dart.o \
 	dcp.o \
 	dcp_iboot.o \
+	devicetree.o \
 	display.o \
 	exception.o exception_asm.o \
 	fb.o font.o font_retina.o \

--- a/src/dart.c
+++ b/src/dart.c
@@ -559,10 +559,10 @@ u64 dart_search(dart_dev_t *dart, void *paddr)
         }
     }
 
-    return 0;
+    return DART_PTR_ERR;
 }
 
-s64 dart_find_iova(dart_dev_t *dart, s64 start, size_t len)
+u64 dart_find_iova(dart_dev_t *dart, s64 start, size_t len)
 {
     if (len % SZ_16K)
         return -1;
@@ -588,7 +588,7 @@ s64 dart_find_iova(dart_dev_t *dart, s64 start, size_t len)
             iova += SZ_16K;
     }
 
-    return -1;
+    return DART_PTR_ERR;
 }
 
 void dart_shutdown(dart_dev_t *dart)

--- a/src/dart.h
+++ b/src/dart.h
@@ -5,6 +5,9 @@
 
 #include "types.h"
 
+#define DART_PTR_ERR     BIT(63)
+#define DART_IS_ERR(val) FIELD_GET(DART_PTR_ERR, val)
+
 typedef struct dart_dev dart_dev_t;
 
 enum dart_type_t {
@@ -21,7 +24,7 @@ void dart_unmap(dart_dev_t *dart, uintptr_t iova, size_t len);
 void dart_free_l2(dart_dev_t *dart, uintptr_t iova);
 void *dart_translate(dart_dev_t *dart, uintptr_t iova);
 u64 dart_search(dart_dev_t *dart, void *paddr);
-s64 dart_find_iova(dart_dev_t *dart, s64 start, size_t len);
+u64 dart_find_iova(dart_dev_t *dart, s64 start, size_t len);
 void dart_shutdown(dart_dev_t *dart);
 
 #endif

--- a/src/dart.h
+++ b/src/dart.h
@@ -18,6 +18,7 @@ enum dart_type_t {
 
 dart_dev_t *dart_init(uintptr_t base, u8 device, bool keep_pts, enum dart_type_t type);
 dart_dev_t *dart_init_adt(const char *path, int instance, int device, bool keep_pts);
+dart_dev_t *dart_init_fdt(void *dt, u32 phandle, int device, bool keep_pts);
 int dart_setup_pt_region(dart_dev_t *dart, const char *path, int device);
 int dart_map(dart_dev_t *dart, uintptr_t iova, void *bfr, size_t len);
 void dart_unmap(dart_dev_t *dart, uintptr_t iova, size_t len);

--- a/src/dart.h
+++ b/src/dart.h
@@ -18,6 +18,7 @@ enum dart_type_t {
 
 dart_dev_t *dart_init(uintptr_t base, u8 device, bool keep_pts, enum dart_type_t type);
 dart_dev_t *dart_init_adt(const char *path, int instance, int device, bool keep_pts);
+void dart_lock_adt(const char *path, int instance);
 dart_dev_t *dart_init_fdt(void *dt, u32 phandle, int device, bool keep_pts);
 int dart_setup_pt_region(dart_dev_t *dart, const char *path, int device);
 int dart_map(dart_dev_t *dart, uintptr_t iova, void *bfr, size_t len);

--- a/src/devicetree.c
+++ b/src/devicetree.c
@@ -1,0 +1,69 @@
+/* SPDX-License-Identifier: MIT */
+
+#include "devicetree.h"
+
+#include "libfdt/libfdt.h"
+
+void dt_parse_ranges(void *dt, int node, struct dt_ranges_tbl *ranges)
+{
+    int len;
+    const struct fdt_property *ranges_prop = fdt_get_property(dt, node, "ranges", &len);
+    if (ranges_prop && len > 0) {
+        int idx = 0;
+        int num_entries = len / sizeof(fdt64_t);
+        if (num_entries > DT_MAX_RANGES)
+            num_entries = DT_MAX_RANGES;
+
+        const fdt64_t *entry = (const fdt64_t *)ranges_prop->data;
+        for (int i = 0; i < num_entries; ++i) {
+            u64 start = fdt64_ld(entry++);
+            u64 parent = fdt64_ld(entry++);
+            u64 size = fdt64_ld(entry++);
+            if (size) {
+                ranges[idx].start = start;
+                ranges[idx].parent = parent;
+                ranges[idx].size = size;
+                idx++;
+            }
+        }
+    }
+}
+
+u64 dt_translate(struct dt_ranges_tbl *ranges, const fdt64_t *reg)
+{
+    u64 addr = fdt64_ld(reg);
+    for (int idx = 0; idx < DT_MAX_RANGES; ++idx) {
+        if (ranges[idx].size == 0)
+            break;
+        if (addr >= ranges[idx].start && addr < ranges[idx].start + ranges[idx].size)
+            return ranges[idx].parent - ranges[idx].start + addr;
+    }
+
+    return addr;
+}
+
+u64 dt_get_address(void *dt, int node)
+{
+    int parent = fdt_parent_offset(dt, node);
+
+    // find parent with "ranges" property
+    while (parent >= 0) {
+        if (fdt_getprop(dt, parent, "ranges", NULL))
+            break;
+
+        parent = fdt_parent_offset(dt, parent);
+    }
+
+    if (parent < 0)
+        return 0;
+
+    // parse ranges for address translation
+    struct dt_ranges_tbl ranges[DT_MAX_RANGES] = {0};
+    dt_parse_ranges(dt, parent, ranges);
+
+    const fdt64_t *reg = fdt_getprop(dt, node, "reg", NULL);
+    if (!reg)
+        return 0;
+
+    return dt_translate(ranges, reg);
+}

--- a/src/devicetree.h
+++ b/src/devicetree.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: MIT */
+
+#ifndef DEVICETREE_H
+#define DEVICETREE_H
+
+#include "types.h"
+
+#include "libfdt/libfdt.h"
+
+#define DT_MAX_RANGES 8
+
+struct dt_ranges_tbl {
+    u64 start;
+    u64 parent;
+    u64 size;
+};
+
+void dt_parse_ranges(void *dt, int node, struct dt_ranges_tbl *ranges);
+u64 dt_translate(struct dt_ranges_tbl *ranges, const fdt64_t *reg);
+u64 dt_get_address(void *dt, int node);
+
+#endif

--- a/src/kboot.c
+++ b/src/kboot.c
@@ -4,6 +4,7 @@
 #include "adt.h"
 #include "assert.h"
 #include "dapf.h"
+#include "devicetree.h"
 #include "exception.h"
 #include "malloc.h"
 #include "memory.h"
@@ -870,52 +871,6 @@ static int dt_set_atc_tunables(void)
     return 0;
 }
 
-#define MAX_RANGES 8
-
-struct ranges_tbl {
-    u64 start;
-    u64 parent;
-    u64 size;
-};
-
-static void parse_ranges(int soc, struct ranges_tbl *ranges)
-{
-    int len;
-    const struct fdt_property *ranges_prop = fdt_get_property(dt, soc, "ranges", &len);
-    if (ranges_prop && len > 0) {
-        int idx = 0;
-        int num_entries = len / sizeof(fdt64_t);
-        if (num_entries > MAX_RANGES)
-            num_entries = MAX_RANGES;
-
-        const fdt64_t *entry = (const fdt64_t *)ranges_prop->data;
-        for (int i = 0; i < num_entries; ++i) {
-            u64 start = fdt64_ld(entry++);
-            u64 parent = fdt64_ld(entry++);
-            u64 size = fdt64_ld(entry++);
-            if (size) {
-                ranges[idx].start = start;
-                ranges[idx].parent = parent;
-                ranges[idx].size = size;
-                idx++;
-            }
-        }
-    }
-}
-
-static u64 translate(struct ranges_tbl *ranges, const fdt64_t *reg)
-{
-    u64 addr = fdt64_ld(reg);
-    for (int idx = 0; idx < MAX_RANGES; ++idx) {
-        if (ranges[idx].size == 0)
-            break;
-        if (addr >= ranges[idx].start && addr < ranges[idx].start + ranges[idx].size)
-            return ranges[idx].parent - ranges[idx].start + addr;
-    }
-
-    return addr;
-}
-
 static int dt_disable_missing_devs(const char *adt_prefix, const char *dt_prefix, int max_devs)
 {
     int ret = -1;
@@ -979,8 +934,8 @@ static int dt_disable_missing_devs(const char *adt_prefix, const char *dt_prefix
             bail("FDT: %s node not found in devtree\n", path);
 
         // parse ranges for address translation
-        struct ranges_tbl ranges[MAX_RANGES] = {0};
-        parse_ranges(soc, ranges);
+        struct dt_ranges_tbl ranges[DT_MAX_RANGES] = {0};
+        dt_parse_ranges(dt, soc, ranges);
 
         /* Disable primary devices */
         fdt_for_each_subnode(node, dt, soc)
@@ -993,7 +948,7 @@ static int dt_disable_missing_devs(const char *adt_prefix, const char *dt_prefix
             if (!reg)
                 bail_cleanup("FDT: failed to get reg property of %s\n", name);
 
-            u64 addr = translate(ranges, reg);
+            u64 addr = dt_translate(ranges, reg);
 
             int i;
             for (i = 0; i < acnt; i++)

--- a/src/kboot.c
+++ b/src/kboot.c
@@ -1124,6 +1124,11 @@ static struct disp_mapping disp_reserved_regions_t8103[] = {
     {"region-id-95", "region95", true, false, true},
 };
 
+static struct disp_mapping dcpext_reserved_regions_t8103[] = {
+    {"region-id-73", "dcpext_data", true, false, false},
+    {"region-id-74", "region74", true, false, false},
+};
+
 static struct disp_mapping disp_reserved_regions_t600x[] = {
     {"region-id-50", "dcp_data", true, false, false},
     {"region-id-57", "region57", true, false, false},
@@ -1134,6 +1139,43 @@ static struct disp_mapping disp_reserved_regions_t600x[] = {
     {"region-id-95", "region95", true, false, true},
     // used on M1 Pro/Max/Ultra, mapped to dcp and disp0
     {"region-id-157", "region157", true, true, false},
+};
+
+#define MAX_DCPEXT 8
+
+static struct disp_mapping dcpext_reserved_regions_t600x[MAX_DCPEXT][2] = {
+    {
+        {"region-id-73", "dcpext0_data", true, false, false},
+        {"region-id-74", "", true, false, false},
+    },
+    {
+        {"region-id-88", "dcpext1_data", true, false, false},
+        {"region-id-89", "region89", true, false, false},
+    },
+    {
+        {"region-id-111", "dcpext2_data", true, false, false},
+        {"region-id-112", "region112", true, false, false},
+    },
+    {
+        {"region-id-119", "dcpext3_data", true, false, false},
+        {"region-id-120", "region120", true, false, false},
+    },
+    {
+        {"region-id-127", "dcpext4_data", true, false, false},
+        {"region-id-128", "region128", true, false, false},
+    },
+    {
+        {"region-id-135", "dcpext5_data", true, false, false},
+        {"region-id-136", "region136", true, false, false},
+    },
+    {
+        {"region-id-143", "dcpext6_data", true, false, false},
+        {"region-id-144", "region144", true, false, false},
+    },
+    {
+        {"region-id-151", "dcpext7_data", true, false, false},
+        {"region-id-152", "region152", true, false, false},
+    },
 };
 
 #define ARRAY_SIZE(s) (sizeof(s) / sizeof((s)[0]))
@@ -1151,17 +1193,33 @@ static int dt_set_display(void)
      * they are missing. */
 
     int ret = 0;
-    if (!fdt_node_check_compatible(dt, 0, "apple,t8103"))
+    if (!fdt_node_check_compatible(dt, 0, "apple,t8103")) {
         ret = dt_carveout_reserved_regions("dcp", "disp0", "disp0_piodma",
                                            disp_reserved_regions_t8103,
                                            ARRAY_SIZE(disp_reserved_regions_t8103));
-    else if (!fdt_node_check_compatible(dt, 0, "apple,t6000") ||
-             !fdt_node_check_compatible(dt, 0, "apple,t6001") ||
-             !fdt_node_check_compatible(dt, 0, "apple,t6002"))
+        if (ret)
+            return ret;
+
+        ret = dt_carveout_reserved_regions("dcpext", NULL, NULL, dcpext_reserved_regions_t8103,
+                                           ARRAY_SIZE(dcpext_reserved_regions_t8103));
+    } else if (!fdt_node_check_compatible(dt, 0, "apple,t6000") ||
+               !fdt_node_check_compatible(dt, 0, "apple,t6001") ||
+               !fdt_node_check_compatible(dt, 0, "apple,t6002")) {
         ret = dt_carveout_reserved_regions("dcp", "disp0", "disp0_piodma",
                                            disp_reserved_regions_t600x,
                                            ARRAY_SIZE(disp_reserved_regions_t600x));
-    else {
+        if (ret)
+            return ret;
+
+        for (int n = 0; n < MAX_DCPEXT && ret == 0; n++) {
+            char dcpext_alias[16];
+
+            snprintf(dcpext_alias, sizeof(dcpext_alias), "dcpext%d", n);
+            ret = dt_carveout_reserved_regions(dcpext_alias, NULL, NULL,
+                                               dcpext_reserved_regions_t600x[n],
+                                               ARRAY_SIZE(dcpext_reserved_regions_t600x[n]));
+        }
+    } else {
         printf("DT: unknown compatible, skip display reserved-memory setup\n");
         return 0;
     }

--- a/src/kboot.c
+++ b/src/kboot.c
@@ -871,6 +871,14 @@ static int dt_set_atc_tunables(void)
     return 0;
 }
 
+static int dt_set_display(void)
+{
+    /* lock dart-disp0 to prevent old software from resetting it */
+    dart_lock_adt("/arm-io/dart-disp0", 0);
+
+    return 0;
+}
+
 static int dt_disable_missing_devs(const char *adt_prefix, const char *dt_prefix, int max_devs)
 {
     int ret = -1;
@@ -1096,6 +1104,8 @@ int kboot_prepare_dt(void *fdt)
     if (dt_set_uboot())
         return -1;
     if (dt_set_atc_tunables())
+        return -1;
+    if (dt_set_display())
         return -1;
     if (dt_disable_missing_devs("usb-drd", "usb@", 8))
         return -1;

--- a/src/kboot.c
+++ b/src/kboot.c
@@ -24,6 +24,8 @@
 
 #define MAX_ATC_DEVS 8
 
+#define MAX_DISP_MAPPINGS 8
+
 static void *dt = NULL;
 static int dt_bufsize = 0;
 static void *initrd_start = NULL;
@@ -871,12 +873,300 @@ static int dt_set_atc_tunables(void)
     return 0;
 }
 
+static dart_dev_t *dt_init_dart_by_node(int node, u32 num)
+{
+    int len;
+    assert(num < 32);
+    const void *prop = fdt_getprop(dt, node, "iommus", &len);
+    if (!prop || len < 0 || (u32)len < 8 * (num + 1)) {
+        printf("FDT: unexpected 'iommus' prop / len %d\n", len);
+        return NULL;
+    }
+
+    const fdt32_t *iommus = prop;
+    u32 iommu_phandle = fdt32_ld(&iommus[num * 2]);
+    u32 iommu_stream = fdt32_ld(&iommus[num * 2 + 1]);
+
+    printf("FDT: iommu phande:%u stream:%u\n", iommu_phandle, iommu_stream);
+
+    return dart_init_fdt(dt, iommu_phandle, iommu_stream, true);
+}
+
+static u64 dart_get_mapping(dart_dev_t *dart, const char *path, u64 paddr, size_t size)
+{
+    u64 iova = dart_search(dart, (void *)paddr);
+    if (DART_IS_ERR(iova)) {
+        printf("ADT: %s paddr: 0x%lx is not mapped\n", path, paddr);
+        return iova;
+    }
+
+    u64 pend = (u64)dart_translate(dart, iova + size - 1);
+    if (pend != (paddr + size - 1)) {
+        printf("ADT: %s is not continuously mapped: 0x%lx\n", path, pend);
+        return DART_PTR_ERR;
+    }
+
+    return iova;
+}
+
+static int dt_device_set_reserved_mem(int node, dart_dev_t *dart, const char *name,
+                                      uint32_t phandle, u64 paddr, u64 size)
+{
+    int ret;
+
+    u64 iova = dart_get_mapping(dart, name, paddr, size);
+    if (DART_IS_ERR(iova))
+        bail("ADT: no mapping found for '%s' 0x%012lx iova:0x%08lx)\n", name, paddr, iova);
+
+    ret = fdt_appendprop_u32(dt, node, "iommu-addresses", phandle);
+    if (ret != 0)
+        bail("DT: could not append phandle '%s.compatible' property: %d\n", name, ret);
+
+    ret = fdt_appendprop_u64(dt, node, "iommu-addresses", iova);
+    if (ret != 0)
+        bail("DT: could not append iova to '%s.iommu-addresses' property: %d\n", name, ret);
+
+    ret = fdt_appendprop_u64(dt, node, "iommu-addresses", size);
+    if (ret != 0)
+        bail("DT: could not append size to '%s.iommu-addresses' property: %d\n", name, ret);
+
+    return 0;
+}
+
+struct disp_mapping {
+    char region_adt[24];
+    char mem_fdt[24];
+    bool map_dcp;
+    bool map_disp;
+    bool map_piodma;
+};
+
+static int dt_carveout_reserved_regions(const char *dcp_alias, const char *disp_alias,
+                                        const char *piodma_alias, struct disp_mapping *maps,
+                                        u32 num_maps)
+{
+    int ret = 0;
+    dart_dev_t *dart_dcp = NULL, *dart_disp = NULL, *dart_piodma = NULL;
+    uint32_t dcp_phandle = 0, disp_phandle = 0, piodma_phandle = 0;
+
+    struct {
+        u64 paddr;
+        u64 size;
+    } region[MAX_DISP_MAPPINGS];
+
+    assert(num_maps <= MAX_DISP_MAPPINGS);
+
+    int node = adt_path_offset(adt, "/chosen/carveout-memory-map");
+    if (node < 0)
+        bail("ADT: '/chosen/carveout-memory-map' not found\n");
+
+    /* read physical addresses of reserved memory regions */
+    /* do this up front to avoid errors after modifying the DT */
+    for (unsigned i = 0; i < num_maps; i++) {
+
+        int ret;
+        u64 phys_map[2];
+        struct disp_mapping *map = &maps[i];
+        const char *name = map->region_adt;
+
+        ret = ADT_GETPROP_ARRAY(adt, node, name, phys_map);
+        if (ret != sizeof(phys_map))
+            bail("ADT: could not get carveout memory '%s'\n", name);
+        if (!phys_map[0] || !phys_map[1])
+            bail("ADT: carveout memory '%s'\n", name);
+
+        region[i].paddr = phys_map[0];
+        region[i].size = phys_map[1];
+    }
+
+    /* Check for display device aliases, if one is missing assume it is an old DT
+     * without display nodes and return without error.
+     * Otherwise init each dart and retrieve the node's phandle.
+     */
+    if (dcp_alias) {
+        int dcp_node = fdt_path_offset(dt, dcp_alias);
+        if (dcp_node < 0) {
+            printf("DT: could not resolve '%s' alias\n", dcp_alias);
+            goto err; // cleanup
+        }
+        dart_dcp = dt_init_dart_by_node(dcp_node, 0);
+        if (!dart_dcp)
+            bail_cleanup("DT: failed to init DART for '%s'\n", dcp_alias);
+        dcp_phandle = fdt_get_phandle(dt, dcp_node);
+    }
+
+    if (disp_alias) {
+        int disp_node = fdt_path_offset(dt, disp_alias);
+        if (disp_node < 0) {
+            printf("DT: could not resolve '%s' alias\n", disp_alias);
+            goto err; // cleanup
+        }
+        dart_disp = dt_init_dart_by_node(disp_node, 0);
+        if (!dart_disp)
+            bail_cleanup("DT: failed to init DART for '%s'\n", disp_alias);
+        disp_phandle = fdt_get_phandle(dt, disp_node);
+    }
+
+    if (piodma_alias) {
+        int piodma_node = fdt_path_offset(dt, piodma_alias);
+        if (piodma_node < 0) {
+            printf("DT: could not resolve '%s' alias\n", piodma_alias);
+            goto err; // cleanup
+        }
+
+        dart_piodma = dt_init_dart_by_node(piodma_node, 0);
+        if (!dart_piodma)
+            bail_cleanup("DT: failed to init DART for '%s'\n", piodma_alias);
+        piodma_phandle = fdt_get_phandle(dt, piodma_node);
+    }
+
+    uint32_t max_phandle;
+    ret = fdt_find_max_phandle(dt, &max_phandle);
+    if (ret)
+        bail_cleanup("DT: failed to get max phandle: %d\n", ret);
+
+    for (unsigned i = 0; i < num_maps; i++) {
+        const char *name = maps[i].mem_fdt;
+        char node_name[64];
+
+        int resv_node = fdt_path_offset(dt, "/reserved-memory");
+        if (resv_node < 0)
+            bail_cleanup("DT: '/reserved-memory' not found\n");
+
+        snprintf(node_name, sizeof(node_name), "%s@%lx", name, region[i].paddr);
+        int mem_node = fdt_add_subnode(dt, resv_node, node_name);
+        if (mem_node < 0)
+            bail_cleanup("DT: failed to add '%s' /reserved-memory subnode: %d\n", node_name, ret);
+
+        uint32_t mem_phandle = ++max_phandle;
+        ret = fdt_setprop_u32(dt, mem_node, "phandle", mem_phandle);
+        if (ret != 0)
+            bail_cleanup("DT: couldn't set '%s.phandle' property: %d\n", node_name, ret);
+
+        u64 reg[2] = {cpu_to_fdt64(region[i].paddr), cpu_to_fdt64(region[i].size)};
+        ret = fdt_setprop(dt, mem_node, "reg", reg, sizeof(reg));
+        if (ret != 0)
+            bail_cleanup("DT: couldn't set '%s.reg' property: %d\n", node_name, ret);
+
+        ret = fdt_setprop_string(dt, mem_node, "compatible", "apple,dcp");
+        if (ret != 0)
+            bail_cleanup("DT: couldn't set '%s.compatible' property: %d\n", node_name, ret);
+
+        ret = fdt_setprop_empty(dt, mem_node, "no-map");
+        if (ret != 0)
+            bail_cleanup("DT: couldn't set '%s.no-map' property: %d\n", node_name, ret);
+
+        if (maps[i].map_dcp && dart_dcp) {
+            ret = dt_device_set_reserved_mem(mem_node, dart_dcp, node_name, dcp_phandle,
+                                             region[i].paddr, region[i].size);
+            if (ret != 0)
+                goto err;
+        }
+        if (maps[i].map_disp && dart_disp) {
+            ret = dt_device_set_reserved_mem(mem_node, dart_disp, node_name, disp_phandle,
+                                             region[i].paddr, region[i].size);
+            if (ret != 0)
+                goto err;
+        }
+        if (maps[i].map_piodma && dart_piodma) {
+            ret = dt_device_set_reserved_mem(mem_node, dart_piodma, node_name, piodma_phandle,
+                                             region[i].paddr, region[i].size);
+            if (ret != 0)
+                goto err;
+        }
+
+        /* modify device nodes after filling /reserved-memory to avoid
+         * reloading mem_node's offset */
+        if (maps[i].map_dcp && dcp_alias) {
+            int dev_node = fdt_path_offset(dt, dcp_alias);
+            if (dev_node < 0)
+                bail_cleanup("DT: failed to get node for alias '%s'\n", dcp_alias);
+            ret = fdt_appendprop_u32(dt, dev_node, "memory-region", mem_phandle);
+            if (ret != 0)
+                bail_cleanup("DT: failed to append to 'memory-region' property\n");
+        }
+        if (maps[i].map_disp && disp_alias) {
+            int dev_node = fdt_path_offset(dt, disp_alias);
+            if (dev_node < 0)
+                bail_cleanup("DT: failed to get node for alias '%s'\n", disp_alias);
+            ret = fdt_appendprop_u32(dt, dev_node, "memory-region", mem_phandle);
+            if (ret != 0)
+                bail_cleanup("DT: failed to append to 'memory-region' property\n");
+        }
+        if (maps[i].map_piodma && piodma_alias) {
+            int dev_node = fdt_path_offset(dt, piodma_alias);
+            if (dev_node < 0)
+                bail_cleanup("DT: failed to get node for alias '%s\n", piodma_alias);
+            ret = fdt_appendprop_u32(dt, dev_node, "memory-region", mem_phandle);
+            if (ret != 0)
+                bail_cleanup("DT: failed to append to 'memory-region' property\n");
+        }
+    }
+
+err:
+    if (dart_dcp)
+        dart_shutdown(dart_dcp);
+    if (dart_disp)
+        dart_shutdown(dart_disp);
+    if (dart_piodma)
+        dart_shutdown(dart_piodma);
+
+    return ret;
+}
+
+static struct disp_mapping disp_reserved_regions_t8103[] = {
+    {"region-id-50", "dcp_data", true, false, false},
+    {"region-id-57", "region57", true, false, false},
+    // boot framebuffer, mapped to dart-disp0 sid 0 and dart-dcp sid 0
+    {"region-id-14", "vram", true, true, false},
+    // The 2 following regions are mapped in dart-dcp sid 0 and dart-disp0 sid 0 and 4
+    {"region-id-94", "region94", true, true, false},
+    {"region-id-95", "region95", true, false, true},
+};
+
+static struct disp_mapping disp_reserved_regions_t600x[] = {
+    {"region-id-50", "dcp_data", true, false, false},
+    {"region-id-57", "region57", true, false, false},
+    // boot framebuffer, mapped to dart-disp0 sid 0 and dart-dcp sid 0
+    {"region-id-14", "vram", true, true, false},
+    // The 2 following regions are mapped in dart-dcp sid 0 and dart-disp0 sid 0 and 4
+    {"region-id-94", "region94", true, true, false},
+    {"region-id-95", "region95", true, false, true},
+    // used on M1 Pro/Max/Ultra, mapped to dcp and disp0
+    {"region-id-157", "region157", true, true, false},
+};
+
+#define ARRAY_SIZE(s) (sizeof(s) / sizeof((s)[0]))
+
 static int dt_set_display(void)
 {
     /* lock dart-disp0 to prevent old software from resetting it */
     dart_lock_adt("/arm-io/dart-disp0", 0);
 
-    return 0;
+    /* Add "/reserved-memory" nodes with iommu mapping and link them to their
+     * devices. The memory is already excluded from useable RAM so these nodes
+     * are only required to inform the OS about the existing mappings.
+     * Required for disp0, dcp and all dcpext.
+     * Checks for dcp* / disp*_piodma / disp* aliases and fails silently if
+     * they are missing. */
+
+    int ret = 0;
+    if (!fdt_node_check_compatible(dt, 0, "apple,t8103"))
+        ret = dt_carveout_reserved_regions("dcp", "disp0", "disp0_piodma",
+                                           disp_reserved_regions_t8103,
+                                           ARRAY_SIZE(disp_reserved_regions_t8103));
+    else if (!fdt_node_check_compatible(dt, 0, "apple,t6000") ||
+             !fdt_node_check_compatible(dt, 0, "apple,t6001") ||
+             !fdt_node_check_compatible(dt, 0, "apple,t6002"))
+        ret = dt_carveout_reserved_regions("dcp", "disp0", "disp0_piodma",
+                                           disp_reserved_regions_t600x,
+                                           ARRAY_SIZE(disp_reserved_regions_t600x));
+    else {
+        printf("DT: unknown compatible, skip display reserved-memory setup\n");
+        return 0;
+    }
+
+    return ret;
 }
 
 static int dt_disable_missing_devs(const char *adt_prefix, const char *dt_prefix, int max_devs)


### PR DESCRIPTION
- Add the boot iommu mappings for dcp/disp0 to the FDT based on https://lore.kernel.org/asahi/20220923123557.866972-1-thierry.reding@gmail.com
- lock dart-disp0

Matching kernel tree is https://github.com/jannau/linux/tree/asahi-dcp-september