### PR TITLE
Panel backlight

### DIFF
--- a/proxyclient/experiments/dcp.py
+++ b/proxyclient/experiments/dcp.py
@@ -15,10 +15,14 @@ from m1n1.fw.dcp.manager import DCPManager
 from m1n1.fw.dcp.ipc import ByRef
 from m1n1.proxyutils import RegMonitor
 
-is_t8103 = u.adt["arm-io"].compatible[0] == "arm-io,t8103"
+disp_name = "/arm-io/disp0"
+
+external = hasattr(u.adt[disp_name], "external") and u.adt[disp_name].external != 0
+compat = u.adt[disp_name].compatible[0].split(",")[-1]
+
 mon = RegMonitor(u)
 
-if is_t8103:
+if compat == 't8103':
     #mon.add(0x230000000, 0x18000)
     #mon.add(0x230018000, 0x4000)
     #mon.add(0x230068000, 0x8000)
@@ -85,7 +89,7 @@ dcp.start()
 dcp.start_ep(0x37)
 dcp.dcpep.initialize()
 
-mgr = DCPManager(dcp.dcpep)
+mgr = DCPManager(dcp.dcpep, compat)
 
 mon.poll()
 
@@ -104,14 +108,14 @@ assert mgr.setPowerState(1, False, ByRef(0)) == 0
 
 mon.poll()
 
-if is_t8103:
+if external:
     assert mgr.set_display_device(2) == 0
 else:
     assert mgr.set_display_device(0) == 2
 assert mgr.set_parameter_dcp(14, [0], 1) == 0
 #mgr.set_digital_out_mode(86, 38)
 
-if is_t8103:
+if external:
     assert mgr.set_display_device(2) == 0
 else:
     assert mgr.set_display_device(0) == 2
@@ -123,7 +127,7 @@ assert mgr.get_gamma_table(t) == 2
 assert mgr.set_contrast(0) == 0
 assert mgr.setBrightnessCorrection(65536) == 0
 
-if is_t8103:
+if external:
     assert mgr.set_display_device(2) == 0
 else:
     assert mgr.set_display_device(0) == 2
@@ -277,7 +281,7 @@ swaps = mgr.swaps
 mon.poll()
 
 fb_size = align_up(width * height * 4, 8 * 0x4000)
-print(f"Dispaly {width}x{height}, fb size: {fb_size}")
+print(f"Display {width}x{height}, fb size: {fb_size}")
 
 buf = u.memalign(0x4000, fb_size)
 

