### PR TITLE
Add a space between '//' and '#' to satisfy clang-format 15

### DIFF
--- a/src/adt.c
+++ b/src/adt.c
@@ -12,7 +12,7 @@
             return err;                                                                            \
     }
 
-//#define DEBUG
+// #define DEBUG
 
 #ifdef DEBUG
 #include "utils.h"

--- a/src/iodev.c
+++ b/src/iodev.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: MIT */
 
-//#define DEBUG_IODEV
+// #define DEBUG_IODEV
 
 #include "iodev.h"
 #include "memory.h"

--- a/src/vsprintf.c
+++ b/src/vsprintf.c
@@ -176,7 +176,7 @@
 #define PRINT_C_SHORT 2
 #define PRINT_C_LONG  3
 #define PRINT_C_LLONG 4
-//#define PRINT_C_LDOUBLE         5
+// #define PRINT_C_LDOUBLE         5
 #define PRINT_C_SIZE    6
 #define PRINT_C_PTRDIFF 7
 #define PRINT_C_INTMAX  8


### PR DESCRIPTION
Signed-off-by: Janne Grunau <j@jannau.net>