### PR TITLE
Add initial PackIt config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ __pycache__
 *.swp
 *.orig
 *.rej
+/m1n1\.spec
+/m1n1-rust-deps\.patch
+/rust-fatfs-fix-build-log\.patch
+/m1n1-*\.src\.rpm
+/m1n1-*\.tar\.gz
+/rust-fatfs-*\.tar\.gz

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,43 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: m1n1.spec
+files_to_sync:
+  - m1n1.spec
+  - m1n1-rust-deps.patch
+  - rust-fatfs-fix-build-log.patch
+  - .packit.yaml
+
+actions:
+  # Fetch the specfile from Rawhide and disable rpmautospec
+  post-upstream-clone: "bash -c \"curl -s https://src.fedoraproject.org/rpms/m1n1/raw/main/f/m1n1.spec | sed -e '/^%autochangelog$/d' > m1n1.spec && curl -s -O https://src.fedoraproject.org/rpms/m1n1/raw/main/f/m1n1-rust-deps.patch -O https://src.fedoraproject.org/rpms/m1n1/raw/main/f/rust-fatfs-fix-build-log.patch\""
+
+srpm_build_deps:
+  - bash
+  - curl
+  - sed
+
+jobs:
+- job: copr_build
+  trigger: commit
+  owner: "@asahi"
+  project: packit-builds
+  targets:
+    - fedora-all-aarch64
+    - fedora-all-armhfp
+    - fedora-all-i386
+    - fedora-all-ppc64le
+    - fedora-all-s390x
+    - fedora-all-x86_64
+
+- job: copr_build
+  trigger: pull_request
+  owner: "@asahi"
+  project: packit-builds
+  targets:
+    - fedora-all-aarch64
+    - fedora-all-armhfp
+    - fedora-all-i386
+    - fedora-all-ppc64le
+    - fedora-all-s390x
+    - fedora-all-x86_64


### PR DESCRIPTION
This adds an initial config so we'll get per-commit and per-PR package builds published at https://copr.fedorainfracloud.org/coprs/g/asahi/packit-builds/ which should make testing easier and provide useful signal in case of regressions.