### PR TITLE
Fix booting with dummy framebuffer

### DIFF
--- a/src/kboot.c
+++ b/src/kboot.c
@@ -1161,8 +1161,10 @@ static int dt_device_set_reserved_mem(int node, dart_dev_t *dart, const char *na
     int ret;
 
     u64 iova = dart_get_mapping(dart, name, paddr, size);
-    if (DART_IS_ERR(iova))
-        bail("ADT: no mapping found for '%s' 0x%012lx iova:0x%08lx)\n", name, paddr, iova);
+    if (DART_IS_ERR(iova)) {
+        printf("ADT: no mapping found for '%s' 0x%012lx iova:0x%08lx)\n", name, paddr, iova);
+        return 0;
+    }
 
     ret = fdt_appendprop_u32(dt, node, "iommu-addresses", phandle);
     if (ret != 0)


### PR DESCRIPTION
With the dummy framebuffer (on a headless M2 Pro mini) it seems that there is no iommu mapping for the framebuffer.
The code added in commit 21dc62273565 makes this fatal. Instead, print the warning but skip adding the mapping
to the device tree.