### PR TITLE
fix(proxy): fix hv translate case

### DIFF
--- a/proxyclient/m1n1/hv/__init__.py
+++ b/proxyclient/m1n1/hv/__init__.py
@@ -111,7 +111,6 @@ class HV(Reloadable):
         self.hvcall_handlers = {}
         self.switching_context = False
         self.show_timestamps = False
-        self.trace_tlbos = False
 
     def _reloadme(self):
         super()._reloadme()
@@ -1313,8 +1312,7 @@ class HV(Reloadable):
         hcr.TVM = 0
         hcr.FMO = 1
         hcr.IMO = 0
-        if self.trace_tlbos:
-            hcr.TTLBOS = 1
+        hcr.TTLBOS = 1
         self.u.msr(HCR_EL2, hcr.value)
 
         # Trap dangerous things

--- a/proxyclient/m1n1/hv/types.py
+++ b/proxyclient/m1n1/hv/types.py
@@ -10,7 +10,9 @@ __all__ = [
 ]
 
 class MMIOTraceFlags(Register32):
+    ATTR = 31, 24
     CPU = 23, 16
+    SH = 15, 14
     WIDTH = 4, 0
     WRITE = 5
     MULTI = 6

--- a/proxyclient/tools/run_guest_kernel.sh
+++ b/proxyclient/tools/run_guest_kernel.sh
@@ -20,7 +20,9 @@ args="$2"
 initramfs=""
 shift 2
 
-if [ -n "$1" ]; then
+if [ "$1" == "--" ]; then
+	shift
+elif [ -n "$1" ]; then
     initramfs="$(realpath "$1")"
     shift
 fi

--- a/src/exception.c
+++ b/src/exception.c
@@ -186,17 +186,18 @@ void print_regs(u64 *regs, int el12)
 
     u64 elr = in_gl ? mrs(SYS_IMP_APL_ELR_GL1) : (el12 ? mrs(ELR_EL12) : mrs(ELR_EL1));
     u64 esr = in_gl ? mrs(SYS_IMP_APL_ESR_GL1) : (el12 ? mrs(ESR_EL12) : mrs(ESR_EL1));
+    u64 far = in_gl ? mrs(SYS_IMP_APL_FAR_GL1) : (el12 ? mrs(FAR_EL12) : mrs(FAR_EL1));
 
     printf("PC:       0x%lx (rel: 0x%lx)\n", elr, elr - (u64)_base);
     printf("SP:       0x%lx\n", sp);
-    printf("SPSR_EL1: 0x%lx\n", spsr);
+    printf("SPSR:     0x%lx\n", spsr);
     if (in_gl12()) {
         printf("ASPSR:    0x%lx\n", mrs(SYS_IMP_APL_ASPSR_GL1));
     }
-    printf("FAR_EL1:  0x%lx\n", el12 ? mrs(FAR_EL12) : mrs(FAR_EL1));
+    printf("FAR:      0x%lx\n", far);
 
     const char *ec_desc = ec_table[(esr >> 26) & 0x3f];
-    printf("ESR_EL1:  0x%lx (%s)\n", esr, ec_desc ? ec_desc : "?");
+    printf("ESR:      0x%lx (%s)\n", esr, ec_desc ? ec_desc : "?");
 
     u64 sts = mrs(SYS_IMP_APL_L2C_ERR_STS);
     printf("L2C_ERR_STS: 0x%lx\n", sts);

--- a/src/hv.h
+++ b/src/hv.h
@@ -10,7 +10,9 @@
 
 typedef bool(hv_hook_t)(struct exc_info *ctx, u64 addr, u64 *val, bool write, int width);
 
+#define MMIO_EVT_ATTR  GENMASK(31, 24)
 #define MMIO_EVT_CPU   GENMASK(23, 16)
+#define MMIO_EVT_SH    GENMASK(15, 14)
 #define MMIO_EVT_MULTI BIT(6)
 #define MMIO_EVT_WRITE BIT(5)
 #define MMIO_EVT_WIDTH GENMASK(4, 0)
@@ -54,7 +56,7 @@ int hv_unmap(u64 from, u64 size);
 int hv_map_hw(u64 from, u64 to, u64 size);
 int hv_map_sw(u64 from, u64 to, u64 size);
 int hv_map_hook(u64 from, hv_hook_t *hook, u64 size);
-u64 hv_translate(u64 addr, bool s1only, bool w);
+u64 hv_translate(u64 addr, bool s1only, bool w, u64 *par_out);
 u64 hv_pt_walk(u64 addr);
 bool hv_handle_dabort(struct exc_info *ctx);
 bool hv_pa_write(struct exc_info *ctx, u64 addr, u64 *val, int width);