--- a/proxyclient/experiments/dcp.py
+++ b/proxyclient/experiments/dcp.py
@@ -205,6 +205,9 @@ swap_rec = Container(
     dst_rect = [[0, 0, width, height],[0,0,0,0],[0,0,0,0],[0,0,0,0]],
     swap_enabled = 0x80000007,
     swap_completed = 0x80000007,
+    bl_unk = 0x1,
+    bl_val = 0x58f058d0, # ~99 nits
+    bl_power = 0x40,
 )
 
 surf = Container(

--- a/proxyclient/m1n1/fw/dcp/ipc.py
+++ b/proxyclient/m1n1/fw/dcp/ipc.py
@@ -449,7 +449,11 @@ IOMFBSwapRec = Struct(
     "unk_2c8" / Hex(Default(Int32ul, 0)),
     "unk_2cc" / UnkBytes(0x14),
     "unk_2e0" / Hex(Default(Int32ul, 0)),
-    "unk_2e4" / UnkBytes(0x3c),
+    "unk_2e2" / UnkBytes(0x2),
+    "bl_unk" / Hex(Int64ul), # seen: 0x0, 0x1, 0x101, 0x1_0000, 0x101_010101
+    "bl_val" / Hex(Int32ul), # range 0x10000000 - approximately 0x7fe07fc0 for 4 - 510 nits
+    "bl_power" / Hex(Int8ul), # constant 0x40, 0x00: backlight off
+    "unk_2f3" / UnkBytes(0x2d),
 )
 
 assert IOMFBSwapRec.sizeof() == 0x320

--- a/proxyclient/m1n1/fw/dcp/manager.py
+++ b/proxyclient/m1n1/fw/dcp/manager.py
@@ -235,6 +235,9 @@ class DCPManager(DCPBaseManager):
         print(f"mapped to dva {dva}")
         return 0
 
+    def update_backlight_factor_prop(self, unk):
+        print(f"update_backlight_factor_prop {unk}")
+
     ## ServiceRelay methods
 
     def sr_setProperty(self, obj, key, value):

--- a/proxyclient/m1n1/fw/dcp/manager.py
+++ b/proxyclient/m1n1/fw/dcp/manager.py
@@ -62,7 +62,7 @@ class DCPBaseManager:
         return functools.partial(method.call, rpc)
 
 class DCPManager(DCPBaseManager):
-    def __init__(self, dcpep):
+    def __init__(self, dcpep, compatible='t8103'):
         super().__init__(dcpep)
 
         self.iomfb_prop = {}
@@ -75,6 +75,8 @@ class DCPManager(DCPBaseManager):
 
         self.mapid = 0
         self.bufs = {}
+
+        self.compatible = compatible
 
     ## IOMobileFramebufferAP methods
 
@@ -130,11 +132,21 @@ class DCPManager(DCPBaseManager):
 
     def rt_bandwidth_setup_ap(self, config):
         print("rt_bandwidth_setup_ap(...)")
-        config.val = {
-            "reg1": 0x23b738014, # reg[5] in disp0/dispext0, plus 0x14 - part of pmgr
-            "reg2": 0x23bc3c000, # reg[6] in disp0/dispext0 - part of pmp/pmgr
-            "bit": 2,
-        }
+        if self.compatible == 't8103':
+            config.val = {
+                "reg1": 0x23b738014, # reg[5] in disp0/dispext0, plus 0x14 - part of pmgr
+                "reg2": 0x23bc3c000, # reg[6] in disp0/dispext0 - part of pmp/pmgr
+                "bit": 2,
+            }
+        elif self.compatible == 't600x':
+            config.val = {
+                "reg1": 0x28e3d0000 + 0x988, # reg[4] in disp0/dispext0, plus 0x988
+                "reg2": 0x0,
+                "bit": 0,
+            }
+        else:
+            raise ValueError(self.compatible)
+
     ## UnifiedPipeline2 methods
 
     def match_pmu_service(self):

--- a/proxyclient/m1n1/fw/dcp/manager.py
+++ b/proxyclient/m1n1/fw/dcp/manager.py
@@ -119,6 +119,9 @@ class DCPManager(DCPBaseManager):
         self.swaps += 1
         self.frame = swap_id
 
+    def enable_backlight_message_ap_gated(self, unkB):
+        print(f"enable_backlight_message_ap_gated({unkB})")
+
     # wrapper for set_digital_out_mode to print information on the setted modes
     def SetDigitalOutMode(self, color_id, timing_id):
         color_mode = [x for x in self.dcpav_prop['ColorElements'] if x['ID'] == color_id][0]
@@ -160,8 +163,14 @@ class DCPManager(DCPBaseManager):
     def match_pmu_service(self):
         pass
 
+    def set_number_property(self, key, value):
+        pass
+
     def create_provider_service(self):
         return True
+
+    def is_dark_boot(self):
+        return False
 
     def read_edt_data(self, key, count, value):
         return False
@@ -234,6 +243,9 @@ class DCPManager(DCPBaseManager):
 
     def get_calendar_time_ms(self):
         return time.time_ns() // 1000_000
+
+    def update_backlight_factor_prop(self, value):
+        pass
 
     def map_buf(self, buf, vaddr, dva, unk):
         print(f"map buf {buf}, {unk}")

--- a/proxyclient/m1n1/fw/dcp/manager.py
+++ b/proxyclient/m1n1/fw/dcp/manager.py
@@ -119,6 +119,14 @@ class DCPManager(DCPBaseManager):
         self.swaps += 1
         self.frame = swap_id
 
+    # wrapper for set_digital_out_mode to print information on the setted modes
+    def SetDigitalOutMode(self, color_id, timing_id):
+        color_mode = [x for x in self.dcpav_prop['ColorElements'] if x['ID'] == color_id][0]
+        timing_mode = [x for x in self.dcpav_prop['TimingElements'] if x['ID'] == timing_id][0]
+        pprint.pprint(color_mode)
+        pprint.pprint(timing_mode)
+        self.set_digital_out_mode(color_id, timing_id)
+
     ## UPPipeAP_H13P methods
 
     def did_boot_signal(self):
@@ -190,7 +198,7 @@ class DCPManager(DCPBaseManager):
         assert self.dcpav_prop_len == len(blob)
         self.dcpav_prop[key] = ipc.OSSerialize().parse(blob)
         self.dcpav_prop_data = self.dcpav_prop_len = self.dcpav_prop_off = None
-        pprint.pprint(self.dcpav_prop[key])
+        #pprint.pprint(self.dcpav_prop[key])
         return True
 
     def set_boolean_property(self, key, value):

--- a/proxyclient/m1n1/fw/dcp/manager.py
+++ b/proxyclient/m1n1/fw/dcp/manager.py
@@ -112,10 +112,10 @@ class DCPManager(DCPBaseManager):
         self.swaps += 1
         self.frame = swap_id
 
-    def swap_complete_intent_gated(self, frame, unkB, unkInt, width, height):
-        print(f"swap_complete_intent_gated({frame}, {unkB}, {unkInt}, {width}, {height}")
+    def swap_complete_intent_gated(self, swap_id, unkB, unkInt, width, height):
+        print(f"swap_complete_intent_gated({swap_id}, {unkB}, {unkInt}, {width}, {height}")
         self.swaps += 1
-        self.frame = frame
+        self.frame = swap_id
 
     ## UPPipeAP_H13P methods
 


### PR DESCRIPTION
Main change of this pull request is to transfer the devices maximal backlight brightness from the ADT to the devicetree. It is also sneaking in a change to enable `disp0_dart` to avoid breaking simpledrm when booting a DCP enabled devicetree with a m1n1 revision which doesn't lock it.

Adds annotations for the backlight control fields in swap_rec.

In addition there are `experiment/dcp.py` which should allow running it on every device and eventually support dcpext if everything else is set up.