### PR TITLE
M2 Mac mini display support, part 1

### DIFF
--- a/src/dart.c
+++ b/src/dart.c
@@ -587,6 +587,16 @@ static void *dart_translate_internal(dart_dev_t *dart, uintptr_t iova, int silen
     u32 ttbr = (iova >> 36) & 0x3;
     u32 l1_index = (iova >> 25) & 0x7ff;
 
+    if ((int)ttbr >= dart->params->ttbr_count) {
+        printf("dart[%lx %u]: ttbr out of range: %d\n", dart->regs, dart->device, ttbr);
+        return NULL;
+    }
+
+    if (!dart->l1[ttbr]) {
+        printf("dart[%lx %u]: l1[%u] is not set\n", dart->regs, dart->device, ttbr);
+        return NULL;
+    }
+
     if (!(dart->l1[ttbr][l1_index] & DART_PTE_VALID) && !silent) {
         printf("dart[%lx %u]: l1 translation failure %x %lx\n", dart->regs, dart->device, l1_index,
                iova);

--- a/src/dart.c
+++ b/src/dart.c
@@ -657,7 +657,7 @@ u64 dart_find_iova(dart_dev_t *dart, s64 start, size_t len)
     if (start < 0 || start % SZ_16K)
         return -1;
 
-    uintptr_t end = 1LLU << 32;
+    uintptr_t end = 1LLU << 36;
     uintptr_t iova = start;
 
     while (iova + len <= end) {

--- a/src/dart.h
+++ b/src/dart.h
@@ -20,7 +20,7 @@ dart_dev_t *dart_init(uintptr_t base, u8 device, bool keep_pts, enum dart_type_t
 dart_dev_t *dart_init_adt(const char *path, int instance, int device, bool keep_pts);
 void dart_lock_adt(const char *path, int instance);
 dart_dev_t *dart_init_fdt(void *dt, u32 phandle, int device, bool keep_pts);
-int dart_setup_pt_region(dart_dev_t *dart, const char *path, int device);
+int dart_setup_pt_region(dart_dev_t *dart, const char *path, int device, u64 vm_base);
 int dart_map(dart_dev_t *dart, uintptr_t iova, void *bfr, size_t len);
 void dart_unmap(dart_dev_t *dart, uintptr_t iova, size_t len);
 void dart_free_l2(dart_dev_t *dart, uintptr_t iova);
@@ -28,5 +28,6 @@ void *dart_translate(dart_dev_t *dart, uintptr_t iova);
 u64 dart_search(dart_dev_t *dart, void *paddr);
 u64 dart_find_iova(dart_dev_t *dart, s64 start, size_t len);
 void dart_shutdown(dart_dev_t *dart);
+u64 dart_vm_base(dart_dev_t *dart);
 
 #endif

--- a/src/dcp.c
+++ b/src/dcp.c
@@ -41,7 +41,7 @@ dcp_dev_t *dcp_init(const char *dcp_path, const char *dcp_dart_path, const char 
     // set disp0's page tables at dart-dcp's vm-base
     dart_setup_pt_region(dcp->dart_disp, disp_dart_path, 0, vm_base);
 
-    dcp->iovad_dcp = iovad_init(0x10000000, 0x20000000);
+    dcp->iovad_dcp = iovad_init(vm_base + 0x10000000, vm_base + 0x20000000);
 
     dcp->asc = asc_init(dcp_path);
     if (!dcp->asc) {

--- a/src/dcp.c
+++ b/src/dcp.c
@@ -9,17 +9,29 @@
 
 dcp_dev_t *dcp_init(const char *dcp_path, const char *dcp_dart_path, const char *disp_dart_path)
 {
+    u32 sid;
+
+    int node = adt_path_offset(adt, "/arm-io/dart-dcp/mapper-dcp");
+    if (node < 0) {
+        printf("dcp: mapper-dcp not found!\n");
+        return NULL;
+    }
+    if (ADT_GETPROP(adt, node, "reg", &sid) < 0) {
+        printf("dcp: failed to read dart stream ID!\n");
+        return NULL;
+    }
+
     dcp_dev_t *dcp = malloc(sizeof(dcp_dev_t));
     if (!dcp)
         return NULL;
 
-    dcp->dart_dcp = dart_init_adt(dcp_dart_path, 0, 0, true);
+    dcp->dart_dcp = dart_init_adt(dcp_dart_path, 0, sid, true);
     if (!dcp->dart_dcp) {
         printf("dcp: failed to initialize DCP DART\n");
         goto out_free;
     }
     u64 vm_base = dart_vm_base(dcp->dart_dcp);
-    dart_setup_pt_region(dcp->dart_dcp, dcp_dart_path, 0, vm_base);
+    dart_setup_pt_region(dcp->dart_dcp, dcp_dart_path, sid, vm_base);
 
     dcp->dart_disp = dart_init_adt(disp_dart_path, 0, 0, true);
     if (!dcp->dart_disp) {

--- a/src/dcp.c
+++ b/src/dcp.c
@@ -18,14 +18,16 @@ dcp_dev_t *dcp_init(const char *dcp_path, const char *dcp_dart_path, const char 
         printf("dcp: failed to initialize DCP DART\n");
         goto out_free;
     }
-    dart_setup_pt_region(dcp->dart_dcp, dcp_dart_path, 0);
+    u64 vm_base = dart_vm_base(dcp->dart_dcp);
+    dart_setup_pt_region(dcp->dart_dcp, dcp_dart_path, 0, vm_base);
 
     dcp->dart_disp = dart_init_adt(disp_dart_path, 0, 0, true);
     if (!dcp->dart_disp) {
         printf("dcp: failed to initialize DISP DART\n");
         goto out_dart_dcp;
     }
-    dart_setup_pt_region(dcp->dart_disp, disp_dart_path, 0);
+    // set disp0's page tables at dart-dcp's vm-base
+    dart_setup_pt_region(dcp->dart_disp, disp_dart_path, 0, vm_base);
 
     dcp->iovad_dcp = iovad_init(0x10000000, 0x20000000);
 

--- a/src/display.c
+++ b/src/display.c
@@ -118,7 +118,8 @@ static uintptr_t display_map_fb(uintptr_t iova, u64 paddr, u64 size)
         u64 iova_disp0 = 0;
         u64 iova_dcp = 0;
 
-        iova_dcp = dart_find_iova(dcp->dart_dcp, iova_dcp, size);
+        // start scanning for free iova space on vm-base
+        iova_dcp = dart_find_iova(dcp->dart_dcp, dart_vm_base(dcp->dart_dcp), size);
         if (DART_IS_ERR(iova_dcp)) {
             printf("display: failed to find IOVA for fb of %06zx bytes (dcp)\n", size);
             return iova_dcp;

--- a/src/display.c
+++ b/src/display.c
@@ -126,7 +126,7 @@ static uintptr_t display_map_fb(uintptr_t iova, u64 paddr, u64 size)
         }
 
         // try to map the fb to the same IOVA on disp0
-        iova_disp0 = dart_find_iova(dcp->dart_dcp, iova_dcp, size);
+        iova_disp0 = dart_find_iova(dcp->dart_disp, iova_dcp, size);
         if (DART_IS_ERR(iova_disp0)) {
             printf("display: failed to find IOVA for fb of %06zx bytes (disp0)\n", size);
             return iova_disp0;

--- a/src/rtkit.c
+++ b/src/rtkit.c
@@ -70,7 +70,7 @@
 #define RTKIT_MIN_VERSION 11
 #define RTKIT_MAX_VERSION 12
 
-#define IOVA_MASK GENMASK(31, 0)
+#define IOVA_MASK GENMASK(35, 0)
 
 enum rtkit_power_state {
     RTKIT_POWER_OFF = 0x00,


### PR DESCRIPTION
This prevents crashes while mapping the carved out memory for the framebuffer. DCP is set up differently on M2. The DART stream id is `5` instead of `0` and it uses the top half of 36-bit IOVA space instead of relying on `asc-dram-mask`. The HDMI output does not work yet. It appears to require setup to connect `disp0` to the DisplayPort to HDMI converter to allow connecting it to the ThunderBolt 4 ports for a second display output.
Further changes for the M2 Pro Mac mini are expected.