### PR TITLE
Document HACR_EL2[56] and it's purpose

### DIFF
--- a/tools/apple_regs.json
+++ b/tools/apple_regs.json
@@ -312,6 +312,7 @@
             {"name": "TRAP_HID",                        "msb": 50, "lsb": 50},
             {"name": "TRAP_s3_0_c15_c12_1z2",           "msb": 51, "lsb": 51},
             {"name": "TRAP_ACC",                        "msb": 52, "lsb": 52},
+            {"name": "TRAP_PMUV3",                      "msb": 56, "lsb": 56},
             {"name": "TRAP_PM",                         "msb": 57, "lsb": 57},
             {"name": "TRAP_UPM",                        "msb": 58, "lsb": 58},
             {"name": "TRAP_s3_1z7_c15_cx_3",            "msb": 59, "lsb": 59}


### PR DESCRIPTION
Hello,

(trying this again to make sure the commit passes the DCO check lol)

Recently my work on getting Windows initially working on M-series Macs required me to find a way to trap PMUv3 accesses from the OS. Seeing as other hypervisors and VMMs like Parallels or UTM also would have encountered the same problem, I figured there should be an MSR that allows this behavior.

Turns out, HACR_EL2 bit 56 is the one that allows EL2 to trap all accesses to PMUv3 registers from EL1. This PR documents this bit and it's purpose by updating apple_regs.json. This should be a very simple PR to document a very useful bit for OSes which don't accommodate non-standard PMCs.

I was not the one who originally found this, original source of information here: https://github.com/utmapp/Hypervisor/blob/main/hv.c#L269-L270

Verified working on a T6002 Mac Studio (M1 Ultra), 2022 model.
