### PR TITLE
Small improvement to tethered boot support from macOS host

### DIFF
--- a/proxyclient/m1n1/proxy.py
+++ b/proxyclient/m1n1/proxy.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-import os, sys, struct, serial, time
+import platform, os, sys, struct, serial, time
 from construct import *
 from enum import IntEnum, IntFlag
 from serial.tools.miniterm import Miniterm
@@ -131,13 +131,18 @@ class UartInterface(Reloadable):
     REPLY_LEN = 36
     EVENT_HDR_LEN = 8
 
+    DEFAULT_UART_DEV="/dev/m1n1"
+    DEFAULT_BAUD_RATE=115200
+    if platform.system() == 'Darwin':
+        DEFAULT_UART_DEV="/dev/cu.usbmodemP_01"
+
     def __init__(self, device=None, debug=False):
         self.debug = debug
         self.devpath = None
         if device is None:
-            device = os.environ.get("M1N1DEVICE", "/dev/m1n1:115200")
+            device = os.environ.get("M1N1DEVICE", self.DEFAULT_UART_DEV)
         if isinstance(device, str):
-            baud = 115200
+            baud = self.DEFAULT_BAUD_RATE
             if ":" in device:
                 device, baud = device.rsplit(":", 1)
                 baud = int(baud)

--- a/proxyclient/m1n1/proxy.py
+++ b/proxyclient/m1n1/proxy.py
@@ -1094,11 +1094,11 @@ class M1N1Proxy(Reloadable):
 __all__.extend(k for k, v in globals().items()
                if (callable(v) or isinstance(v, type)) and v.__module__ == __name__)
 
+# To run m1n1/proxy.py as script, use:
+# $ cd <path to>/m1n1/proxyclient
+# $ python3 -m m1n1.proxy m1n1/proxy.py
 if __name__ == "__main__":
-    import serial
-    uartdev = os.environ.get("M1N1DEVICE", "/dev/m1n1")
-    usbuart = serial.Serial(uartdev, 115200)
-    uartif = UartInterface(usbuart, debug=True)
+    uartif = UartInterface(device=None, debug=True)
     print("Sending NOP...", end=' ')
     uartif.nop()
     print("OK")

--- a/proxyclient/tools/picocom-sec.sh
+++ b/proxyclient/tools/picocom-sec.sh
@@ -1,7 +1,23 @@
 #!/bin/sh
+#
+# Secondary UART device name exposed when m1n1 boots is /dev/m1n1-sec on
+# Linux host and /dev/cu.usbmodemP_03 on macOS host
+#
+DEFAULT_SECDEV=/dev/m1n1-sec
+PLATFORM_NAME=$(uname)
+
+case "${PLATFORM_NAME}" in
+Darwin)
+    SECDEV=/dev/cu.usbmodemP_03 ;;
+*)
+    SECDEV="$DEFAULT_SECDEV" ;;
+esac
+
+# The secondary UART device shows up when m1n1 boots on the tethered machine
+echo "Waiting for UART device file '$SECDEV' to appear (Ctrl+C to abort)..."
 
 while true; do
-    while [ ! -e /dev/m1n1-sec ]; do sleep 1; done
-    picocom --omap crlf --imap lfcrlf -b 500000 /dev/m1n1-sec
+    while [ ! -e $SECDEV ] ; do sleep 1 ; done
+    picocom --omap crlf --imap lfcrlf -b 500000 $SECDEV
     sleep 1
 done

--- a/proxyclient/tools/picocom-sec.sh
+++ b/proxyclient/tools/picocom-sec.sh
@@ -13,6 +13,11 @@ Darwin)
     SECDEV="$DEFAULT_SECDEV" ;;
 esac
 
+if [ "$M1N1DEVICE" ] ; then
+    SECDEV="$M1N1DEVICE"
+    echo "warning: overriding device name from M1N1DEVICE environment variable ($DECDEV)!"
+fi
+
 # The secondary UART device shows up when m1n1 boots on the tethered machine
 echo "Waiting for UART device file '$SECDEV' to appear (Ctrl+C to abort)..."
 


### PR DESCRIPTION
Small improvement to the out-of-the-box experience when using maOS as tethered boot host

- use `/dev/cu.usbmodemP_03` and `/dev/cu.usbmodemP_01` for `picocom-sec.sh` and `proxyclient` respectively