### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/proxyclient/experiments/prores.py
+++ b/proxyclient/experiments/prores.py
@@ -593,7 +593,7 @@ desc = EncodeNotRawDescriptor(
     unk_pad_0x5a_=b'\x00',
     bitstream_version=0,
     encoder_identifier=0xcafeface,
-    # cannot change arbitrily, will break
+    # cannot change arbitrarily, will break
     pix_surface_w_byteswap_=bswp16(im_W),
     pix_surface_h_byteswap_=bswp16(im_H),
     # seemingly can change arbitrarily

--- a/proxyclient/hv/trace_gpio.py
+++ b/proxyclient/hv/trace_gpio.py
@@ -4,7 +4,7 @@ from m1n1.trace.gpio import GPIOTracer
 
 #trace_device("/arm-io/gpio", True)
 
-# trace gpio interrups, useful to follow the cascaded interrupts
+# trace gpio interrupts, useful to follow the cascaded interrupts
 aic_phandle = getattr(hv.adt["/arm-io/aic"], "AAPL,phandle")
 try:
     node = hv.adt["/arm-io/gpio0"]

--- a/proxyclient/m1n1/constructutils.py
+++ b/proxyclient/m1n1/constructutils.py
@@ -140,7 +140,7 @@ class ConstructClassException(Exception):
     pass
 
 
-# We need to inherrit Construct as a metaclass so things like If and Select will work
+# We need to inherit Construct as a metaclass so things like If and Select will work
 class ReloadableConstructMeta(ReloadableMeta, Construct):
 
     def __new__(cls, name, bases, attrs):
@@ -187,9 +187,9 @@ class ReloadableConstructMeta(ReloadableMeta, Construct):
         return cls
 
 class ConstructClassBase(Reloadable, metaclass=ReloadableConstructMeta):
-    """ Offers two benifits over regular construct
+    """ Offers two benefits over regular construct
 
-        1. It's reloadable, and can recusrivly reload other refrenced ConstructClasses
+        1. It's reloadable, and can recusrivly reload other referenced ConstructClasses
         2. It's a class, so you can define methods
 
         Currently only supports parsing, but could be extended to support building
@@ -386,9 +386,9 @@ class ROPointer(Pointer):
         return Pointer._parse(self, stream, context, path)
 
 class ConstructClass(ConstructClassBase, Container):
-    """ Offers two benifits over regular construct
+    """ Offers two benefits over regular construct
 
-        1. It's reloadable, and can recusrivly reload other refrenced ConstructClasses
+        1. It's reloadable, and can recusrivly reload other referenced ConstructClasses
         2. It's a class, so you can define methods
 
         Currently only supports parsing, but could be extended to support building

--- a/proxyclient/m1n1/fw/agx/cmdqueue.py
+++ b/proxyclient/m1n1/fw/agx/cmdqueue.py
@@ -29,7 +29,7 @@ class WorkCommandBarrier(ConstructClass):
 
 class WorkCommandInitBM(ConstructClass):
     """
-        occationally sent before WorkCommandTA on the SubmitTA queue.
+        occasionally sent before WorkCommandTA on the SubmitTA queue.
 
     Example:
     00000004 0c378018 ffffffa0 00000c00 00000006 00000900 08002c9a 00000000
@@ -494,7 +494,7 @@ class CommandQueueInfo(ConstructClass):
     """ Structure type shared by Submit3D, SubmitTA and SubmitCompute
         Applications have multiple of these, one of each submit type
         TODO: Can applications have more than one of each type? One per encoder?
-        Mostly managed by GPU, only intialize by CPU
+        Mostly managed by GPU, only initialize by CPU
 
     """
     subcon = Struct(

--- a/proxyclient/m1n1/fw/agx/microsequence.py
+++ b/proxyclient/m1n1/fw/agx/microsequence.py
@@ -897,7 +897,7 @@ class TimestampCmd(ConstructClass):
         "unk_1" / Int8ul,
         "unk_2" / Int8ul,
         "unk_3" / Int8ul, # Sometimes 0x80
-        # all these pointers point to 0xfa0... addresses. Might be where the timestamp should be writen?
+        # all these pointers point to 0xfa0... addresses. Might be where the timestamp should be written?
         "ts0_addr" / Int64ul,
         "ts0" / ROPointer(this.ts0_addr, TimeStamp),
         "ts1_addr" / Int64ul,

--- a/proxyclient/m1n1/fw/dcp/ipc.py
+++ b/proxyclient/m1n1/fw/dcp/ipc.py
@@ -718,7 +718,7 @@ class IOMobileFramebufferAP(IPCObject):
     D598 = Callback(void, "find_swap_function_gated")
 
 class ServiceRelay(IPCObject):
-    D400 = Callback(void, "get_property", obj=FourCC, key=string(0x40), value=OutPtr(Bytes(0x200)), lenght=InOutPtr(uint))
+    D400 = Callback(void, "get_property", obj=FourCC, key=string(0x40), value=OutPtr(Bytes(0x200)), length=InOutPtr(uint))
     D401 = Callback(bool_, "sr_get_uint_prop", obj=FourCC, key=string(0x40), value=InOutPtr(ulong))
     D404 = Callback(void, "sr_set_uint_prop", obj=FourCC, key=string(0x40), value=uint)
     D406 = Callback(void, "set_fx_prop", obj=FourCC, key=string(0x40), value=uint)

--- a/proxyclient/m1n1/fw/dcp/manager.py
+++ b/proxyclient/m1n1/fw/dcp/manager.py
@@ -122,7 +122,7 @@ class DCPManager(DCPBaseManager):
     def enable_backlight_message_ap_gated(self, unkB):
         print(f"enable_backlight_message_ap_gated({unkB})")
 
-    # wrapper for set_digital_out_mode to print information on the setted modes
+    # wrapper for set_digital_out_mode to print information on the set modes
     def SetDigitalOutMode(self, color_id, timing_id):
         color_mode = [x for x in self.dcpav_prop['ColorElements'] if x['ID'] == color_id][0]
         timing_mode = [x for x in self.dcpav_prop['TimingElements'] if x['ID'] == timing_id][0]

--- a/proxyclient/m1n1/hv/__init__.py
+++ b/proxyclient/m1n1/hv/__init__.py
@@ -1363,7 +1363,7 @@ class HV(Reloadable):
         self.device_addr_tbl = self.adt.build_addr_lookup()
         self.print_tracer = trace.PrintTracer(self, self.device_addr_tbl)
 
-        # disable unused USB iodev early so interrupts can be reenabled in hv_init()
+        # disable unused USB iodev early so interrupts can be re-enabled in hv_init()
         for iodev in IODEV:
             if iodev >= IODEV.USB0 and iodev != self.iodev:
                 print(f"Disable iodev {iodev!s}")

--- a/proxyclient/m1n1/hw/aes.py
+++ b/proxyclient/m1n1/hw/aes.py
@@ -90,7 +90,7 @@ class AESControlReg(Register32):
     START = 0, 0
     STOP = 1, 1
     CLEAR_FIFO = 2, 2
-    # TOOD: not convinced about RESET anymore, I remember this un-broke the engine once but I can't reproduce that anymore
+    # TODO: not convinced about RESET anymore, I remember this un-broke the engine once but I can't reproduce that anymore
     RESET = 3, 3
 
 

--- a/proxyclient/m1n1/hw/ane.py
+++ b/proxyclient/m1n1/hw/ane.py
@@ -146,7 +146,7 @@ class ANETaskManager:
 
 		# transfer to main queue (now in in TM range)
 		self.regs.REQ_ADDR.val = self.tq.REQ_ADDR1[qid].val
-		# doesnt go through if 0
+		# does not go through if 0
 		self.regs.REQ_INFO.val = self.tq.REQ_SIZE1[qid].val | req.td_count
 		# let's do magic
 		self.regs.REQ_PUSH.val = self.tq_prty[qid] | (qid & 7) << 8

--- a/proxyclient/m1n1/hw/i2c.py
+++ b/proxyclient/m1n1/hw/i2c.py
@@ -65,7 +65,7 @@ class R_SMSTA(Register32):
     XIP     = 28            # Xaction in progress
     XEN     = 27            # Xaction ended
     UJF     = 26            # UnJam failure
-    JMD     = 25            # Jam ocurred
+    JMD     = 25            # Jam occurred
     JAM     = 24            # Currently jammed
     MTO     = 23            # Master timeout
     MTA     = 22            # Master arb lost

--- a/proxyclient/m1n1/hw/isp.py
+++ b/proxyclient/m1n1/hw/isp.py
@@ -275,7 +275,7 @@ class ISPChannel:
     writes doorbell register. In the other hand, when ISP wants to notify CPU
     about a new message it triggers a hardware interrupt. 
 
-    Channel Type is a mistery, but it seems to have a connection with cmd bit
+    Channel Type is a mystery, but it seems to have a connection with cmd bit
     mask. 
     """
 

--- a/proxyclient/m1n1/hw/prores.py
+++ b/proxyclient/m1n1/hw/prores.py
@@ -26,7 +26,7 @@ EncodeNotRawDescriptor = namedtuple('EncodeNotRawDescriptor', [
         #   01 -> 16bpp?
         #   10 -> 16bpp?
         #   11 -> 16bpp?
-        #       the last three all produce slightly differnet outputs
+        #       the last three all produce slightly different outputs
         #       so might be 10/12/14/16?????
     'flags2',                               # +0x004
     'output_iova',                          # +0x008

--- a/proxyclient/m1n1/proxy.py
+++ b/proxyclient/m1n1/proxy.py
@@ -471,7 +471,7 @@ REGION_RW_EL0 = 0xa0000000000
 REGION_RX_EL1 = 0xc0000000000
 
 # Uses UartInterface.proxyreq() to send requests to M1N1 and process
-# reponses sent back.
+# responses sent back.
 class M1N1Proxy(Reloadable):
     S_OK = 0
     S_BADCMD = -1

--- a/proxyclient/m1n1/trace/agx.py
+++ b/proxyclient/m1n1/trace/agx.py
@@ -31,7 +31,7 @@ class PongMsg(GpuMsg):
     UNK     = 47, 0
 
 class PongEp(EP):
-    # This endpoint recives pongs. The cpu code reads some status registers after receiving one
+    # This endpoint receives pongs. The cpu code reads some status registers after receiving one
     # Might be a "work done" message.
     BASE_MESSAGE = GpuMsg
 

--- a/src/chickens.c
+++ b/src/chickens.c
@@ -50,7 +50,7 @@ const char *init_cpu(void)
     else
         reg_set(SYS_IMP_APL_HID4, HID4_DISABLE_DC_MVA | HID4_DISABLE_DC_SW_L2_OPS);
 
-    /* Enable NEX powergating, the reset cycles might be overriden by chickens */
+    /* Enable NEX powergating, the reset cycles might be overridden by chickens */
     if (!is_ecore()) {
         reg_mask(SYS_IMP_APL_HID13, HID13_RESET_CYCLES_MASK, HID13_RESET_CYCLES(12));
         reg_set(SYS_IMP_APL_HID14, HID14_ENABLE_NEX_POWER_GATING);

--- a/src/chickens_firestorm.c
+++ b/src/chickens_firestorm.c
@@ -38,7 +38,7 @@ static void init_m1_firestorm(void)
     init_common_firestorm();
 
     // "Cross-beat Crypto(AES/PMUL) ICache fusion is not disabled for branch
-    // uncondtional "recoded instruction."
+    // unconditional "recoded instruction."
     reg_set(SYS_IMP_APL_HID0, HID0_FETCH_WIDTH_DISABLE | HID0_CACHE_FUSION_DISABLE);
 
     reg_set(SYS_IMP_APL_HID7, HID7_FORCE_NONSPEC_IF_STEPPING |

--- a/src/dlmalloc/malloc.c
+++ b/src/dlmalloc/malloc.c
@@ -85,7 +85,7 @@
        executions, so externally crafted fake chunks cannot be
        freed. This improves security by rejecting frees/reallocs that
        could corrupt heap memory, in addition to the checks preventing
-       writes to statistics that are always on.  This may further improve
+       writes to statics that are always on.  This may further improve
        security at the expense of time and space overhead.  (Note that
        FOOTERS may also be worth using with MSPACES.)
 

--- a/src/dlmalloc/malloc.c
+++ b/src/dlmalloc/malloc.c
@@ -85,7 +85,7 @@
        executions, so externally crafted fake chunks cannot be
        freed. This improves security by rejecting frees/reallocs that
        could corrupt heap memory, in addition to the checks preventing
-       writes to statics that are always on.  This may further improve
+       writes to statistics that are always on.  This may further improve
        security at the expense of time and space overhead.  (Note that
        FOOTERS may also be worth using with MSPACES.)
 
@@ -1680,7 +1680,7 @@ static FORCEINLINE void* win32direct_mmap(size_t size) {
   return (ptr != 0)? ptr: MFAIL;
 }
 
-/* This function supports releasing coalesed segments */
+/* This function supports releasing coalesced segments */
 static FORCEINLINE int win32munmap(void* ptr, size_t size) {
   MEMORY_BASIC_INFORMATION minfo;
   char* cptr = (char*)ptr;
@@ -1768,7 +1768,7 @@ static FORCEINLINE int win32munmap(void* ptr, size_t size) {
     #define CALL_MREMAP(addr, osz, nsz, mv)     MFAIL
 #endif /* HAVE_MMAP && HAVE_MREMAP */
 
-/* mstate bit set if continguous morecore disabled or failed */
+/* mstate bit set if contiguous morecore disabled or failed */
 #define USE_NONCONTIGUOUS_BIT (4U)
 
 /* segment bit set in create_mspace_with_base */
@@ -4682,7 +4682,7 @@ void* dlmalloc(size_t bytes) {
 
 void dlfree(void* mem) {
   /*
-     Consolidate freed chunks with preceeding or succeeding bordering
+     Consolidate freed chunks with preceding or succeeding bordering
      free chunks, if they exist, and then place in a bin.  Intermixed
      with special cases for top, dv, mmapped chunks, and usage errors.
   */
@@ -6216,10 +6216,10 @@ History:
         Wolfram Gloger (Gloger@lrz.uni-muenchen.de).
       * Use last_remainder in more cases.
       * Pack bins using idea from  colin@nyx10.cs.du.edu
-      * Use ordered bins instead of best-fit threshhold
+      * Use ordered bins instead of best-fit threshold
       * Eliminate block-local decls to simplify tracing and debugging.
       * Support another case of realloc via move into top
-      * Fix error occuring when initial sbrk_base not word-aligned.
+      * Fix error occurring when initial sbrk_base not word-aligned.
       * Rely on page size for units instead of SBRK_UNIT to
         avoid surprises about sbrk alignment conventions.
       * Add mallinfo, mallopt. Thanks to Raymond Nijssen

--- a/src/hv.c
+++ b/src/hv.c
@@ -57,7 +57,7 @@ void hv_init(void)
     // Make sure we wake up DCP if we put it to sleep, just quiesce it to match ADT
     if (display_is_external && display_start_dcp() >= 0)
         display_shutdown(DCP_QUIESCED);
-    // reenable hpm interrupts for the guest for unused iodevs
+    // re-enable hpm interrupts for the guest for unused iodevs
     usb_hpm_restore_irqs(0);
     smp_start_secondaries();
     smp_set_wfe_mode(true);

--- a/src/hv_exc.c
+++ b/src/hv_exc.c
@@ -232,7 +232,7 @@ static bool hv_handle_msr_unlocked(struct exc_info *ctx, u64 iss)
         SYSREG_MAP(SYS_ACTLR_EL1, SYS_IMP_APL_ACTLR_EL12)
         SYSREG_PASS(SYS_IMP_APL_HID4)
         SYSREG_PASS(SYS_IMP_APL_EHID4)
-        /* We don't normally trap hese, but if we do, they're noisy */
+        /* We don't normally trap these, but if we do, they're noisy */
         SYSREG_PASS(SYS_IMP_APL_GXF_STATUS_EL1)
         SYSREG_PASS(SYS_IMP_APL_CNTVCT_ALIAS_EL0)
         SYSREG_PASS(SYS_IMP_APL_TPIDR_GL1)
@@ -405,7 +405,7 @@ static void hv_exc_exit(struct exc_info *ctx)
 {
     hv_wdt_breadcrumb('x');
     hv_update_fiq();
-    /* reenable PMU counters */
+    /* re-enable PMU counters */
     reg_set(SYS_IMP_APL_PMCR0, PERCPU(exc_entry_pmcr0_cnt));
     msr(CNTVOFF_EL2, stolen_time);
     spin_unlock(&bhl);

--- a/src/kboot.c
+++ b/src/kboot.c
@@ -1665,7 +1665,7 @@ static int dt_set_display(void)
     dart_lock_adt("/arm-io/dart-disp0", 0);
 
     /* Add "/reserved-memory" nodes with iommu mapping and link them to their
-     * devices. The memory is already excluded from useable RAM so these nodes
+     * devices. The memory is already excluded from usable RAM so these nodes
      * are only required to inform the OS about the existing mappings.
      * Required for disp0, dcp and all dcpext.
      * Checks for dcp* / disp*_piodma / disp* aliases and fails silently if

--- a/src/libfdt/libfdt.h
+++ b/src/libfdt/libfdt.h
@@ -711,7 +711,7 @@ static inline struct fdt_property *fdt_get_property_w(void *fdt, int nodeoffset,
  * to within the device blob itself, not a copy of the value).  If
  * lenp is non-NULL, the length of the property value is also
  * returned, in the integer pointed to by lenp.  If namep is non-NULL,
- * the property's namne will also be returned in the char * pointed to
+ * the property's name will also be returned in the char * pointed to
  * by namep (this will be a pointer to within the device tree's string
  * block, not a new copy of the name).
  *
@@ -719,7 +719,7 @@ static inline struct fdt_property *fdt_get_property_w(void *fdt, int nodeoffset,
  *	pointer to the property's value
  *		if lenp is non-NULL, *lenp contains the length of the property
  *		value (>=0)
- *		if namep is non-NULL *namep contiains a pointer to the property
+ *		if namep is non-NULL *namep contains a pointer to the property
  *		name.
  *	NULL, on error
  *		if lenp is non-NULL, *lenp contains an error code (<0):
@@ -2050,7 +2050,7 @@ int fdt_del_node(void *fdt, int nodeoffset);
  * returns:
  *	0, on success
  *	-FDT_ERR_NOSPACE, there's not enough space in the base device tree
- *	-FDT_ERR_NOTFOUND, the overlay points to some inexistant nodes or
+ *	-FDT_ERR_NOTFOUND, the overlay points to some inexistent nodes or
  *		properties in the base DT
  *	-FDT_ERR_BADPHANDLE,
  *	-FDT_ERR_BADOVERLAY,

--- a/src/memory.c
+++ b/src/memory.c
@@ -87,7 +87,7 @@ static inline void write_sctlr(u64 val)
  * [L1 index]  [L2 index]  [L3 index] [page offset]
  *   12 bits     11 bits     11 bits    14 bits
  *
- * We initalize one double-size L1 table which covers the entire virtual memory space,
+ * We initialize one double-size L1 table which covers the entire virtual memory space,
  * point to the two halves in the single L0 table and then create L2/L3 tables on demand.
  */
 
@@ -447,7 +447,7 @@ static void mmu_add_default_mappings(void)
     mmu_add_mapping(ram_base | REGION_RX_EL1, ram_base, ram_size, MAIR_IDX_NORMAL, PERM_RX_EL0);
 
     /*
-     * Create four seperate full mappings of MMIO space, with different access types
+     * Create four separate full mappings of MMIO space, with different access types
      */
     mmu_add_mapping(0xc000000000, 0x0000000000, 0x0800000000, MAIR_IDX_DEVICE_GRE, PERM_RW_EL0);
     mmu_add_mapping(0xd000000000, 0x0000000000, 0x0800000000, MAIR_IDX_DEVICE_nGRE, PERM_RW_EL0);
@@ -496,7 +496,7 @@ void mmu_init(void)
     printf("MMU: Initializing...\n");
 
     if (read_sctlr() & SCTLR_M) {
-        printf("MMU: already intialized.\n");
+        printf("MMU: already initialized.\n");
         return;
     }
 

--- a/src/minilzlib/lzmadec.c
+++ b/src/minilzlib/lzmadec.c
@@ -28,7 +28,7 @@ Environment:
 #include "lzmadec.h"
 
 //
-// Probability Bit Model for Lenghts in Rep and in Match sequences
+// Probability Bit Model for Lengths in Rep and in Match sequences
 //
 typedef struct _LENGTH_DECODER_STATE
 {
@@ -291,7 +291,7 @@ LzDecodeLen (
     uint16_t limit;
 
     //
-    // Lenghts of 2 and higher are encoded in 3 possible types of arithmetic-
+    // Lengths of 2 and higher are encoded in 3 possible types of arithmetic-
     // coded bit trees, depending on the size of the length.
     //
     // Lengths 2-9 are encoded in trees called "Low" using 3 bits of data.

--- a/src/minilzlib/lzmadec.h
+++ b/src/minilzlib/lzmadec.h
@@ -81,13 +81,13 @@ typedef enum _LZMA_SEQUENCE_STATE
     //
     LzmaLitLitLitState,
     //
-    // States where we last saw two literals preceeded by a non-literal
+    // States where we last saw two literals preceded by a non-literal
     //
     LzmaMatchLitLitState,
     LzmaRepLitLitState,
     LzmaLitShortrepLitLitState,
     //
-    // States where we last saw one literal preceeded by a non-literal
+    // States where we last saw one literal preceded by a non-literal
     //
     LzmaMatchLitState,
     LzmaRepLitState,
@@ -97,7 +97,7 @@ typedef enum _LZMA_SEQUENCE_STATE
     //
     LzmaMaxLitState,
     //
-    // States where we last saw a non-literal preceeded by a literal
+    // States where we last saw a non-literal preceded by a literal
     //
     LzmaLitMatchState = 7,
     LzmaLitRepState,

--- a/src/rtkit.c
+++ b/src/rtkit.c
@@ -363,7 +363,7 @@ int rtkit_recv(rtkit_dev_t *rtk, struct rtkit_message *msg)
         msg->msg = asc_msg.msg0;
         msg->ep = (u8)asc_msg.msg1;
 
-        /* if this is an app message we can just forwad it to the caller */
+        /* if this is an app message we can just forward it to the caller */
         if (msg->ep >= 0x20)
             return 1;
 

--- a/src/sio.c
+++ b/src/sio.c
@@ -112,7 +112,7 @@ struct copy_rule copy_rules[] = {
         .fw_param = PARAM_PANIC_BUFFER,
     },
     {
-        // peformance endpoint? FIFO?
+        // performance endpoint? FIFO?
         .blobsize = 0x4000,
         .fw_param = PARAM_UNK_030d,
     },

--- a/src/tps6598x.c
+++ b/src/tps6598x.c
@@ -112,7 +112,7 @@ int tps6598x_disable_irqs(tps6598x_dev_t *dev, tps6598x_irq_state_t *state)
     u8 tmp[CD3218B12_IRQ_WIDTH] = {0x00};
     read = i2c_smbus_read(dev->i2c, dev->addr, TPS_REG_INT_MASK1, tmp, CD3218B12_IRQ_WIDTH);
     if (read != CD3218B12_IRQ_WIDTH)
-        printf("tps6598x: failed verifcation, can't read TPS_REG_INT_MASK1\n");
+        printf("tps6598x: failed verification, can't read TPS_REG_INT_MASK1\n");
     else {
         printf("tps6598x: verify: TPS_REG_INT_MASK1 vs. saved IntMask1\n");
         hexdump(tmp, sizeof(tmp));
@@ -138,7 +138,7 @@ int tps6598x_restore_irqs(tps6598x_dev_t *dev, tps6598x_irq_state_t *state)
     u8 tmp[CD3218B12_IRQ_WIDTH];
     read = i2c_smbus_read(dev->i2c, dev->addr, TPS_REG_INT_MASK1, tmp, sizeof(tmp));
     if (read != sizeof(tmp))
-        printf("tps6598x: failed verifcation, can't read TPS_REG_INT_MASK1\n");
+        printf("tps6598x: failed verification, can't read TPS_REG_INT_MASK1\n");
     else {
         printf("tps6598x: verify saved IntMask1 vs. TPS_REG_INT_MASK1:\n");
         hexdump(state->int_mask1, sizeof(state->int_mask1));

--- a/src/usb_dwc3_regs.h
+++ b/src/usb_dwc3_regs.h
@@ -73,7 +73,7 @@
 #define DWC3_GSNPSID_MASK    0xffff0000
 #define DWC3_GSNPSREV_MASK   0xffff
 
-/* DWC3 registers memory space boundries */
+/* DWC3 registers memory space boundaries */
 #define DWC3_XHCI_REGS_START    0x0
 #define DWC3_XHCI_REGS_END      0x7fff
 #define DWC3_GLOBALS_REGS_START 0xc100


### PR DESCRIPTION
https://pypi.org/project/codespell/

% `codespell --ignore-words-list="afe,ane,ans,blong,busses,clen,crate,inout,opps,ot,sart,ser,statics,te"`

% `codespell --ignore-words-list="afe,ane,ans,blong,busses,clen,crate,inout,opps,ot,sart,ser,statics,te" --write-changes`