### PR TITLE
tunables_static: start ANE support

### DIFF
--- a/src/tunables_static.c
+++ b/src/tunables_static.c
@@ -190,16 +190,16 @@ static void tunables_apply(struct sequence *seq)
     }
 }
 
-int power_and_apply(const char *path, struct sequence *seq)
+int power_and_apply(const char *path, struct sequence *seqs)
 {
     if (pmgr_adt_power_enable(path) < 0) {
         printf("tunables: Failed to enable power: %s\n", path);
         return -1;
     }
 
-    while (seq->base != UINT32_MAX) {
-        tunables_apply(seq);
-        seq++;
+    while (seqs->base != UINT64_MAX) {
+        tunables_apply(seqs);
+        seqs++;
     }
 
     if (pmgr_adt_power_disable(path) < 0) {


### PR DESCRIPTION
The new `sequence` abstraction consolidates tunables under a power domain & allows reuse of entries -- both of which are helpful for the wall of ANE tunables needed. T6000 should be added once I get a trace.

Signed-off-by: Eileen Yoon <eyn@gmx.com>