### PR TITLE
m1n1.fw.asc.ioreporting: Support IOP provided buffers

### DIFF
--- a/proxyclient/m1n1/fw/asc/ioreporting.py
+++ b/proxyclient/m1n1/fw/asc/ioreporting.py
@@ -31,9 +31,15 @@ class ASCIOReportingEndpoint(ASCBaseEndpoint):
             self.log("WARNING: trying to reset iobuffer!")
 
         self.bufsize = align(0x1000 * msg.SIZE, 0x4000)
-        self.iobuffer, self.iobuffer_dva = self.asc.ioalloc(self.bufsize)
-        self.log(f"buf {self.iobuffer:#x} / {self.iobuffer_dva:#x}")
-        self.send(IOReporting_GetBuf(DVA=self.iobuffer_dva, SIZE=self.bufsize // 0x1000))
+
+        if msg.DVA != 0:
+            self.iobuffer = self.iobuffer_dva = msg.DVA
+            self.log(f"buf {self.iobuffer:#x} / {self.iobuffer_dva:#x}")
+        else:
+            self.iobuffer, self.iobuffer_dva = self.asc.ioalloc(self.bufsize)
+            self.log(f"buf {self.iobuffer:#x} / {self.iobuffer_dva:#x}")
+            self.send(IOReporting_GetBuf(DVA=self.iobuffer_dva, SIZE=self.bufsize // 0x1000))
+
         return True
 
     @msg_handler(0xc, IOReporting_Start)


### PR DESCRIPTION
SMC provides buffer from its MMIO space. Since the macOS 13 SMC firmware the firmware crashes when ACK-ing a GetBuf which provided a buffer.

Signed-off-by: Janne Grunau <j@jannau.net>