### PR TITLE
Support concatenated initramfs images

### DIFF
--- a/proxyclient/tools/run_guest_kernel.sh
+++ b/proxyclient/tools/run_guest_kernel.sh
@@ -47,6 +47,14 @@ else
 fi
 
 if [ -n "$initramfs" ]; then
+    initramfs_size=$(stat --printf='%s' "$initramfs")
+    python - << EOF >>"$TMPDIR/m1n1-linux.bin"
+import os, sys
+
+magic = b'm1n1_initramfs'
+size = int(${initramfs_size}).to_bytes(4, byteorder='little')
+os.write(sys.stdout.fileno(), magic + size)
+EOF
     cat "$initramfs" >>"$TMPDIR/m1n1-linux.bin"
 fi
 

--- a/src/payload.c
+++ b/src/payload.c
@@ -24,6 +24,9 @@ static const u8 kernel_magic[] = {'A', 'R', 'M', 0x64};          // at 0x38
 static const u8 cpio_magic[] = {'0', '7', '0', '7', '0'};        // '1' or '2' next
 static const u8 img4_magic[] = {0x16, 0x04, 'I', 'M', 'G', '4'}; // IA5String 'IMG4'
 static const u8 sig_magic[] = {'m', '1', 'n', '1', '_', 's', 'i', 'g'};
+static const u8 initramfs_magic[] = {
+    'm', '1', 'n', '1', '_', 'i', 'n',
+    'i', 't', 'r', 'a', 'm', 'f', 's'}; // followed by size as little endian uint32_t
 static const u8 empty[] = {0, 0, 0, 0};
 
 static char expect_compatible[256];
@@ -214,6 +217,12 @@ static void *load_one_payload(void *start, size_t size)
 
         printf("Found a m1n1 signature at %p, skipping 0x%x bytes\n", p, size);
         return p + size;
+    } else if (!memcmp(p, initramfs_magic, sizeof(initramfs_magic))) {
+        u32 size;
+        memcpy(&size, p + sizeof(initramfs_magic), 4);
+        printf("Found a m1n1 initramfs payload at %p, 0x%x bytes\n", p, size);
+        p += sizeof(initramfs_magic) + 4;
+        return load_cpio(p, size);
     } else if (check_var(&p)) {
         return p;
     } else if (!memcmp(p, empty, sizeof empty) ||


### PR DESCRIPTION
To support modules during development with `run_guest_kernel.sh` a cpio archive with matching modules can be created with `make dir-pkg` and `usr/gen_initramfs.sh` in the kernel dir. A specially prepared initramfs can use the modules and make them available to the OS in a similar way as the vendor firmware.