### PR TITLE
Replace a use of AMX_CTL_EL1 with AMX_CONFIG_EL1 in proxyclient.

### DIFF
--- a/proxyclient/m1n1/hv/__init__.py
+++ b/proxyclient/m1n1/hv/__init__.py
@@ -1429,9 +1429,9 @@ class HV(Reloadable):
         self.u.msr(MDSCR_EL1, MDSCR(MDE=1).value)
 
         # Enable AMX
-        amx_ctl = AMX_CTL(self.u.mrs(AMX_CTL_EL1))
+        amx_ctl = AMX_CTL(self.u.mrs(AMX_CONFIG_EL1))
         amx_ctl.EN_EL1 = 1
-        self.u.msr(AMX_CTL_EL1, amx_ctl.value)
+        self.u.msr(AMX_CONFIG_EL1, amx_ctl.value)
 
         # Set guest AP keys
         self.u.msr(VMKEYLO_EL2, 0x4E7672476F6E6147)


### PR DESCRIPTION
Likely introduced by [this commit](https://github.com/AsahiLinux/m1n1/commit/ae1bcd6fe2693fea3e8d818fe0d1bfd228fc480a).