### PR TITLE
kboot: Add new U-Boot driver model 'phase-tags'

### DIFF
--- a/src/kboot.c
+++ b/src/kboot.c
@@ -697,6 +697,7 @@ static void dt_set_uboot_dm_preloc(int node)
 {
     // Tell U-Boot to bind this node early
     fdt_setprop_empty(dt, node, "u-boot,dm-pre-reloc");
+    fdt_setprop_empty(dt, node, "bootph-all");
 
     // Make sure the power domains are bound early as well
     int pds_size;


### PR DESCRIPTION
U-Boot is moving to a new set of tags to indicate devices that should be bound/probed in early bootstrap phases.  Add 'bootph-all' tags from the new bindings such that probing the serial port early on in U-Boot continues to work and doesn't hang the system.

Signed-off-by: Mark Kettenis <kettenis@openbsd.org>