### PR TITLE
fix ESR_EC macro

### DIFF
--- a/proxyclient/m1n1/sysreg.py
+++ b/proxyclient/m1n1/sysreg.py
@@ -74,7 +74,7 @@ class ESR_EC(IntEnum):
     UNKNOWN        = 0b000000
     WFI            = 0b000001
     FP_TRAP        = 0b000111
-    PAUTH_TRAP     = 0b001000
+    PAUTH_TRAP     = 0b001001
     LS64           = 0b001010
     BTI            = 0b001101
     ILLEGAL        = 0b001110

--- a/src/arm_cpu_regs.h
+++ b/src/arm_cpu_regs.h
@@ -56,7 +56,7 @@
 #define ESR_EC_UNKNOWN      0b000000
 #define ESR_EC_WFI          0b000001
 #define ESR_EC_FP_TRAP      0b000111
-#define ESR_EC_PAUTH_TRAP   0b001000
+#define ESR_EC_PAUTH_TRAP   0b001001
 #define ESR_EC_LS64         0b001010
 #define ESR_EC_BTI          0b001101
 #define ESR_EC_ILLEGAL      0b001110


### PR DESCRIPTION
According to the manual, I fix the FEAT_PAuth ESR_EC macro

The manual says:

```
EC == 0b001000
When AArch32 is supported:
Trapped VMRS access, from ID group trap, that is not reported using EC 0b000111. See ISS encoding for an exception from an MCR or MRC access.
EC == 0b001001
When FEAT_PAuth is implemented:
Trapped use of a Pointer authentication instruction because HCR_EL2.API == 0 || SCR_EL3.API == 0.
```