--- a/src/hv_exc.c
+++ b/src/hv_exc.c
@@ -254,6 +254,12 @@ static bool hv_handle_msr(struct exc_info *ctx, u64 iss)
         SYSREG_PASS(SYS_IMP_APL_PMC8)
         SYSREG_PASS(SYS_IMP_APL_PMC9)
 
+        /* Outer Sharable TLB maintenance instructions */
+        SYSREG_PASS(sys_reg(1, 0, 8, 1, 0)) // TLBI VMALLE1OS
+        SYSREG_PASS(sys_reg(1, 0, 8, 1, 1)) // TLBI VAE1OS
+        SYSREG_PASS(sys_reg(1, 0, 8, 1, 2)) // TLBI ASIDE1OS
+        SYSREG_PASS(sys_reg(1, 0, 8, 5, 1)) // TLBI RVAE1OS
+
         /*
          * Handle this one here because m1n1/Linux (will) use it for explicit cpuidle.
          * We can pass it through; going into deep sleep doesn't break the HV since we

--- a/src/hv_exc.c
+++ b/src/hv_exc.c
@@ -58,9 +58,9 @@ static void _hv_exc_proxy(struct exc_info *ctx, uartproxy_boot_reason_t reason, 
 
     u64 entry_time = mrs(CNTPCT_EL0);
 
-    ctx->elr_phys = hv_translate(ctx->elr, false, false);
-    ctx->far_phys = hv_translate(ctx->far, false, false);
-    ctx->sp_phys = hv_translate(from_el == 0 ? ctx->sp[0] : ctx->sp[1], false, false);
+    ctx->elr_phys = hv_translate(ctx->elr, false, false, NULL);
+    ctx->far_phys = hv_translate(ctx->far, false, false, NULL);
+    ctx->sp_phys = hv_translate(from_el == 0 ? ctx->sp[0] : ctx->sp[1], false, false, NULL);
     ctx->extra = extra;
 
     struct uartproxy_msg_start start = {

--- a/src/kboot.c
+++ b/src/kboot.c
@@ -11,7 +11,6 @@
 #include "pmgr.h"
 #include "sep.h"
 #include "smp.h"
-#include "tunables.h"
 #include "types.h"
 #include "usb.h"
 #include "utils.h"
@@ -1160,7 +1159,6 @@ int kboot_boot(void *kernel)
     usb_init();
     pcie_init();
     dapf_init_all();
-    tunables_apply_static();
 
     printf("Setting SMP mode to WFE...\n");
     smp_set_wfe_mode(true);

--- a/src/main.c
+++ b/src/main.c
@@ -23,6 +23,7 @@
 #include "sep.h"
 #include "smp.h"
 #include "string.h"
+#include "tunables.h"
 #include "uart.h"
 #include "uartproxy.h"
 #include "usb.h"
@@ -151,6 +152,7 @@ void m1n1_main(void)
     wdt_disable();
 #ifndef BRINGUP
     pmgr_init();
+    tunables_apply_static();
 
 #ifdef USE_FB
     display_init();

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -446,7 +446,8 @@ int proxy_process(ProxyRequest *request, ProxyReply *reply)
             hv_start((void *)request->args[0], &request->args[1]);
             break;
         case P_HV_TRANSLATE:
-            reply->retval = hv_translate(request->args[0], request->args[1], request->args[2], request->args[3]);
+            reply->retval = hv_translate(request->args[0], request->args[1], request->args[2],
+             &request->args[3]);
             break;
         case P_HV_PT_WALK:
             reply->retval = hv_pt_walk(request->args[0]);

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -447,7 +447,7 @@ int proxy_process(ProxyRequest *request, ProxyReply *reply)
             break;
         case P_HV_TRANSLATE:
             reply->retval = hv_translate(request->args[0], request->args[1], request->args[2],
-             &request->args[3]);
+                    &request->args[3]);
             break;
         case P_HV_PT_WALK:
             reply->retval = hv_pt_walk(request->args[0]);

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -446,7 +446,7 @@ int proxy_process(ProxyRequest *request, ProxyReply *reply)
             hv_start((void *)request->args[0], &request->args[1]);
             break;
         case P_HV_TRANSLATE:
-            reply->retval = hv_translate(request->args[0], request->args[1], request->args[2]);
+            reply->retval = hv_translate(request->args[0], request->args[1], request->args[2], request->args[3]);
             break;
         case P_HV_PT_WALK:
             reply->retval = hv_pt_walk(request->args[0]);


### PR DESCRIPTION
The P_HV_TRANSLATE case calls hv_translate(), which requires the fourth parameter to be a pointer to a u64. This line also fails lint tests; the fourth parameter should be on a new line.

Signed-off-by: Elijah Conners <business@elijahpepe.com>