### PR TITLE
M2+ desktop dcp/dptx HDMI output support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ LIBFDT_OBJECTS := $(patsubst %,libfdt/%, \
 	fdt_wip.o fdt.o)
 
 DCP_OBJECTS := $(patsubst %,dcp/%, \
+	dpav_ep.o \
 	dptx_phy.o \
 	dptx_port_ep.o \
 	parser.o)

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ LIBFDT_OBJECTS := $(patsubst %,libfdt/%, \
 	fdt_wip.o fdt.o)
 
 DCP_OBJECTS := $(patsubst %,dcp/%, \
+	dptx_phy.o \
 	parser.o)
 
 OBJECTS := \

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,8 @@ DCP_OBJECTS := $(patsubst %,dcp/%, \
 	dpav_ep.o \
 	dptx_phy.o \
 	dptx_port_ep.o \
-	parser.o)
+	parser.o \
+	system_ep.o)
 
 OBJECTS := \
 	adt.o \

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,9 @@ LIBFDT_OBJECTS := $(patsubst %,libfdt/%, \
 	fdt_addresses.o fdt_empty_tree.o fdt_ro.o fdt_rw.o fdt_strerror.o fdt_sw.o \
 	fdt_wip.o fdt.o)
 
+DCP_OBJECTS := $(patsubst %,dcp/%, \
+	parser.o)
+
 OBJECTS := \
 	adt.o \
 	afk.o \
@@ -129,6 +132,7 @@ OBJECTS := \
 	utils.o utils_asm.o \
 	vsprintf.o \
 	wdt.o \
+	$(DCP_OBJECTS) \
 	$(MINILZLIB_OBJECTS) $(TINF_OBJECTS) $(DLMALLOC_OBJECTS) $(LIBFDT_OBJECTS) $(RUST_LIBS)
 
 FP_OBJECTS := \
@@ -152,9 +156,9 @@ all: update_tag update_cfg build/$(TARGET) build/$(TARGET_RAW)
 clean:
 	rm -rf build/*
 format:
-	$(CLANG_FORMAT) -i src/*.c src/math/*.c src/*.h src/math/*.h sysinc/*.h
+	$(CLANG_FORMAT) -i src/*.c src/dcp/*.c src/math/*.c src/*.h src/dcp/*.h src/math/*.h sysinc/*.h
 format-check:
-	$(CLANG_FORMAT) --dry-run --Werror src/*.c src/*.h sysinc/*.h
+	$(CLANG_FORMAT) --dry-run --Werror src/*.c src/*.h src/dcp/*.c src/dcp/*.h sysinc/*.h
 rustfmt:
 	cd rust && cargo fmt
 rustfmt-check:

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ LIBFDT_OBJECTS := $(patsubst %,libfdt/%, \
 
 DCP_OBJECTS := $(patsubst %,dcp/%, \
 	dptx_phy.o \
+	dptx_port_ep.o \
 	parser.o)
 
 OBJECTS := \

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ OBJECTS := \
 	sart.o \
 	sep.o \
 	sio.o \
+	smc.o \
 	smp.o \
 	start.o \
 	startup.o \

--- a/src/afk.c
+++ b/src/afk.c
@@ -39,11 +39,6 @@ enum EPICCategory {
     CAT_COMMAND = 0x30,
 };
 
-enum EPICMessage {
-    SUBTYPE_ANNOUNCE = 0x30,
-    SUBTYPE_STD_SERVICE = 0xc0,
-};
-
 struct afk_qe {
     u32 magic;
     u32 size;

--- a/src/afk.c
+++ b/src/afk.c
@@ -108,6 +108,7 @@ struct afk_epic_ep {
     struct rtkit_buffer rxbuf;
 
     bool started;
+    u16 seq;
 
     const afk_epic_service_ops_t *ops;
     afk_epic_service_t services[AFK_MAX_CHANNEL];
@@ -427,7 +428,7 @@ int afk_epic_command(afk_epic_ep_t *epic, int channel, u16 sub_type, void *txbuf
     memset(&msg, 0, sizeof(msg));
 
     msg.hdr.version = 2;
-    msg.hdr.seq = 0;
+    msg.hdr.seq = epic->seq++;
     msg.sub.length = sizeof(msg.cmd);
     msg.sub.version = 4;
     msg.sub.category = CAT_COMMAND;

--- a/src/afk.c
+++ b/src/afk.c
@@ -479,11 +479,13 @@ int afk_epic_command(afk_epic_ep_t *epic, int channel, u16 sub_type, void *txbuf
         return rcmd->retcode; // should be negative already
     }
 
-    assert(*rxsize >= rcmd->rxlen);
-    *rxsize = rcmd->rxlen;
+    if (rxsize) {
+        assert(*rxsize >= rcmd->rxlen);
+        *rxsize = rcmd->rxlen;
 
-    if (rxsize && *rxsize && rcmd->rxbuf)
-        memcpy(rxbuf, epic->rxbuf.bfr, *rxsize);
+        if (*rxsize && rcmd->rxbuf)
+            memcpy(rxbuf, epic->rxbuf.bfr, *rxsize);
+    }
 
     afk_epic_rx_ack(epic);
 

--- a/src/afk.h
+++ b/src/afk.h
@@ -6,6 +6,11 @@
 #include "rtkit.h"
 #include "types.h"
 
+enum EPICMessage {
+    SUBTYPE_ANNOUNCE = 0x30,
+    SUBTYPE_STD_SERVICE = 0xc0,
+};
+
 typedef struct afk_epic afk_epic_t;
 typedef struct afk_epic_ep afk_epic_ep_t;
 

--- a/src/afk.h
+++ b/src/afk.h
@@ -11,7 +11,7 @@ afk_epic_ep_t *afk_epic_init(rtkit_dev_t *rtkit, int endpoint);
 int afk_epic_shutdown(afk_epic_ep_t *epic);
 
 int afk_epic_start_interface(afk_epic_ep_t *epic, char *name, size_t insize, size_t outsize);
-int afk_epic_command(afk_epic_ep_t *epic, int channel, u16 code, void *txbuf, size_t txsize,
+int afk_epic_command(afk_epic_ep_t *epic, int channel, u16 sub_type, void *txbuf, size_t txsize,
                      void *rxbuf, size_t *rxsize);
 
 #endif

--- a/src/afk.h
+++ b/src/afk.h
@@ -11,14 +11,34 @@ typedef struct afk_epic_ep afk_epic_ep_t;
 
 typedef struct afk_epic_service_ops afk_epic_service_ops_t;
 
+typedef struct afk_epic_service {
+    void *cookie;
+    const afk_epic_service_ops_t *ops;
+    afk_epic_ep_t *epic;
+    void *intf;
+    u32 channel;
+    u16 seq;
+    bool enabled;
+
+} afk_epic_service_t;
+
+typedef struct afk_epic_service_ops {
+    const char name[32];
+
+    void (*init)(afk_epic_service_t *service, const char *name, const char *eclass, s64 unit);
+    int (*call)(afk_epic_service_t *service, u32 idx, const void *data, size_t data_size,
+                void *reply, size_t reply_size);
+} afk_epic_service_ops_t;
+
 afk_epic_t *afk_epic_init(rtkit_dev_t *rtkit);
 int afk_epic_shutdown(afk_epic_t *afk);
 
-afk_epic_ep_t *afk_epic_start_ep(afk_epic_t *afk, int endpoint, bool notify);
+afk_epic_ep_t *afk_epic_start_ep(afk_epic_t *afk, int endpoint, const afk_epic_service_ops_t *ops,
+                                 bool notify);
 int afk_epic_shutdown_ep(afk_epic_ep_t *epic);
 
 int afk_epic_work(afk_epic_t *afk, int endpoint);
-int afk_epic_start_interface(afk_epic_ep_t *epic, char *name, size_t insize, size_t outsize);
+int afk_epic_start_interface(afk_epic_ep_t *epic, void *intf, size_t insize, size_t outsize);
 int afk_epic_command(afk_epic_ep_t *epic, int channel, u16 sub_type, void *txbuf, size_t txsize,
                      void *rxbuf, size_t *rxsize);
 

--- a/src/afk.h
+++ b/src/afk.h
@@ -4,12 +4,20 @@
 #define DCP_AFK_H
 
 #include "rtkit.h"
+#include "types.h"
 
+typedef struct afk_epic afk_epic_t;
 typedef struct afk_epic_ep afk_epic_ep_t;
 
-afk_epic_ep_t *afk_epic_init(rtkit_dev_t *rtkit, int endpoint);
-int afk_epic_shutdown(afk_epic_ep_t *epic);
+typedef struct afk_epic_service_ops afk_epic_service_ops_t;
 
+afk_epic_t *afk_epic_init(rtkit_dev_t *rtkit);
+int afk_epic_shutdown(afk_epic_t *afk);
+
+afk_epic_ep_t *afk_epic_start_ep(afk_epic_t *afk, int endpoint, bool notify);
+int afk_epic_shutdown_ep(afk_epic_ep_t *epic);
+
+int afk_epic_work(afk_epic_t *afk, int endpoint);
 int afk_epic_start_interface(afk_epic_ep_t *epic, char *name, size_t insize, size_t outsize);
 int afk_epic_command(afk_epic_ep_t *epic, int channel, u16 sub_type, void *txbuf, size_t txsize,
                      void *rxbuf, size_t *rxsize);

--- a/src/dart.c
+++ b/src/dart.c
@@ -324,6 +324,8 @@ dart_dev_t *dart_init_adt(const char *path, int instance, int device, bool keep_
     }
     if (ADT_GETPROP(adt, node, "vm-base", &dart->vm_base) < 0)
         dart->vm_base = 0;
+    else
+        dart->vm_base &= (1LLU << 36) - 1;
 
     return dart;
 }

--- a/src/dcp.c
+++ b/src/dcp.c
@@ -60,8 +60,15 @@ dcp_dev_t *dcp_init(const char *dcp_path, const char *dcp_dart_path, const char 
         goto out_iovad;
     }
 
+    dcp->afk = afk_epic_init(dcp->rtkit);
+    if (!dcp->afk) {
+        printf("dcp: failed to initialize AFK\n");
+        goto out_rtkit;
+    }
+
     return dcp;
 
+out_rtkit:
     rtkit_quiesce(dcp->rtkit);
     rtkit_free(dcp->rtkit);
 out_iovad:
@@ -76,6 +83,7 @@ out_free:
 
 int dcp_shutdown(dcp_dev_t *dcp, bool sleep)
 {
+    afk_epic_shutdown(dcp->afk);
     if (sleep) {
         rtkit_sleep(dcp->rtkit);
         pmgr_reset(0, "DISP0_CPU0");

--- a/src/dcp.c
+++ b/src/dcp.c
@@ -49,7 +49,7 @@ dcp_dev_t *dcp_init(const char *dcp_path, const char *dcp_dart_path, const char 
         goto out_iovad;
     }
 
-    dcp->rtkit = rtkit_init("dcp", dcp->asc, dcp->dart_dcp, dcp->iovad_dcp, NULL);
+    dcp->rtkit = rtkit_init("dcp", dcp->asc, dcp->dart_dcp, dcp->iovad_dcp, NULL, false);
     if (!dcp->rtkit) {
         printf("dcp: failed to initialize RTKit\n");
         goto out_iovad;

--- a/src/dcp.h
+++ b/src/dcp.h
@@ -3,6 +3,7 @@
 #ifndef DCP_H
 #define DCP_H
 
+#include "afk.h"
 #include "asc.h"
 #include "dart.h"
 #include "rtkit.h"
@@ -13,6 +14,7 @@ typedef struct {
     iova_domain_t *iovad_dcp;
     asc_dev_t *asc;
     rtkit_dev_t *rtkit;
+    afk_epic_t *afk;
 } dcp_dev_t;
 
 dcp_dev_t *dcp_init(const char *dcp_path, const char *dcp_dart_path, const char *disp_dart_path);

--- a/src/dcp.h
+++ b/src/dcp.h
@@ -8,7 +8,7 @@
 #include "dart.h"
 #include "rtkit.h"
 
-typedef struct {
+typedef struct dcp_dev {
     dart_dev_t *dart_dcp;
     dart_dev_t *dart_disp;
     iova_domain_t *iovad_dcp;

--- a/src/dcp.h
+++ b/src/dcp.h
@@ -8,6 +8,21 @@
 #include "dart.h"
 #include "rtkit.h"
 
+#include "dcp/dpav_ep.h"
+#include "dcp/dptx_port_ep.h"
+#include "dcp/system_ep.h"
+
+typedef struct {
+    const char dcp[24];
+    const char dcp_dart[24];
+    const char disp_dart[24];
+    const char dptx_phy[24];
+    const char dp2hdmi_gpio[24];
+    const char pmgr_dev[24];
+    u32 dcp_index;
+    u8 die;
+} display_config_t;
+
 typedef struct dcp_dev {
     dart_dev_t *dart_dcp;
     dart_dev_t *dart_disp;
@@ -15,9 +30,18 @@ typedef struct dcp_dev {
     asc_dev_t *asc;
     rtkit_dev_t *rtkit;
     afk_epic_t *afk;
+    dcp_system_if_t *system_ep;
+    dcp_dpav_if_t *dpav_ep;
+    dcp_dptx_if_t *dptx_ep;
+    dptx_phy_t *phy;
+    u32 dp2hdmi_pwr_gpio;
+    u32 hdmi_pwr_gpio;
 } dcp_dev_t;
 
-dcp_dev_t *dcp_init(const char *dcp_path, const char *dcp_dart_path, const char *disp_dart_path);
+int dcp_connect_dptx(dcp_dev_t *dcp);
+int dcp_work(dcp_dev_t *dcp);
+
+dcp_dev_t *dcp_init(const display_config_t *config);
 
 int dcp_shutdown(dcp_dev_t *dcp, bool sleep);
 

--- a/src/dcp/dpav_ep.c
+++ b/src/dcp/dpav_ep.c
@@ -1,0 +1,78 @@
+
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+/* Copyright 2022 Sven Peter <sven@svenpeter.dev> */
+
+#include <stdbool.h>
+#include <string.h>
+
+#include "dpav_ep.h"
+#include "malloc.h"
+#include "parser.h"
+
+#include "../afk.h"
+#include "../dcp.h"
+#include "../types.h"
+#include "../utils.h"
+
+#define DCP_DPAV_ENDPOINT 0x24
+#define TXBUF_LEN         0x4000
+#define RXBUF_LEN         0x4000
+
+typedef struct dcp_dpav_if {
+    afk_epic_ep_t *epic;
+    dcp_dev_t *dcp;
+} dcp_dpav_if_t;
+
+static void dpav_init(afk_epic_service_t *service, const char *name, const char *eclass, s64 unit)
+{
+    UNUSED(service);
+    UNUSED(name);
+    UNUSED(eclass);
+    UNUSED(unit);
+    // printf("DPAV: init(name='%s', class='%s' unit=%ld:\n", name, eclass, unit);
+}
+
+static const afk_epic_service_ops_t dcp_dpav_ops[] = {
+    {
+        .name = "AppleDCPDPTXController",
+        .init = dpav_init,
+    },
+    {},
+};
+
+dcp_dpav_if_t *dcp_dpav_init(dcp_dev_t *dcp)
+{
+    dcp_dpav_if_t *dpav = malloc(sizeof(dcp_dpav_if_t));
+    if (!dpav)
+        return NULL;
+
+    dpav->dcp = dcp;
+    dpav->epic = afk_epic_start_ep(dcp->afk, DCP_DPAV_ENDPOINT, dcp_dpav_ops, true);
+    if (!dpav->epic) {
+        printf("dpav: failed to initialize EPIC\n");
+        goto err_free;
+    }
+
+    int err = afk_epic_start_interface(dpav->epic, dpav, TXBUF_LEN, RXBUF_LEN);
+    if (err < 0) {
+        printf("dpav: failed to initialize DPAV interface\n");
+        goto err_shutdown;
+    }
+
+    return dpav;
+
+err_shutdown:
+    afk_epic_shutdown_ep(dpav->epic);
+err_free:
+    free(dpav);
+    return NULL;
+}
+
+int dcp_dpav_shutdown(dcp_dpav_if_t *dpav)
+{
+    if (dpav) {
+        afk_epic_shutdown_ep(dpav->epic);
+        free(dpav);
+    }
+    return 0;
+}

--- a/src/dcp/dpav_ep.h
+++ b/src/dcp/dpav_ep.h
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+/* Copyright 2023 Janne Grunau <j@jannau.net> */
+
+#ifndef __APPLE_DCP_DPAV_EP_H__
+#define __APPLE_DCP_DPAV_EP_H__
+
+#include "../types.h"
+
+typedef struct dcp_dev dcp_dev_t;
+
+typedef struct dcp_dpav_if dcp_dpav_if_t;
+
+dcp_dpav_if_t *dcp_dpav_init(dcp_dev_t *dcp);
+int dcp_dpav_shutdown(dcp_dpav_if_t *dpav);
+
+#endif

--- a/src/dcp/dptx_phy.c
+++ b/src/dcp/dptx_phy.c
@@ -1,0 +1,514 @@
+/* SPDX-License-Identifier: MIT */
+
+#include "dptx_phy.h"
+#include "malloc.h"
+
+#include "../adt.h"
+#include "../utils.h"
+
+#define DPTX_MAX_LANES 4
+
+enum dptx_type {
+    DPTX_PHY_T8112,
+    DPTX_PHY_T602X,
+};
+
+typedef struct dptx_phy {
+    u64 regs[2];
+    enum dptx_type type;
+    u32 dcp_index;
+    u32 active_lanes;
+} dptx_phy_t;
+
+int dptx_phy_activate(dptx_phy_t *phy)
+{
+    // MMIO: R.4   0x23c500010 (dptx-phy[1], offset 0x10) = 0x0
+    // MMIO: W.4   0x23c500010 (dptx-phy[1], offset 0x10) = 0x0
+    read32(phy->regs[1] + 0x10);
+    write32(phy->regs[1] + 0x10, phy->dcp_index);
+
+    // MMIO: R.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x444
+    read32(phy->regs[1] + 0x48);
+    // MMIO: W.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x454
+    write32(phy->regs[1] + 0x48, 0x454);
+    // MMIO: R.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x454
+    read32(phy->regs[1] + 0x48);
+    // MMIO: W.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x474
+    write32(phy->regs[1] + 0x48, 0x474);
+    // MMIO: R.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x474
+    read32(phy->regs[1] + 0x48);
+    // MMIO: W.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x434
+    write32(phy->regs[1] + 0x48, 0x434);
+    // MMIO: R.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x434
+    read32(phy->regs[1] + 0x48);
+    // MMIO: W.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x534
+    write32(phy->regs[1] + 0x48, 0x534);
+    // MMIO: R.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x534
+    read32(phy->regs[1] + 0x48);
+    // MMIO: W.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x734
+    write32(phy->regs[1] + 0x48, 0x734);
+    // MMIO: R.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x734
+    read32(phy->regs[1] + 0x48);
+    // MMIO: W.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x334
+    write32(phy->regs[1] + 0x48, 0x334);
+    // MMIO: R.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x334
+    read32(phy->regs[1] + 0x48);
+    // MMIO: W.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x335
+    write32(phy->regs[1] + 0x48, 0x335);
+    // MMIO: R.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x335
+    read32(phy->regs[1] + 0x48);
+    // MMIO: W.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x337
+    write32(phy->regs[1] + 0x48, 0x337);
+    // MMIO: R.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x337
+    read32(phy->regs[1] + 0x48);
+    // MMIO: W.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x333
+    write32(phy->regs[1] + 0x48, 0x333);
+    // MMIO: R.4   0x23c542014 (dptx-phy[0], offset 0x2014) = 0x80a0c
+    read32(phy->regs[0] + 0x2014);
+    // MMIO: W.4   0x23c542014 (dptx-phy[0], offset 0x2014) = 0x300a0c
+    write32(phy->regs[0] + 0x2014, 0x300a0c);
+    // MMIO: R.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x644800
+    read32(phy->regs[0] + 0x20b8);
+    // MMIO: W.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x654800
+    write32(phy->regs[0] + 0x20b8, 0x654800);
+    // MMIO: R.4   0x23c542220 (dptx-phy[0], offset 0x2220) = 0x11090a2
+    read32(phy->regs[0] + 0x2220);
+    // MMIO: W.4   0x23c542220 (dptx-phy[0], offset 0x2220) = 0x11090a0
+    write32(phy->regs[0] + 0x2220, 0x11090a0);
+    // MMIO: R.4   0x23c54222c (dptx-phy[0], offset 0x222c) = 0x103003
+    read32(phy->regs[0] + 0x222c);
+    // MMIO: W.4   0x23c54222c (dptx-phy[0], offset 0x222c) = 0x103803
+    write32(phy->regs[0] + 0x222c, 0x103803);
+    // MMIO: R.4   0x23c54222c (dptx-phy[0], offset 0x222c) = 0x103803
+    read32(phy->regs[0] + 0x222c);
+    // MMIO: W.4   0x23c54222c (dptx-phy[0], offset 0x222c) = 0x103903
+    write32(phy->regs[0] + 0x222c, 0x103903);
+    // MMIO: R.4   0x23c542230 (dptx-phy[0], offset 0x2230) = 0x2308804
+    read32(phy->regs[0] + 0x2230);
+    // MMIO: W.4   0x23c542230 (dptx-phy[0], offset 0x2230) = 0x2208804
+    write32(phy->regs[0] + 0x2230, 0x2208804);
+    // MMIO: R.4   0x23c542278 (dptx-phy[0], offset 0x2278) = 0x18300811
+    read32(phy->regs[0] + 0x2278);
+    // MMIO: W.4   0x23c542278 (dptx-phy[0], offset 0x2278) = 0x10300811
+    write32(phy->regs[0] + 0x2278, 0x10300811);
+    // MMIO: R.4   0x23c5422a4 (dptx-phy[0], offset 0x22a4) = 0x1044200
+    read32(phy->regs[0] + 0x22a4);
+    // MMIO: W.4   0x23c5422a4 (dptx-phy[0], offset 0x22a4) = 0x1044201
+    write32(phy->regs[0] + 0x22a4, 0x1044201);
+    // MMIO: R.4   0x23c544008 (dptx-phy[0], offset 0x4008) = 0x18030
+    read32(phy->regs[0] + 0x4008);
+    // MMIO: W.4   0x23c544008 (dptx-phy[0], offset 0x4008) = 0x30030
+    write32(phy->regs[0] + 0x4008, 0x30030);
+    // MMIO: R.4   0x23c544008 (dptx-phy[0], offset 0x4008) = 0x30030
+    read32(phy->regs[0] + 0x4008);
+    // MMIO: W.4   0x23c544008 (dptx-phy[0], offset 0x4008) = 0x30010
+    write32(phy->regs[0] + 0x4008, 0x30010);
+    // MMIO: R.4   0x23c54420c (dptx-phy[0], offset 0x420c) = 0x88e3
+    read32(phy->regs[0] + 0x420c);
+    // MMIO: W.4   0x23c54420c (dptx-phy[0], offset 0x420c) = 0x88c3
+    write32(phy->regs[0] + 0x420c, 0x88c3);
+    // MMIO: R.4   0x23c544600 (dptx-phy[0], offset 0x4600) = 0x0
+    read32(phy->regs[0] + 0x4600);
+    // MMIO: W.4   0x23c544600 (dptx-phy[0], offset 0x4600) = 0x8000000
+    write32(phy->regs[0] + 0x4600, 0x8000000);
+    // MMIO: R.4   0x23c545040 (dptx-phy[0], offset 0x5040) = 0x21780
+    read32(phy->regs[0] + 0x5040);
+    // MMIO: W.4   0x23c545040 (dptx-phy[0], offset 0x5040) = 0x221780
+    write32(phy->regs[0] + 0x5040, 0x221780);
+    // MMIO: R.4   0x23c546040 (dptx-phy[0], offset 0x6040) = 0x21780
+    read32(phy->regs[0] + 0x6040);
+    // MMIO: W.4   0x23c546040 (dptx-phy[0], offset 0x6040) = 0x221780
+    write32(phy->regs[0] + 0x6040, 0x221780);
+    // MMIO: R.4   0x23c547040 (dptx-phy[0], offset 0x7040) = 0x21780
+    read32(phy->regs[0] + 0x7040);
+    // MMIO: W.4   0x23c547040 (dptx-phy[0], offset 0x7040) = 0x221780
+    write32(phy->regs[0] + 0x7040, 0x221780);
+    // MMIO: R.4   0x23c548040 (dptx-phy[0], offset 0x8040) = 0x21780
+    read32(phy->regs[0] + 0x8040);
+    // MMIO: W.4   0x23c548040 (dptx-phy[0], offset 0x8040) = 0x221780
+    write32(phy->regs[0] + 0x8040, 0x221780);
+    // MMIO: R.4   0x23c545040 (dptx-phy[0], offset 0x5040) = 0x221780
+    read32(phy->regs[0] + 0x5040);
+    // MMIO: W.4   0x23c545040 (dptx-phy[0], offset 0x5040) = 0x2a1780
+    write32(phy->regs[0] + 0x5040, 0x2a1780);
+    // MMIO: R.4   0x23c546040 (dptx-phy[0], offset 0x6040) = 0x221780
+    read32(phy->regs[0] + 0x6040);
+    // MMIO: W.4   0x23c546040 (dptx-phy[0], offset 0x6040) = 0x2a1780
+    write32(phy->regs[0] + 0x6040, 0x2a1780);
+    // MMIO: R.4   0x23c547040 (dptx-phy[0], offset 0x7040) = 0x221780
+    read32(phy->regs[0] + 0x7040);
+    // MMIO: W.4   0x23c547040 (dptx-phy[0], offset 0x7040) = 0x2a1780
+    write32(phy->regs[0] + 0x7040, 0x2a1780);
+    // MMIO: R.4   0x23c548040 (dptx-phy[0], offset 0x8040) = 0x221780
+    read32(phy->regs[0] + 0x8040);
+    // MMIO: W.4   0x23c548040 (dptx-phy[0], offset 0x8040) = 0x2a1780
+    write32(phy->regs[0] + 0x8040, 0x2a1780);
+    // MMIO: R.4   0x23c545244 (dptx-phy[0], offset 0x5244) = 0x18
+    read32(phy->regs[0] + 0x5244);
+    // MMIO: W.4   0x23c545244 (dptx-phy[0], offset 0x5244) = 0x8
+    write32(phy->regs[0] + 0x5244, 0x8);
+    // MMIO: R.4   0x23c546244 (dptx-phy[0], offset 0x6244) = 0x18
+    read32(phy->regs[0] + 0x6244);
+    // MMIO: W.4   0x23c546244 (dptx-phy[0], offset 0x6244) = 0x8
+    write32(phy->regs[0] + 0x6244, 0x8);
+    // MMIO: R.4   0x23c547244 (dptx-phy[0], offset 0x7244) = 0x18
+    read32(phy->regs[0] + 0x7244);
+    // MMIO: W.4   0x23c547244 (dptx-phy[0], offset 0x7244) = 0x8
+    write32(phy->regs[0] + 0x7244, 0x8);
+    // MMIO: R.4   0x23c548244 (dptx-phy[0], offset 0x8244) = 0x18
+    read32(phy->regs[0] + 0x8244);
+    // MMIO: W.4   0x23c548244 (dptx-phy[0], offset 0x8244) = 0x8
+    write32(phy->regs[0] + 0x8244, 0x8);
+    // MMIO: R.4   0x23c542214 (dptx-phy[0], offset 0x2214) = 0x1e0
+    read32(phy->regs[0] + 0x2214);
+    // MMIO: W.4   0x23c542214 (dptx-phy[0], offset 0x2214) = 0x1e1
+    write32(phy->regs[0] + 0x2214, 0x1e1);
+    // MMIO: R.4   0x23c542224 (dptx-phy[0], offset 0x2224) = 0x20086001
+    read32(phy->regs[0] + 0x2224);
+    // MMIO: W.4   0x23c542224 (dptx-phy[0], offset 0x2224) = 0x20086000
+    write32(phy->regs[0] + 0x2224, 0x20086000);
+    // MMIO: R.4   0x23c542200 (dptx-phy[0], offset 0x2200) = 0x2000
+    read32(phy->regs[0] + 0x2200);
+    // MMIO: W.4   0x23c542200 (dptx-phy[0], offset 0x2200) = 0x2002
+    write32(phy->regs[0] + 0x2200, 0x2002);
+    // MMIO: R.4   0x23c541000 (dptx-phy[0], offset 0x1000) = 0xe0000003
+    read32(phy->regs[0] + 0x1000);
+    // MMIO: W.4   0x23c541000 (dptx-phy[0], offset 0x1000) = 0xe0000001
+    write32(phy->regs[0] + 0x1000, 0xe0000001);
+    // MMIO: R.4   0x23c544004 (dptx-phy[0], offset 0x4004) = 0x41
+    read32(phy->regs[0] + 0x4004);
+    // MMIO: W.4   0x23c544004 (dptx-phy[0], offset 0x4004) = 0x49
+    write32(phy->regs[0] + 0x4004, 0x49);
+    // MMIO: R.4   0x23c544404 (dptx-phy[0], offset 0x4404) = 0x555d444
+    read32(phy->regs[0] + 0x4404);
+    // MMIO: W.4   0x23c544404 (dptx-phy[0], offset 0x4404) = 0x555d444
+    write32(phy->regs[0] + 0x4404, 0x555d444);
+    // MMIO: R.4   0x23c544404 (dptx-phy[0], offset 0x4404) = 0x555d444
+    read32(phy->regs[0] + 0x4404);
+    // MMIO: W.4   0x23c544404 (dptx-phy[0], offset 0x4404) = 0x555d444
+    write32(phy->regs[0] + 0x4404, 0x555d444);
+
+    dptx_phy_set_active_lane_count(phy, 0);
+
+    // MMIO: R.4   0x23c544200 (dptx-phy[0], offset 0x4200) = 0x4002430
+    read32(phy->regs[0] + 0x4200);
+    // MMIO: W.4   0x23c544200 (dptx-phy[0], offset 0x4200) = 0x4002420
+    write32(phy->regs[0] + 0x4200, 0x4002420);
+    // MMIO: R.4   0x23c544600 (dptx-phy[0], offset 0x4600) = 0x8000000
+    read32(phy->regs[0] + 0x4600);
+    // MMIO: W.4   0x23c544600 (dptx-phy[0], offset 0x4600) = 0x8000000
+    write32(phy->regs[0] + 0x4600, 0x8000000);
+    // MMIO: R.4   0x23c544600 (dptx-phy[0], offset 0x4600) = 0x8000000
+    read32(phy->regs[0] + 0x4600);
+    // MMIO: W.4   0x23c544600 (dptx-phy[0], offset 0x4600) = 0x8000001
+    write32(phy->regs[0] + 0x4600, 0x8000001);
+    // MMIO: R.4   0x23c544600 (dptx-phy[0], offset 0x4600) = 0x8000001
+    read32(phy->regs[0] + 0x4600);
+    // MMIO: W.4   0x23c544600 (dptx-phy[0], offset 0x4600) = 0x8000003
+    write32(phy->regs[0] + 0x4600, 0x8000003);
+    // MMIO: R.4   0x23c544600 (dptx-phy[0], offset 0x4600) = 0x8000043
+    read32(phy->regs[0] + 0x4600);
+    // MMIO: R.4   0x23c544600 (dptx-phy[0], offset 0x4600) = 0x8000043
+    read32(phy->regs[0] + 0x4600);
+    // MMIO: W.4   0x23c544600 (dptx-phy[0], offset 0x4600) = 0x8000041
+    write32(phy->regs[0] + 0x4600, 0x8000041);
+    // MMIO: R.4   0x23c544408 (dptx-phy[0], offset 0x4408) = 0x482
+    read32(phy->regs[0] + 0x4408);
+    // MMIO: W.4   0x23c544408 (dptx-phy[0], offset 0x4408) = 0x482
+    write32(phy->regs[0] + 0x4408, 0x482);
+    // MMIO: R.4   0x23c544408 (dptx-phy[0], offset 0x4408) = 0x482
+    read32(phy->regs[0] + 0x4408);
+    // MMIO: W.4   0x23c544408 (dptx-phy[0], offset 0x4408) = 0x483
+    write32(phy->regs[0] + 0x4408, 0x483);
+
+    return 0;
+}
+
+int dptx_phy_set_active_lane_count(dptx_phy_t *phy, u32 num_lanes)
+{
+    u32 l;
+
+    printf("DPTX-PHY: set_active_lane_count(%u) phy_regs = {0x%lx, 0x%lx}\n", num_lanes,
+           phy->regs[0], phy->regs[1]);
+
+    if (num_lanes == 3 || num_lanes > DPTX_MAX_LANES)
+        return -1;
+
+    u32 ctrl = read32(phy->regs[0] + 0x4000);
+    write32(phy->regs[0] + 0x4000, ctrl);
+
+    for (l = 0; l < num_lanes; l++) {
+        u64 offset = 0x5000 + 0x1000 * l;
+        read32(phy->regs[0] + offset);
+        write32(phy->regs[0] + offset, 0x100);
+    }
+    for (; l < DPTX_MAX_LANES; l++) {
+        u64 offset = 0x5000 + 0x1000 * l;
+        read32(phy->regs[0] + offset);
+        write32(phy->regs[0] + offset, 0x300);
+    }
+    for (l = 0; l < num_lanes; l++) {
+        u64 offset = 0x5000 + 0x1000 * l;
+        read32(phy->regs[0] + offset);
+        write32(phy->regs[0] + offset, 0x0);
+    }
+    for (; l < DPTX_MAX_LANES; l++) {
+        u64 offset = 0x5000 + 0x1000 * l;
+        read32(phy->regs[0] + offset);
+        write32(phy->regs[0] + offset, 0x300);
+    }
+
+    if (num_lanes > 0) {
+        // clear32(phy->regs[0] + 0x4000, 0x4000000);
+        ctrl = read32(phy->regs[0] + 0x4000);
+        ctrl &= ~0x4000000;
+        write32(phy->regs[0] + 0x4000, ctrl);
+    }
+    phy->active_lanes = num_lanes;
+
+    return 0;
+}
+
+int dptx_phy_set_link_rate(dptx_phy_t *phy, u32 link_rate)
+{
+    UNUSED(link_rate);
+    // MMIO: R.4   0x23c544004 (dptx-phy[0], offset 0x4004) = 0x49
+    read32(phy->regs[0] + 0x4004);
+    // MMIO: W.4   0x23c544004 (dptx-phy[0], offset 0x4004) = 0x49
+    write32(phy->regs[0] + 0x4004, 0x49);
+    // MMIO: R.4   0x23c544000 (dptx-phy[0], offset 0x4000) = 0x41021ac
+    read32(phy->regs[0] + 0x4000);
+    // MMIO: W.4   0x23c544000 (dptx-phy[0], offset 0x4000) = 0x41021ac
+    write32(phy->regs[0] + 0x4000, 0x41021ac);
+    // MMIO: R.4   0x23c544004 (dptx-phy[0], offset 0x4004) = 0x49
+    read32(phy->regs[0] + 0x4004);
+    // MMIO: W.4   0x23c544004 (dptx-phy[0], offset 0x4004) = 0x41
+    write32(phy->regs[0] + 0x4004, 0x41);
+    // MMIO: R.4   0x23c544000 (dptx-phy[0], offset 0x4000) = 0x41021ac
+    read32(phy->regs[0] + 0x4000);
+    // >ep:27 00a2000000000300 ()
+    // MMIO: W.4   0x23c544000 (dptx-phy[0], offset 0x4000) = 0x41021ac
+    write32(phy->regs[0] + 0x4000, 0x41021ac);
+    // <ep:27 0085000000000000 ()
+    // MMIO: R.4   0x23c544000 (dptx-phy[0], offset 0x4000) = 0x41021ac
+    read32(phy->regs[0] + 0x4000);
+    // MMIO: W.4   0x23c544000 (dptx-phy[0], offset 0x4000) = 0x41021ac
+    write32(phy->regs[0] + 0x4000, 0x41021ac);
+    // MMIO: R.4   0x23c542200 (dptx-phy[0], offset 0x2200) = 0x2002
+    read32(phy->regs[0] + 0x2200);
+    // MMIO: R.4   0x23c542200 (dptx-phy[0], offset 0x2200) = 0x2002
+    read32(phy->regs[0] + 0x2200);
+    // MMIO: W.4   0x23c542200 (dptx-phy[0], offset 0x2200) = 0x2000
+    write32(phy->regs[0] + 0x2200, 0x2000);
+    // MMIO: R.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf000
+    read32(phy->regs[0] + 0x100c);
+    // MMIO: W.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf000
+    write32(phy->regs[0] + 0x100c, 0xf000);
+    // MMIO: R.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf000
+    read32(phy->regs[0] + 0x100c);
+    // MMIO: W.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf008
+    write32(phy->regs[0] + 0x100c, 0xf008);
+    // MMIO: R.4   0x23c541014 (dptx-phy[0], offset 0x1014) = 0x1
+    read32(phy->regs[0] + 0x1014);
+    // MMIO: R.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf008
+    read32(phy->regs[0] + 0x100c);
+    // MMIO: W.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf000
+    write32(phy->regs[0] + 0x100c, 0xf000);
+    // MMIO: R.4   0x23c541008 (dptx-phy[0], offset 0x1008) = 0x1
+    read32(phy->regs[0] + 0x1008);
+    // MMIO: R.4   0x23c542220 (dptx-phy[0], offset 0x2220) = 0x11090a0
+    read32(phy->regs[0] + 0x2220);
+    // MMIO: W.4   0x23c542220 (dptx-phy[0], offset 0x2220) = 0x1109020
+    write32(phy->regs[0] + 0x2220, 0x1109020);
+    // MMIO: R.4   0x23c5420b0 (dptx-phy[0], offset 0x20b0) = 0x1e0e01c2
+    read32(phy->regs[0] + 0x20b0);
+    // MMIO: W.4   0x23c5420b0 (dptx-phy[0], offset 0x20b0) = 0x1e0e01c2
+    write32(phy->regs[0] + 0x20b0, 0x1e0e01c2);
+    // MMIO: R.4   0x23c5420b4 (dptx-phy[0], offset 0x20b4) = 0x7fffffe
+    read32(phy->regs[0] + 0x20b4);
+    // MMIO: W.4   0x23c5420b4 (dptx-phy[0], offset 0x20b4) = 0x7fffffe
+    write32(phy->regs[0] + 0x20b4, 0x7fffffe);
+    // MMIO: R.4   0x23c5420b4 (dptx-phy[0], offset 0x20b4) = 0x7fffffe
+    read32(phy->regs[0] + 0x20b4);
+    // MMIO: W.4   0x23c5420b4 (dptx-phy[0], offset 0x20b4) = 0x7fffffe
+    write32(phy->regs[0] + 0x20b4, 0x7fffffe);
+    // MMIO: R.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x654800
+    read32(phy->regs[0] + 0x20b8);
+    // MMIO: W.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x654800
+    write32(phy->regs[0] + 0x20b8, 0x654800);
+    // MMIO: R.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x654800
+    read32(phy->regs[0] + 0x20b8);
+    // MMIO: W.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x654800
+    write32(phy->regs[0] + 0x20b8, 0x654800);
+    // MMIO: R.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x654800
+    read32(phy->regs[0] + 0x20b8);
+    // MMIO: W.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x654800
+    write32(phy->regs[0] + 0x20b8, 0x654800);
+    // MMIO: R.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x654800
+    read32(phy->regs[0] + 0x20b8);
+    // MMIO: W.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x454800
+    write32(phy->regs[0] + 0x20b8, 0x454800);
+    // MMIO: R.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x454800
+    read32(phy->regs[0] + 0x20b8);
+    // MMIO: W.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x454800
+    write32(phy->regs[0] + 0x20b8, 0x454800);
+    // MMIO: R.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x0
+    read32(phy->regs[1] + 0xa0);
+    // MMIO: W.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x8
+    write32(phy->regs[1] + 0xa0, 0x8);
+    // MMIO: R.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x8
+    read32(phy->regs[1] + 0xa0);
+    // MMIO: W.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0xc
+    write32(phy->regs[1] + 0xa0, 0xc);
+    // MMIO: R.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0xc
+    read32(phy->regs[1] + 0xa0);
+    // MMIO: W.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x4000c
+    write32(phy->regs[1] + 0xa0, 0x4000c);
+    // MMIO: R.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x4000c
+    read32(phy->regs[1] + 0xa0);
+    // MMIO: W.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0xc
+    write32(phy->regs[1] + 0xa0, 0xc);
+    // MMIO: R.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0xc
+    read32(phy->regs[1] + 0xa0);
+    // MMIO: W.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x8000c
+    write32(phy->regs[1] + 0xa0, 0x8000c);
+    // MMIO: R.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x8000c
+    read32(phy->regs[1] + 0xa0);
+    // MMIO: W.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0xc
+    write32(phy->regs[1] + 0xa0, 0xc);
+    // MMIO: R.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0xc
+    read32(phy->regs[1] + 0xa0);
+    // MMIO: W.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x8
+    write32(phy->regs[1] + 0xa0, 0x8);
+    // MMIO: R.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x8
+    read32(phy->regs[1] + 0xa0);
+    // MMIO: W.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x0
+    write32(phy->regs[1] + 0xa0, 0x0);
+    // MMIO: R.4   0x23c542000 (dptx-phy[0], offset 0x2000) = 0x2
+    read32(phy->regs[0] + 0x2000);
+    // MMIO: W.4   0x23c542000 (dptx-phy[0], offset 0x2000) = 0x2
+    write32(phy->regs[0] + 0x2000, 0x2);
+    // MMIO: R.4   0x23c542018 (dptx-phy[0], offset 0x2018) = 0x0
+    read32(phy->regs[0] + 0x2018);
+    // MMIO: W.4   0x23c542018 (dptx-phy[0], offset 0x2018) = 0x0
+    write32(phy->regs[0] + 0x2018, 0x0);
+    // MMIO: R.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf000
+    read32(phy->regs[0] + 0x100c);
+    // MMIO: W.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf007
+    write32(phy->regs[0] + 0x100c, 0xf007);
+    // MMIO: R.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf007
+    read32(phy->regs[0] + 0x100c);
+    // MMIO: W.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf00f
+    write32(phy->regs[0] + 0x100c, 0xf00f);
+    // MMIO: R.4   0x23c541014 (dptx-phy[0], offset 0x1014) = 0x38f
+    read32(phy->regs[0] + 0x1014);
+    // MMIO: R.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf00f
+    read32(phy->regs[0] + 0x100c);
+    // MMIO: W.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf007
+    write32(phy->regs[0] + 0x100c, 0xf007);
+    // MMIO: R.4   0x23c541008 (dptx-phy[0], offset 0x1008) = 0x9
+    read32(phy->regs[0] + 0x1008);
+    // MMIO: R.4   0x23c542200 (dptx-phy[0], offset 0x2200) = 0x2000
+    read32(phy->regs[0] + 0x2200);
+    // MMIO: W.4   0x23c542200 (dptx-phy[0], offset 0x2200) = 0x2002
+    write32(phy->regs[0] + 0x2200, 0x2002);
+    // MMIO: R.4   0x23c545010 (dptx-phy[0], offset 0x5010) = 0x18003000
+    read32(phy->regs[0] + 0x5010);
+    // MMIO: W.4   0x23c545010 (dptx-phy[0], offset 0x5010) = 0x18003000
+    write32(phy->regs[0] + 0x5010, 0x18003000);
+    // MMIO: R.4   0x23c546010 (dptx-phy[0], offset 0x6010) = 0x18003000
+    read32(phy->regs[0] + 0x6010);
+    // MMIO: W.4   0x23c546010 (dptx-phy[0], offset 0x6010) = 0x18003000
+    write32(phy->regs[0] + 0x6010, 0x18003000);
+    // MMIO: R.4   0x23c547010 (dptx-phy[0], offset 0x7010) = 0x18003000
+    read32(phy->regs[0] + 0x7010);
+    // MMIO: W.4   0x23c547010 (dptx-phy[0], offset 0x7010) = 0x18003000
+    write32(phy->regs[0] + 0x7010, 0x18003000);
+    // MMIO: R.4   0x23c548010 (dptx-phy[0], offset 0x8010) = 0x18003000
+    read32(phy->regs[0] + 0x8010);
+    // MMIO: W.4   0x23c548010 (dptx-phy[0], offset 0x8010) = 0x18003000
+    write32(phy->regs[0] + 0x8010, 0x18003000);
+    // MMIO: R.4   0x23c544000 (dptx-phy[0], offset 0x4000) = 0x41021ac
+    read32(phy->regs[0] + 0x4000);
+    // MMIO: W.4   0x23c544000 (dptx-phy[0], offset 0x4000) = 0x51021ac
+    write32(phy->regs[0] + 0x4000, 0x51021ac);
+    // MMIO: R.4   0x23c544000 (dptx-phy[0], offset 0x4000) = 0x51021ac
+    read32(phy->regs[0] + 0x4000);
+    // MMIO: W.4   0x23c544000 (dptx-phy[0], offset 0x4000) = 0x71021ac
+    write32(phy->regs[0] + 0x4000, 0x71021ac);
+    // MMIO: R.4   0x23c544004 (dptx-phy[0], offset 0x4004) = 0x41
+    read32(phy->regs[0] + 0x4004);
+    // MMIO: W.4   0x23c544004 (dptx-phy[0], offset 0x4004) = 0x49
+    write32(phy->regs[0] + 0x4004, 0x49);
+    // MMIO: R.4   0x23c544000 (dptx-phy[0], offset 0x4000) = 0x71021ac
+    read32(phy->regs[0] + 0x4000);
+    // MMIO: W.4   0x23c544000 (dptx-phy[0], offset 0x4000) = 0x71021ec
+    write32(phy->regs[0] + 0x4000, 0x71021ec);
+    // MMIO: R.4   0x23c544004 (dptx-phy[0], offset 0x4004) = 0x49
+    read32(phy->regs[0] + 0x4004);
+    // MMIO: W.4   0x23c544004 (dptx-phy[0], offset 0x4004) = 0x48
+    write32(phy->regs[0] + 0x4004, 0x48);
+
+    return 0;
+}
+
+u32 dptx_phy_dcp_output(dptx_phy_t *phy)
+{
+    switch (phy->type) {
+        case DPTX_PHY_T8112:
+            return 5;
+        case DPTX_PHY_T602X:
+            return 4;
+        default:
+            return 5;
+    }
+}
+
+dptx_phy_t *dptx_phy_init(const char *phy_node, u32 dcp_index)
+{
+    enum dptx_type type;
+    int adt_phy_path[8];
+
+    int node = adt_path_offset_trace(adt, phy_node, adt_phy_path);
+    if (node < 0) {
+        printf("DPtx-phy: Error getting phy node %s\n", phy_node);
+        return NULL;
+    }
+
+    if (adt_is_compatible(adt, node, "dptx-phy,t8112"))
+        type = DPTX_PHY_T8112;
+    else if (adt_is_compatible(adt, node, "dptx-phy,t602x"))
+        type = DPTX_PHY_T602X;
+    else {
+        printf("DPtx-phy: dptx-phy node %s is not compatible\n", phy_node);
+        return NULL;
+    }
+
+    dptx_phy_t *phy = calloc(sizeof *phy, 1);
+    if (!phy)
+        return NULL;
+
+    phy->type = type;
+    phy->dcp_index = dcp_index;
+
+    if (adt_get_reg(adt, adt_phy_path, "reg", 0, &phy->regs[0], NULL) < 0) {
+        printf("DPtx-phy: failed to get %s.reg[0]\n", phy_node);
+        goto out_err;
+    }
+
+    if (adt_get_reg(adt, adt_phy_path, "reg", 1, &phy->regs[1], NULL) < 0) {
+        printf("DPtx-phy: failed to get %s.reg[1]\n", phy_node);
+        goto out_err;
+    }
+
+    return phy;
+
+out_err:
+    free(phy);
+    return NULL;
+}
+
+void dptx_phy_shutdown(dptx_phy_t *phy)
+{
+    free(phy);
+}

--- a/src/dcp/dptx_phy.c
+++ b/src/dcp/dptx_phy.c
@@ -253,182 +253,196 @@ int dptx_phy_set_active_lane_count(dptx_phy_t *phy, u32 num_lanes)
 int dptx_phy_set_link_rate(dptx_phy_t *phy, u32 link_rate)
 {
     UNUSED(link_rate);
+    u32 sts_1008, sts_1014;
+
     // MMIO: R.4   0x23c544004 (dptx-phy[0], offset 0x4004) = 0x49
-    read32(phy->regs[0] + 0x4004);
     // MMIO: W.4   0x23c544004 (dptx-phy[0], offset 0x4004) = 0x49
-    write32(phy->regs[0] + 0x4004, 0x49);
+    set32(phy->regs[0] + 0x4004, 0x08);
+
     // MMIO: R.4   0x23c544000 (dptx-phy[0], offset 0x4000) = 0x41021ac
-    read32(phy->regs[0] + 0x4000);
     // MMIO: W.4   0x23c544000 (dptx-phy[0], offset 0x4000) = 0x41021ac
-    write32(phy->regs[0] + 0x4000, 0x41021ac);
+    clear32(phy->regs[0] + 0x4000, 0x0000040);
+
     // MMIO: R.4   0x23c544004 (dptx-phy[0], offset 0x4004) = 0x49
-    read32(phy->regs[0] + 0x4004);
     // MMIO: W.4   0x23c544004 (dptx-phy[0], offset 0x4004) = 0x41
-    write32(phy->regs[0] + 0x4004, 0x41);
+    clear32(phy->regs[0] + 0x4004, 0x08);
+
     // MMIO: R.4   0x23c544000 (dptx-phy[0], offset 0x4000) = 0x41021ac
-    read32(phy->regs[0] + 0x4000);
-    // >ep:27 00a2000000000300 ()
     // MMIO: W.4   0x23c544000 (dptx-phy[0], offset 0x4000) = 0x41021ac
-    write32(phy->regs[0] + 0x4000, 0x41021ac);
-    // <ep:27 0085000000000000 ()
+    clear32(phy->regs[0] + 0x4000, 0x2000000);
     // MMIO: R.4   0x23c544000 (dptx-phy[0], offset 0x4000) = 0x41021ac
-    read32(phy->regs[0] + 0x4000);
     // MMIO: W.4   0x23c544000 (dptx-phy[0], offset 0x4000) = 0x41021ac
-    write32(phy->regs[0] + 0x4000, 0x41021ac);
+    set32(phy->regs[0] + 0x4000, 0x1000000);
+
     // MMIO: R.4   0x23c542200 (dptx-phy[0], offset 0x2200) = 0x2002
-    read32(phy->regs[0] + 0x2200);
     // MMIO: R.4   0x23c542200 (dptx-phy[0], offset 0x2200) = 0x2002
-    read32(phy->regs[0] + 0x2200);
     // MMIO: W.4   0x23c542200 (dptx-phy[0], offset 0x2200) = 0x2000
-    write32(phy->regs[0] + 0x2200, 0x2000);
-    // MMIO: R.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf000
-    read32(phy->regs[0] + 0x100c);
-    // MMIO: W.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf000
-    write32(phy->regs[0] + 0x100c, 0xf000);
-    // MMIO: R.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf000
-    read32(phy->regs[0] + 0x100c);
-    // MMIO: W.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf008
-    write32(phy->regs[0] + 0x100c, 0xf008);
-    // MMIO: R.4   0x23c541014 (dptx-phy[0], offset 0x1014) = 0x1
-    read32(phy->regs[0] + 0x1014);
-    // MMIO: R.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf008
-    read32(phy->regs[0] + 0x100c);
-    // MMIO: W.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf000
-    write32(phy->regs[0] + 0x100c, 0xf000);
-    // MMIO: R.4   0x23c541008 (dptx-phy[0], offset 0x1008) = 0x1
-    read32(phy->regs[0] + 0x1008);
-    // MMIO: R.4   0x23c542220 (dptx-phy[0], offset 0x2220) = 0x11090a0
-    read32(phy->regs[0] + 0x2220);
-    // MMIO: W.4   0x23c542220 (dptx-phy[0], offset 0x2220) = 0x1109020
-    write32(phy->regs[0] + 0x2220, 0x1109020);
-    // MMIO: R.4   0x23c5420b0 (dptx-phy[0], offset 0x20b0) = 0x1e0e01c2
-    read32(phy->regs[0] + 0x20b0);
-    // MMIO: W.4   0x23c5420b0 (dptx-phy[0], offset 0x20b0) = 0x1e0e01c2
-    write32(phy->regs[0] + 0x20b0, 0x1e0e01c2);
-    // MMIO: R.4   0x23c5420b4 (dptx-phy[0], offset 0x20b4) = 0x7fffffe
-    read32(phy->regs[0] + 0x20b4);
-    // MMIO: W.4   0x23c5420b4 (dptx-phy[0], offset 0x20b4) = 0x7fffffe
-    write32(phy->regs[0] + 0x20b4, 0x7fffffe);
-    // MMIO: R.4   0x23c5420b4 (dptx-phy[0], offset 0x20b4) = 0x7fffffe
-    read32(phy->regs[0] + 0x20b4);
-    // MMIO: W.4   0x23c5420b4 (dptx-phy[0], offset 0x20b4) = 0x7fffffe
-    write32(phy->regs[0] + 0x20b4, 0x7fffffe);
-    // MMIO: R.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x654800
-    read32(phy->regs[0] + 0x20b8);
-    // MMIO: W.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x654800
-    write32(phy->regs[0] + 0x20b8, 0x654800);
-    // MMIO: R.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x654800
-    read32(phy->regs[0] + 0x20b8);
-    // MMIO: W.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x654800
-    write32(phy->regs[0] + 0x20b8, 0x654800);
-    // MMIO: R.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x654800
-    read32(phy->regs[0] + 0x20b8);
-    // MMIO: W.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x654800
-    write32(phy->regs[0] + 0x20b8, 0x654800);
-    // MMIO: R.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x654800
-    read32(phy->regs[0] + 0x20b8);
-    // MMIO: W.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x454800
-    write32(phy->regs[0] + 0x20b8, 0x454800);
-    // MMIO: R.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x454800
-    read32(phy->regs[0] + 0x20b8);
-    // MMIO: W.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x454800
-    write32(phy->regs[0] + 0x20b8, 0x454800);
-    // MMIO: R.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x0
-    read32(phy->regs[1] + 0xa0);
-    // MMIO: W.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x8
-    write32(phy->regs[1] + 0xa0, 0x8);
-    // MMIO: R.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x8
-    read32(phy->regs[1] + 0xa0);
-    // MMIO: W.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0xc
-    write32(phy->regs[1] + 0xa0, 0xc);
-    // MMIO: R.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0xc
-    read32(phy->regs[1] + 0xa0);
-    // MMIO: W.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x4000c
-    write32(phy->regs[1] + 0xa0, 0x4000c);
-    // MMIO: R.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x4000c
-    read32(phy->regs[1] + 0xa0);
-    // MMIO: W.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0xc
-    write32(phy->regs[1] + 0xa0, 0xc);
-    // MMIO: R.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0xc
-    read32(phy->regs[1] + 0xa0);
-    // MMIO: W.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x8000c
-    write32(phy->regs[1] + 0xa0, 0x8000c);
-    // MMIO: R.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x8000c
-    read32(phy->regs[1] + 0xa0);
-    // MMIO: W.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0xc
-    write32(phy->regs[1] + 0xa0, 0xc);
-    // MMIO: R.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0xc
-    read32(phy->regs[1] + 0xa0);
-    // MMIO: W.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x8
-    write32(phy->regs[1] + 0xa0, 0x8);
-    // MMIO: R.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x8
-    read32(phy->regs[1] + 0xa0);
-    // MMIO: W.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x0
-    write32(phy->regs[1] + 0xa0, 0x0);
-    // MMIO: R.4   0x23c542000 (dptx-phy[0], offset 0x2000) = 0x2
-    read32(phy->regs[0] + 0x2000);
-    // MMIO: W.4   0x23c542000 (dptx-phy[0], offset 0x2000) = 0x2
-    write32(phy->regs[0] + 0x2000, 0x2);
-    // MMIO: R.4   0x23c542018 (dptx-phy[0], offset 0x2018) = 0x0
-    read32(phy->regs[0] + 0x2018);
-    // MMIO: W.4   0x23c542018 (dptx-phy[0], offset 0x2018) = 0x0
-    write32(phy->regs[0] + 0x2018, 0x0);
-    // MMIO: R.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf000
-    read32(phy->regs[0] + 0x100c);
-    // MMIO: W.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf007
-    write32(phy->regs[0] + 0x100c, 0xf007);
-    // MMIO: R.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf007
-    read32(phy->regs[0] + 0x100c);
-    // MMIO: W.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf00f
-    write32(phy->regs[0] + 0x100c, 0xf00f);
-    // MMIO: R.4   0x23c541014 (dptx-phy[0], offset 0x1014) = 0x38f
-    read32(phy->regs[0] + 0x1014);
-    // MMIO: R.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf00f
-    read32(phy->regs[0] + 0x100c);
-    // MMIO: W.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf007
-    write32(phy->regs[0] + 0x100c, 0xf007);
-    // MMIO: R.4   0x23c541008 (dptx-phy[0], offset 0x1008) = 0x9
-    read32(phy->regs[0] + 0x1008);
-    // MMIO: R.4   0x23c542200 (dptx-phy[0], offset 0x2200) = 0x2000
+    /* TODO: what is this read checking for? */
     read32(phy->regs[0] + 0x2200);
+    clear32(phy->regs[0] + 0x2200, 0x0002);
+
+    // MMIO: R.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf000
+    // MMIO: W.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf000
+    // MMIO: R.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf000
+    // MMIO: W.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf008
+    /* TODO: what is the setting/clearing? */
+    u32 val_100c = read32(phy->regs[0] + 0x100c);
+    write32(phy->regs[0] + 0x100c, val_100c);
+    set32(phy->regs[0] + 0x100c, 0x0008);
+
+    // MMIO: R.4   0x23c541014 (dptx-phy[0], offset 0x1014) = 0x1
+    sts_1014 = read32(phy->regs[0] + 0x1014);
+    UNUSED(sts_1014); /* TODO: assert(sts_1014 == 0x1); */
+
+    // MMIO: R.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf008
+    // MMIO: W.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf000
+    clear32(phy->regs[0] + 0x100c, 0x0008);
+
+    // MMIO: R.4   0x23c541008 (dptx-phy[0], offset 0x1008) = 0x1
+    sts_1008 = read32(phy->regs[0] + 0x1008);
+    UNUSED(sts_1008); /* TODO: assert(sts_1008 == 0x1); */
+
+    // MMIO: R.4   0x23c542220 (dptx-phy[0], offset 0x2220) = 0x11090a0
+    // MMIO: W.4   0x23c542220 (dptx-phy[0], offset 0x2220) = 0x1109020
+    clear32(phy->regs[0] + 0x2220, 0x0000080);
+
+    // MMIO: R.4   0x23c5420b0 (dptx-phy[0], offset 0x20b0) = 0x1e0e01c2
+    // MMIO: W.4   0x23c5420b0 (dptx-phy[0], offset 0x20b0) = 0x1e0e01c2
+    u32 val_20b0 = read32(phy->regs[0] + 0x20b0);
+    /* TODO: what happens on dptx-phy */
+    if (phy->type == DPTX_PHY_T602X)
+        val_20b0 = (val_20b0 & ~0x3ff) | 0x2a3;
+    write32(phy->regs[0] + 0x20b0, val_20b0);
+
+    // MMIO: R.4   0x23c5420b4 (dptx-phy[0], offset 0x20b4) = 0x7fffffe
+    // MMIO: W.4   0x23c5420b4 (dptx-phy[0], offset 0x20b4) = 0x7fffffe
+    u32 val_20b4 = read32(phy->regs[0] + 0x20b4);
+    /* TODO: what happens on dptx-phy */
+    if (phy->type == DPTX_PHY_T602X)
+        val_20b4 = (val_20b4 | 0x4000000) & ~0x0008000;
+    write32(phy->regs[0] + 0x20b4, val_20b4);
+
+    // MMIO: R.4   0x23c5420b4 (dptx-phy[0], offset 0x20b4) = 0x7fffffe
+    // MMIO: W.4   0x23c5420b4 (dptx-phy[0], offset 0x20b4) = 0x7fffffe
+    val_20b4 = read32(phy->regs[0] + 0x20b4);
+    /* TODO: what happens on dptx-phy */
+    if (phy->type == DPTX_PHY_T602X)
+        val_20b4 = (val_20b4 | 0x0000001) & ~0x0000004;
+    write32(phy->regs[0] + 0x20b4, val_20b4);
+
+    // MMIO: R.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x654800
+    // MMIO: W.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x654800
+    /* TODO: unclear */
+    set32(phy->regs[0] + 0x20b8, 0);
+    // MMIO: R.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x654800
+    // MMIO: W.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x654800
+    /* TODO: unclear */
+    set32(phy->regs[0] + 0x20b8, 0);
+    // MMIO: R.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x654800
+    // MMIO: W.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x654800
+    /* TODO: unclear */
+    if (phy->type == DPTX_PHY_T602X)
+        set32(phy->regs[0] + 0x20b8, 0x010000);
+    else
+        set32(phy->regs[0] + 0x20b8, 0);
+    // MMIO: R.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x654800
+    // MMIO: W.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x454800
+    clear32(phy->regs[0] + 0x20b8, 0x200000);
+
+    // MMIO: R.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x454800
+    // MMIO: W.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x454800
+    /* TODO: unclear */
+    set32(phy->regs[0] + 0x20b8, 0);
+
+    // MMIO: R.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x0
+    // MMIO: W.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x8
+    // MMIO: R.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x8
+    // MMIO: W.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0xc
+    // MMIO: R.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0xc
+    // MMIO: W.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x4000c
+    // MMIO: R.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x4000c
+    // MMIO: W.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0xc
+    // MMIO: R.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0xc
+    // MMIO: W.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x8000c
+    // MMIO: R.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x8000c
+    // MMIO: W.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0xc
+    // MMIO: R.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0xc
+    // MMIO: W.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x8
+    // MMIO: R.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x8
+    // MMIO: W.4   0x23c5000a0 (dptx-phy[1], offset 0xa0) = 0x0
+    set32(phy->regs[1] + 0xa0, 0x8);
+    set32(phy->regs[1] + 0xa0, 0x4);
+    set32(phy->regs[1] + 0xa0, 0x40000);
+    clear32(phy->regs[1] + 0xa0, 0x40000);
+    set32(phy->regs[1] + 0xa0, 0x80000);
+    clear32(phy->regs[1] + 0xa0, 0x80000);
+    clear32(phy->regs[1] + 0xa0, 0x4);
+    clear32(phy->regs[1] + 0xa0, 0x8);
+
+    // MMIO: R.4   0x23c542000 (dptx-phy[0], offset 0x2000) = 0x2
+    // MMIO: W.4   0x23c542000 (dptx-phy[0], offset 0x2000) = 0x2
+    /* TODO: unclear */
+    set32(phy->regs[0] + 0x2000, 0x0);
+
+    // MMIO: R.4   0x23c542018 (dptx-phy[0], offset 0x2018) = 0x0
+    // MMIO: W.4   0x23c542018 (dptx-phy[0], offset 0x2018) = 0x0
+    clear32(phy->regs[0] + 0x2018, 0x0);
+
+    // MMIO: R.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf000
+    // MMIO: W.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf007
+    set32(phy->regs[0] + 0x100c, 0x0007);
+    // MMIO: R.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf007
+    // MMIO: W.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf00f
+    set32(phy->regs[0] + 0x100c, 0x0008);
+
+    // MMIO: R.4   0x23c541014 (dptx-phy[0], offset 0x1014) = 0x38f
+    sts_1014 = read32(phy->regs[0] + 0x1014);
+    /* TODO: assert(sts_1014 == 0x38f); */
+
+    // MMIO: R.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf00f
+    // MMIO: W.4   0x23c54100c (dptx-phy[0], offset 0x100c) = 0xf007
+    clear32(phy->regs[0] + 0x100c, 0x0008);
+
+    // MMIO: R.4   0x23c541008 (dptx-phy[0], offset 0x1008) = 0x9
+    sts_1008 = read32(phy->regs[0] + 0x1008);
+    /* TODO: assert(sts_1008 == 0x9); */
+
+    // MMIO: R.4   0x23c542200 (dptx-phy[0], offset 0x2200) = 0x2000
     // MMIO: W.4   0x23c542200 (dptx-phy[0], offset 0x2200) = 0x2002
-    write32(phy->regs[0] + 0x2200, 0x2002);
+    set32(phy->regs[0] + 0x2200, 0x0002);
+
     // MMIO: R.4   0x23c545010 (dptx-phy[0], offset 0x5010) = 0x18003000
-    read32(phy->regs[0] + 0x5010);
     // MMIO: W.4   0x23c545010 (dptx-phy[0], offset 0x5010) = 0x18003000
-    write32(phy->regs[0] + 0x5010, 0x18003000);
     // MMIO: R.4   0x23c546010 (dptx-phy[0], offset 0x6010) = 0x18003000
-    read32(phy->regs[0] + 0x6010);
     // MMIO: W.4   0x23c546010 (dptx-phy[0], offset 0x6010) = 0x18003000
-    write32(phy->regs[0] + 0x6010, 0x18003000);
     // MMIO: R.4   0x23c547010 (dptx-phy[0], offset 0x7010) = 0x18003000
-    read32(phy->regs[0] + 0x7010);
     // MMIO: W.4   0x23c547010 (dptx-phy[0], offset 0x7010) = 0x18003000
-    write32(phy->regs[0] + 0x7010, 0x18003000);
     // MMIO: R.4   0x23c548010 (dptx-phy[0], offset 0x8010) = 0x18003000
-    read32(phy->regs[0] + 0x8010);
     // MMIO: W.4   0x23c548010 (dptx-phy[0], offset 0x8010) = 0x18003000
     write32(phy->regs[0] + 0x8010, 0x18003000);
+    for (u32 loff = DPTX_LANE0_OFFSET; loff < DPTX_LANE_END; loff += DPTX_LANE_STRIDE) {
+        u32 val_l010 = read32(phy->regs[0] + loff + 0x10);
+        write32(phy->regs[0] + loff + 0x10, val_l010);
+    }
+
     // MMIO: R.4   0x23c544000 (dptx-phy[0], offset 0x4000) = 0x41021ac
-    read32(phy->regs[0] + 0x4000);
     // MMIO: W.4   0x23c544000 (dptx-phy[0], offset 0x4000) = 0x51021ac
-    write32(phy->regs[0] + 0x4000, 0x51021ac);
+    set32(phy->regs[0] + 0x4000, 0x1000000);
     // MMIO: R.4   0x23c544000 (dptx-phy[0], offset 0x4000) = 0x51021ac
-    read32(phy->regs[0] + 0x4000);
     // MMIO: W.4   0x23c544000 (dptx-phy[0], offset 0x4000) = 0x71021ac
-    write32(phy->regs[0] + 0x4000, 0x71021ac);
+    set32(phy->regs[0] + 0x4000, 0x2000000);
+
     // MMIO: R.4   0x23c544004 (dptx-phy[0], offset 0x4004) = 0x41
-    read32(phy->regs[0] + 0x4004);
     // MMIO: W.4   0x23c544004 (dptx-phy[0], offset 0x4004) = 0x49
-    write32(phy->regs[0] + 0x4004, 0x49);
+    set32(phy->regs[0] + 0x4004, 0x08);
+
     // MMIO: R.4   0x23c544000 (dptx-phy[0], offset 0x4000) = 0x71021ac
-    read32(phy->regs[0] + 0x4000);
     // MMIO: W.4   0x23c544000 (dptx-phy[0], offset 0x4000) = 0x71021ec
-    write32(phy->regs[0] + 0x4000, 0x71021ec);
+    set32(phy->regs[0] + 0x4000, 0x0000040);
+
     // MMIO: R.4   0x23c544004 (dptx-phy[0], offset 0x4004) = 0x49
-    read32(phy->regs[0] + 0x4004);
     // MMIO: W.4   0x23c544004 (dptx-phy[0], offset 0x4004) = 0x48
-    write32(phy->regs[0] + 0x4004, 0x48);
+    clear32(phy->regs[0] + 0x4004, 0x01);
 
     return 0;
 }

--- a/src/dcp/dptx_phy.c
+++ b/src/dcp/dptx_phy.c
@@ -6,7 +6,10 @@
 #include "../adt.h"
 #include "../utils.h"
 
-#define DPTX_MAX_LANES 4
+#define DPTX_MAX_LANES    4
+#define DPTX_LANE0_OFFSET 0x5000
+#define DPTX_LANE_STRIDE  0x1000
+#define DPTX_LANE_END     (DPTX_LANE0_OFFSET + DPTX_MAX_LANES * DPTX_LANE_STRIDE)
 
 enum dptx_type {
     DPTX_PHY_T8112,
@@ -28,157 +31,135 @@ int dptx_phy_activate(dptx_phy_t *phy)
     write32(phy->regs[1] + 0x10, phy->dcp_index);
 
     // MMIO: R.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x444
-    read32(phy->regs[1] + 0x48);
     // MMIO: W.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x454
-    write32(phy->regs[1] + 0x48, 0x454);
+    set32(phy->regs[1] + 0x48, 0x010);
     // MMIO: R.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x454
-    read32(phy->regs[1] + 0x48);
     // MMIO: W.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x474
-    write32(phy->regs[1] + 0x48, 0x474);
+    set32(phy->regs[1] + 0x48, 0x020);
     // MMIO: R.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x474
-    read32(phy->regs[1] + 0x48);
     // MMIO: W.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x434
-    write32(phy->regs[1] + 0x48, 0x434);
+    clear32(phy->regs[1] + 0x48, 0x040);
     // MMIO: R.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x434
-    read32(phy->regs[1] + 0x48);
     // MMIO: W.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x534
-    write32(phy->regs[1] + 0x48, 0x534);
+    set32(phy->regs[1] + 0x48, 0x100);
     // MMIO: R.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x534
-    read32(phy->regs[1] + 0x48);
     // MMIO: W.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x734
-    write32(phy->regs[1] + 0x48, 0x734);
+    set32(phy->regs[1] + 0x48, 0x200);
     // MMIO: R.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x734
-    read32(phy->regs[1] + 0x48);
     // MMIO: W.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x334
-    write32(phy->regs[1] + 0x48, 0x334);
+    clear32(phy->regs[1] + 0x48, 0x400);
     // MMIO: R.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x334
-    read32(phy->regs[1] + 0x48);
     // MMIO: W.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x335
-    write32(phy->regs[1] + 0x48, 0x335);
+    set32(phy->regs[1] + 0x48, 0x001);
     // MMIO: R.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x335
-    read32(phy->regs[1] + 0x48);
     // MMIO: W.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x337
-    write32(phy->regs[1] + 0x48, 0x337);
+    set32(phy->regs[1] + 0x48, 0x002);
     // MMIO: R.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x337
-    read32(phy->regs[1] + 0x48);
     // MMIO: W.4   0x23c500048 (dptx-phy[1], offset 0x48) = 0x333
-    write32(phy->regs[1] + 0x48, 0x333);
+    clear32(phy->regs[1] + 0x48, 0x004);
+
     // MMIO: R.4   0x23c542014 (dptx-phy[0], offset 0x2014) = 0x80a0c
-    read32(phy->regs[0] + 0x2014);
+    u32 val_2014 = read32(phy->regs[0] + 0x2014);
     // MMIO: W.4   0x23c542014 (dptx-phy[0], offset 0x2014) = 0x300a0c
-    write32(phy->regs[0] + 0x2014, 0x300a0c);
+    write32(phy->regs[0] + 0x2014, (0x30 << 16) | (val_2014 & 0xffff));
+
     // MMIO: R.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x644800
-    read32(phy->regs[0] + 0x20b8);
     // MMIO: W.4   0x23c5420b8 (dptx-phy[0], offset 0x20b8) = 0x654800
-    write32(phy->regs[0] + 0x20b8, 0x654800);
+    set32(phy->regs[0] + 0x20b8, 0x010000);
+
     // MMIO: R.4   0x23c542220 (dptx-phy[0], offset 0x2220) = 0x11090a2
-    read32(phy->regs[0] + 0x2220);
     // MMIO: W.4   0x23c542220 (dptx-phy[0], offset 0x2220) = 0x11090a0
-    write32(phy->regs[0] + 0x2220, 0x11090a0);
+    clear32(phy->regs[0] + 0x2220, 0x0000002);
+
     // MMIO: R.4   0x23c54222c (dptx-phy[0], offset 0x222c) = 0x103003
-    read32(phy->regs[0] + 0x222c);
     // MMIO: W.4   0x23c54222c (dptx-phy[0], offset 0x222c) = 0x103803
-    write32(phy->regs[0] + 0x222c, 0x103803);
+    set32(phy->regs[0] + 0x222c, 0x000800);
     // MMIO: R.4   0x23c54222c (dptx-phy[0], offset 0x222c) = 0x103803
-    read32(phy->regs[0] + 0x222c);
     // MMIO: W.4   0x23c54222c (dptx-phy[0], offset 0x222c) = 0x103903
-    write32(phy->regs[0] + 0x222c, 0x103903);
+    set32(phy->regs[0] + 0x222c, 0x000100);
+
     // MMIO: R.4   0x23c542230 (dptx-phy[0], offset 0x2230) = 0x2308804
-    read32(phy->regs[0] + 0x2230);
     // MMIO: W.4   0x23c542230 (dptx-phy[0], offset 0x2230) = 0x2208804
-    write32(phy->regs[0] + 0x2230, 0x2208804);
+    clear32(phy->regs[0] + 0x2230, 0x0100000);
+
     // MMIO: R.4   0x23c542278 (dptx-phy[0], offset 0x2278) = 0x18300811
-    read32(phy->regs[0] + 0x2278);
     // MMIO: W.4   0x23c542278 (dptx-phy[0], offset 0x2278) = 0x10300811
-    write32(phy->regs[0] + 0x2278, 0x10300811);
+    clear32(phy->regs[0] + 0x2278, 0x08000000);
+
     // MMIO: R.4   0x23c5422a4 (dptx-phy[0], offset 0x22a4) = 0x1044200
-    read32(phy->regs[0] + 0x22a4);
     // MMIO: W.4   0x23c5422a4 (dptx-phy[0], offset 0x22a4) = 0x1044201
-    write32(phy->regs[0] + 0x22a4, 0x1044201);
+    set32(phy->regs[0] + 0x22a4, 0x0000001);
+
     // MMIO: R.4   0x23c544008 (dptx-phy[0], offset 0x4008) = 0x18030
-    read32(phy->regs[0] + 0x4008);
+    u32 val_4008 = read32(phy->regs[0] + 0x4008);
     // MMIO: W.4   0x23c544008 (dptx-phy[0], offset 0x4008) = 0x30030
-    write32(phy->regs[0] + 0x4008, 0x30030);
+    write32(phy->regs[0] + 0x4008, (0x6 << 15) | (val_4008 & 0x7fff));
     // MMIO: R.4   0x23c544008 (dptx-phy[0], offset 0x4008) = 0x30030
-    read32(phy->regs[0] + 0x4008);
     // MMIO: W.4   0x23c544008 (dptx-phy[0], offset 0x4008) = 0x30010
-    write32(phy->regs[0] + 0x4008, 0x30010);
+    clear32(phy->regs[0] + 0x4008, 0x00020);
+
     // MMIO: R.4   0x23c54420c (dptx-phy[0], offset 0x420c) = 0x88e3
-    read32(phy->regs[0] + 0x420c);
     // MMIO: W.4   0x23c54420c (dptx-phy[0], offset 0x420c) = 0x88c3
-    write32(phy->regs[0] + 0x420c, 0x88c3);
+    clear32(phy->regs[0] + 0x420c, 0x0020);
+
     // MMIO: R.4   0x23c544600 (dptx-phy[0], offset 0x4600) = 0x0
-    read32(phy->regs[0] + 0x4600);
     // MMIO: W.4   0x23c544600 (dptx-phy[0], offset 0x4600) = 0x8000000
-    write32(phy->regs[0] + 0x4600, 0x8000000);
+    set32(phy->regs[0] + 0x4600, 0x8000000);
+
     // MMIO: R.4   0x23c545040 (dptx-phy[0], offset 0x5040) = 0x21780
-    read32(phy->regs[0] + 0x5040);
     // MMIO: W.4   0x23c545040 (dptx-phy[0], offset 0x5040) = 0x221780
-    write32(phy->regs[0] + 0x5040, 0x221780);
     // MMIO: R.4   0x23c546040 (dptx-phy[0], offset 0x6040) = 0x21780
-    read32(phy->regs[0] + 0x6040);
     // MMIO: W.4   0x23c546040 (dptx-phy[0], offset 0x6040) = 0x221780
-    write32(phy->regs[0] + 0x6040, 0x221780);
     // MMIO: R.4   0x23c547040 (dptx-phy[0], offset 0x7040) = 0x21780
-    read32(phy->regs[0] + 0x7040);
     // MMIO: W.4   0x23c547040 (dptx-phy[0], offset 0x7040) = 0x221780
-    write32(phy->regs[0] + 0x7040, 0x221780);
     // MMIO: R.4   0x23c548040 (dptx-phy[0], offset 0x8040) = 0x21780
-    read32(phy->regs[0] + 0x8040);
     // MMIO: W.4   0x23c548040 (dptx-phy[0], offset 0x8040) = 0x221780
-    write32(phy->regs[0] + 0x8040, 0x221780);
+    for (u32 loff = DPTX_LANE0_OFFSET; loff < DPTX_LANE_END; loff += DPTX_LANE_STRIDE)
+        set32(phy->regs[0] + loff + 0x40, 0x200000);
+
     // MMIO: R.4   0x23c545040 (dptx-phy[0], offset 0x5040) = 0x221780
-    read32(phy->regs[0] + 0x5040);
     // MMIO: W.4   0x23c545040 (dptx-phy[0], offset 0x5040) = 0x2a1780
-    write32(phy->regs[0] + 0x5040, 0x2a1780);
     // MMIO: R.4   0x23c546040 (dptx-phy[0], offset 0x6040) = 0x221780
-    read32(phy->regs[0] + 0x6040);
     // MMIO: W.4   0x23c546040 (dptx-phy[0], offset 0x6040) = 0x2a1780
-    write32(phy->regs[0] + 0x6040, 0x2a1780);
     // MMIO: R.4   0x23c547040 (dptx-phy[0], offset 0x7040) = 0x221780
-    read32(phy->regs[0] + 0x7040);
     // MMIO: W.4   0x23c547040 (dptx-phy[0], offset 0x7040) = 0x2a1780
-    write32(phy->regs[0] + 0x7040, 0x2a1780);
     // MMIO: R.4   0x23c548040 (dptx-phy[0], offset 0x8040) = 0x221780
-    read32(phy->regs[0] + 0x8040);
     // MMIO: W.4   0x23c548040 (dptx-phy[0], offset 0x8040) = 0x2a1780
-    write32(phy->regs[0] + 0x8040, 0x2a1780);
+    for (u32 loff = DPTX_LANE0_OFFSET; loff < DPTX_LANE_END; loff += DPTX_LANE_STRIDE)
+        set32(phy->regs[0] + loff + 0x40, 0x080000);
+
     // MMIO: R.4   0x23c545244 (dptx-phy[0], offset 0x5244) = 0x18
-    read32(phy->regs[0] + 0x5244);
     // MMIO: W.4   0x23c545244 (dptx-phy[0], offset 0x5244) = 0x8
-    write32(phy->regs[0] + 0x5244, 0x8);
     // MMIO: R.4   0x23c546244 (dptx-phy[0], offset 0x6244) = 0x18
-    read32(phy->regs[0] + 0x6244);
     // MMIO: W.4   0x23c546244 (dptx-phy[0], offset 0x6244) = 0x8
-    write32(phy->regs[0] + 0x6244, 0x8);
     // MMIO: R.4   0x23c547244 (dptx-phy[0], offset 0x7244) = 0x18
-    read32(phy->regs[0] + 0x7244);
     // MMIO: W.4   0x23c547244 (dptx-phy[0], offset 0x7244) = 0x8
-    write32(phy->regs[0] + 0x7244, 0x8);
     // MMIO: R.4   0x23c548244 (dptx-phy[0], offset 0x8244) = 0x18
-    read32(phy->regs[0] + 0x8244);
     // MMIO: W.4   0x23c548244 (dptx-phy[0], offset 0x8244) = 0x8
-    write32(phy->regs[0] + 0x8244, 0x8);
+    for (u32 loff = DPTX_LANE0_OFFSET; loff < DPTX_LANE_END; loff += DPTX_LANE_STRIDE)
+        clear32(phy->regs[0] + loff + 0x244, 0x10);
+
     // MMIO: R.4   0x23c542214 (dptx-phy[0], offset 0x2214) = 0x1e0
-    read32(phy->regs[0] + 0x2214);
     // MMIO: W.4   0x23c542214 (dptx-phy[0], offset 0x2214) = 0x1e1
-    write32(phy->regs[0] + 0x2214, 0x1e1);
+    set32(phy->regs[0] + 0x2214, 0x001);
+
     // MMIO: R.4   0x23c542224 (dptx-phy[0], offset 0x2224) = 0x20086001
-    read32(phy->regs[0] + 0x2224);
     // MMIO: W.4   0x23c542224 (dptx-phy[0], offset 0x2224) = 0x20086000
-    write32(phy->regs[0] + 0x2224, 0x20086000);
+    clear32(phy->regs[0] + 0x2224, 0x00000001);
+
     // MMIO: R.4   0x23c542200 (dptx-phy[0], offset 0x2200) = 0x2000
-    read32(phy->regs[0] + 0x2200);
     // MMIO: W.4   0x23c542200 (dptx-phy[0], offset 0x2200) = 0x2002
-    write32(phy->regs[0] + 0x2200, 0x2002);
+    set32(phy->regs[0] + 0x2200, 0x0002);
+
     // MMIO: R.4   0x23c541000 (dptx-phy[0], offset 0x1000) = 0xe0000003
-    read32(phy->regs[0] + 0x1000);
     // MMIO: W.4   0x23c541000 (dptx-phy[0], offset 0x1000) = 0xe0000001
-    write32(phy->regs[0] + 0x1000, 0xe0000001);
+    clear32(phy->regs[0] + 0x1000, 0x00000002);
+
     // MMIO: R.4   0x23c544004 (dptx-phy[0], offset 0x4004) = 0x41
-    read32(phy->regs[0] + 0x4004);
     // MMIO: W.4   0x23c544004 (dptx-phy[0], offset 0x4004) = 0x49
-    write32(phy->regs[0] + 0x4004, 0x49);
+    set32(phy->regs[0] + 0x4004, 0x08);
+
+    /* TODO: no idea what happens here, supposedly setting/clearing some bits */
     // MMIO: R.4   0x23c544404 (dptx-phy[0], offset 0x4404) = 0x555d444
     read32(phy->regs[0] + 0x4404);
     // MMIO: W.4   0x23c544404 (dptx-phy[0], offset 0x4404) = 0x555d444
@@ -191,35 +172,35 @@ int dptx_phy_activate(dptx_phy_t *phy)
     dptx_phy_set_active_lane_count(phy, 0);
 
     // MMIO: R.4   0x23c544200 (dptx-phy[0], offset 0x4200) = 0x4002430
-    read32(phy->regs[0] + 0x4200);
     // MMIO: W.4   0x23c544200 (dptx-phy[0], offset 0x4200) = 0x4002420
-    write32(phy->regs[0] + 0x4200, 0x4002420);
+    clear32(phy->regs[0] + 0x4200, 0x0000010);
+
     // MMIO: R.4   0x23c544600 (dptx-phy[0], offset 0x4600) = 0x8000000
-    read32(phy->regs[0] + 0x4600);
     // MMIO: W.4   0x23c544600 (dptx-phy[0], offset 0x4600) = 0x8000000
-    write32(phy->regs[0] + 0x4600, 0x8000000);
+    clear32(phy->regs[0] + 0x4600, 0x0000001);
     // MMIO: R.4   0x23c544600 (dptx-phy[0], offset 0x4600) = 0x8000000
-    read32(phy->regs[0] + 0x4600);
     // MMIO: W.4   0x23c544600 (dptx-phy[0], offset 0x4600) = 0x8000001
-    write32(phy->regs[0] + 0x4600, 0x8000001);
+    set32(phy->regs[0] + 0x4600, 0x0000001);
     // MMIO: R.4   0x23c544600 (dptx-phy[0], offset 0x4600) = 0x8000001
-    read32(phy->regs[0] + 0x4600);
     // MMIO: W.4   0x23c544600 (dptx-phy[0], offset 0x4600) = 0x8000003
-    write32(phy->regs[0] + 0x4600, 0x8000003);
+    set32(phy->regs[0] + 0x4600, 0x0000002);
     // MMIO: R.4   0x23c544600 (dptx-phy[0], offset 0x4600) = 0x8000043
-    read32(phy->regs[0] + 0x4600);
     // MMIO: R.4   0x23c544600 (dptx-phy[0], offset 0x4600) = 0x8000043
-    read32(phy->regs[0] + 0x4600);
     // MMIO: W.4   0x23c544600 (dptx-phy[0], offset 0x4600) = 0x8000041
-    write32(phy->regs[0] + 0x4600, 0x8000041);
+    /* TODO: read first to check if the previous set(...,0x2) sticked? */
+    read32(phy->regs[0] + 0x4600);
+    clear32(phy->regs[0] + 0x4600, 0x0000001);
+
     // MMIO: R.4   0x23c544408 (dptx-phy[0], offset 0x4408) = 0x482
-    read32(phy->regs[0] + 0x4408);
     // MMIO: W.4   0x23c544408 (dptx-phy[0], offset 0x4408) = 0x482
-    write32(phy->regs[0] + 0x4408, 0x482);
+    /* TODO: probably a set32 of an already set bit */
+    u32 val_4408 = read32(phy->regs[0] + 0x4408);
+    if (val_4408 != 0x482 && val_4408 != 0x483)
+        printf("DPTX-PHY: unexpected initial value at regs[0] offset 0x4408: 0x%03x\n", val_4408);
+    write32(phy->regs[0] + 0x4408, val_4408);
     // MMIO: R.4   0x23c544408 (dptx-phy[0], offset 0x4408) = 0x482
-    read32(phy->regs[0] + 0x4408);
     // MMIO: W.4   0x23c544408 (dptx-phy[0], offset 0x4408) = 0x483
-    write32(phy->regs[0] + 0x4408, 0x483);
+    set32(phy->regs[0] + 0x4408, 0x001);
 
     return 0;
 }

--- a/src/dcp/dptx_phy.h
+++ b/src/dcp/dptx_phy.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: MIT */
+
+#ifndef DCP_DPTX_PHY_H
+#define DCP_DPTX_PHY_H
+
+#include "../types.h"
+
+typedef struct dptx_phy dptx_phy_t;
+
+int dptx_phy_activate(dptx_phy_t *phy);
+int dptx_phy_set_active_lane_count(dptx_phy_t *phy, u32 num_lanes);
+int dptx_phy_set_link_rate(dptx_phy_t *phy, u32 link_rate);
+
+u32 dptx_phy_dcp_output(dptx_phy_t *phy);
+
+dptx_phy_t *dptx_phy_init(const char *phy_path, u32 dcp_index);
+void dptx_phy_shutdown(dptx_phy_t *phy);
+
+#endif /* DCP_DPTX_PHY_H */

--- a/src/dcp/dptx_port_ep.c
+++ b/src/dcp/dptx_port_ep.c
@@ -1,0 +1,582 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+/* Copyright 2022 Sven Peter <sven@svenpeter.dev> */
+
+#include <stdbool.h>
+#include <string.h>
+
+#include "dptx_port_ep.h"
+#include "dptx_phy.h"
+#include "malloc.h"
+
+#include "../afk.h"
+#include "../dcp.h"
+#include "../types.h"
+#include "../utils.h"
+
+#define DCP_DPTX_PORT_ENDPOINT 0x2a
+#define TXBUF_LEN              0x4000
+#define RXBUF_LEN              0x4000
+
+struct dcpdptx_connection_cmd {
+    u32 unk;
+    u32 target;
+} __attribute__((packed));
+
+struct dcpdptx_hotplug_cmd {
+    u8 _pad0[16];
+    u32 unk;
+} __attribute__((packed));
+
+struct dptxport_apcall_link_rate {
+    u32 retcode;
+    u8 _unk0[12];
+    u32 link_rate;
+    u8 _unk1[12];
+} __attribute__((packed));
+
+struct dptxport_apcall_lane_count {
+    u32 retcode;
+    u8 _unk0[12];
+    u64 lane_count;
+    u8 _unk1[8];
+} __attribute__((packed));
+
+struct dptxport_apcall_set_active_lane_count {
+    u32 retcode;
+    u8 _unk0[12];
+    u64 lane_count;
+    u8 _unk1[8];
+} __attribute__((packed));
+
+struct dptxport_apcall_get_support {
+    u32 retcode;
+    u8 _unk0[12];
+    u32 supported;
+    u8 _unk1[12];
+} __attribute__((packed));
+
+struct dptxport_apcall_max_drive_settings {
+    u32 retcode;
+    u8 _unk0[12];
+    u32 max_drive_settings[2];
+    u8 _unk1[8];
+} __attribute__((packed));
+
+struct dptxport_apcall_set_tiled {
+    u32 retcode;
+};
+
+struct epic_service_call {
+    u8 _pad0[2];
+    u16 group;
+    u32 command;
+    u32 data_len;
+#define EPIC_SERVICE_CALL_MAGIC 0x69706378
+    u32 magic;
+    u8 _pad1[48];
+} __attribute__((packed));
+
+typedef struct dptx_port {
+    bool enabled;
+    u32 unit;
+    afk_epic_service_t *service;
+    dptx_phy_t *phy;
+    u32 link_rate, pending_link_rate;
+} dptx_port_t;
+
+typedef struct dcp_dptx_if {
+    afk_epic_ep_t *epic;
+    dcp_dev_t *dcp;
+    dptx_phy_t *phy;
+
+    struct dptx_port port[2];
+} dcp_dptx_if_t;
+
+static int afk_service_call(afk_epic_service_t *service, u16 group, u32 command, const void *data,
+                            size_t data_len, size_t data_pad, void *output, size_t output_len,
+                            size_t output_pad)
+{
+    struct epic_service_call *call;
+    void *bfr;
+    size_t bfr_len = max(data_len + data_pad, output_len + output_pad) + sizeof(*call);
+    int ret;
+    u32 retlen;
+    size_t rx_len = bfr_len;
+
+    bfr = calloc(bfr_len, 1);
+    if (!bfr)
+        return -1;
+
+    call = bfr;
+    call->group = group;
+    call->command = command;
+    call->data_len = data_len + data_pad;
+    call->magic = EPIC_SERVICE_CALL_MAGIC;
+
+    memcpy(bfr + sizeof(*call), data, data_len);
+
+    ret = afk_epic_command(service->epic, service->channel, SUBTYPE_STD_SERVICE, bfr, bfr_len, bfr,
+                           &rx_len);
+    if (ret)
+        goto out;
+
+    if (call->magic != EPIC_SERVICE_CALL_MAGIC || call->group != group ||
+        call->command != command) {
+        ret = -1;
+        goto out;
+    }
+
+    retlen = call->data_len;
+    if (output_len < retlen)
+        retlen = output_len;
+    if (output && output_len) {
+        memset(output, 0, output_len);
+        memcpy(output, bfr + sizeof(*call), retlen);
+    }
+
+out:
+    free(bfr);
+    return ret;
+}
+
+int dptxport_validate_connection(afk_epic_service_t *service, u8 core, u8 atc, u8 die)
+{
+    struct dcpdptx_connection_cmd cmd, resp;
+    int ret;
+    u32 target = FIELD_PREP(DCPDPTX_REMOTE_PORT_CORE, core) |
+                 FIELD_PREP(DCPDPTX_REMOTE_PORT_DFP, atc) |
+                 FIELD_PREP(DCPDPTX_REMOTE_PORT_DIE, die) | DCPDPTX_REMOTE_PORT_CONNECTED;
+
+    cmd.target = target;
+    cmd.unk = 0x100;
+    ret = afk_service_call(service, 0, 12, &cmd, sizeof(cmd), 40, &resp, sizeof(resp), 40);
+    if (ret)
+        return ret;
+
+    if (resp.target != target)
+        return -1;
+    if (resp.unk != 0x100)
+        return -1;
+
+    return 0;
+}
+
+int dptxport_connect(afk_epic_service_t *service, u8 core, u8 atc, u8 die)
+{
+    struct dcpdptx_connection_cmd cmd = {0}, resp = {0};
+    int ret;
+    u32 target = FIELD_PREP(DCPDPTX_REMOTE_PORT_CORE, core) |
+                 FIELD_PREP(DCPDPTX_REMOTE_PORT_DFP, atc) |
+                 FIELD_PREP(DCPDPTX_REMOTE_PORT_DIE, die) | DCPDPTX_REMOTE_PORT_CONNECTED;
+
+    cmd.target = target;
+    // cmd.unk = 0x100;
+    ret = afk_service_call(service, 0, 11, &cmd, sizeof(cmd), 24, &resp, sizeof(resp), 24);
+    if (ret)
+        return ret;
+
+    if (resp.target != target)
+        return -1;
+    if (resp.unk != 0x100)
+        return -1;
+
+    return 0;
+}
+
+int dptxport_request_display(afk_epic_service_t *service)
+{
+    return afk_service_call(service, 0, 6, NULL, 0, 16, NULL, 0, 16);
+}
+
+int dptxport_release_display(afk_epic_service_t *service)
+{
+    return afk_service_call(service, 0, 7, NULL, 0, 16, NULL, 0, 16);
+}
+
+int dptxport_set_hpd(afk_epic_service_t *service, bool hpd)
+{
+    struct dcpdptx_hotplug_cmd cmd, resp;
+    int ret;
+
+    memset(&cmd, 0, sizeof(cmd));
+
+    if (hpd)
+        cmd.unk = 1;
+
+    ret = afk_service_call(service, 8, 8, &cmd, sizeof(cmd), 12, &resp, sizeof(resp), 12);
+    if (ret)
+        return ret;
+    if (resp.unk != 1)
+        return -1;
+    return 0;
+}
+
+static int dptxport_call_get_max_drive_settings(afk_epic_service_t *service, void *reply_,
+                                                size_t reply_size)
+{
+    UNUSED(service);
+    struct dptxport_apcall_max_drive_settings *reply = reply_;
+
+    if (reply_size < sizeof(*reply))
+        return -1;
+
+    reply->retcode = 0;
+    reply->max_drive_settings[0] = 0x3;
+    reply->max_drive_settings[1] = 0x3;
+
+    return 0;
+}
+
+static int dptxport_call_get_max_link_rate(afk_epic_service_t *service, void *reply_,
+                                           size_t reply_size)
+{
+    UNUSED(service);
+    struct dptxport_apcall_link_rate *reply = reply_;
+
+    if (reply_size < sizeof(*reply))
+        return -1;
+
+    reply->retcode = 0;
+    reply->link_rate = LINK_RATE_HBR3;
+
+    return 0;
+}
+
+static int dptxport_call_get_max_lane_count(afk_epic_service_t *service, void *reply_,
+                                            size_t reply_size)
+{
+    UNUSED(service);
+    struct dptxport_apcall_lane_count *reply = reply_;
+
+    if (reply_size < sizeof(*reply))
+        return -1;
+
+    reply->retcode = 0;
+    reply->lane_count = 4;
+
+    return 0;
+}
+
+static int dptxport_call_set_active_lane_count(afk_epic_service_t *service, const void *data,
+                                               size_t data_size, void *reply_, size_t reply_size)
+{
+    struct dptx_port *port = service->cookie;
+    const struct dptxport_apcall_set_active_lane_count *request = data;
+    struct dptxport_apcall_set_active_lane_count *reply = reply_;
+    int ret = 0;
+    int retcode = 0;
+
+    if (reply_size < sizeof(*reply))
+        return -1;
+    if (data_size < sizeof(*request))
+        return -1;
+
+    u64 lane_count = request->lane_count;
+
+    switch (lane_count) {
+        case 0 ... 2:
+        case 4:
+            ret = dptx_phy_set_active_lane_count(port->phy, lane_count);
+            break;
+        default:
+            printf("DPTX-PORT: set_active_lane_count: invalid lane count:%lu\n", lane_count);
+            retcode = 1;
+            lane_count = 0;
+            break;
+    }
+
+    reply->retcode = retcode;
+    reply->lane_count = lane_count;
+
+    return ret;
+}
+
+static int dptxport_call_get_link_rate(afk_epic_service_t *service, void *reply_, size_t reply_size)
+{
+    struct dptx_port *port = service->cookie;
+    struct dptxport_apcall_link_rate *reply = reply_;
+
+    if (reply_size < sizeof(*reply))
+        return -1;
+
+    reply->retcode = 0;
+    reply->link_rate = port->link_rate;
+
+    return 0;
+}
+
+static int dptxport_call_will_change_link_config(afk_epic_service_t *service)
+{
+    UNUSED(service);
+    return 0;
+}
+
+static int dptxport_call_did_change_link_config(afk_epic_service_t *service)
+{
+    UNUSED(service);
+    // struct dptx_port *dptx = service->intf;
+    // int ret = 0;
+
+    mdelay(100);
+    // dispext0,0 -> atcph1,dpphy
+    // mux_control_select(dptx->mux, 0);
+
+    return 0;
+}
+
+static int dptxport_call_set_link_rate(afk_epic_service_t *service, const void *data,
+                                       size_t data_size, void *reply_, size_t reply_size)
+{
+    dptx_port_t *port = service->cookie;
+    const struct dptxport_apcall_link_rate *request = data;
+    struct dptxport_apcall_link_rate *reply = reply_;
+    u32 link_rate, phy_link_rate;
+    bool phy_set_rate = false;
+
+    if (reply_size < sizeof(*reply))
+        return -1;
+    if (data_size < sizeof(*request))
+        return -1;
+
+    link_rate = request->link_rate;
+
+    switch (link_rate) {
+        case LINK_RATE_RBR:
+            phy_link_rate = 1620;
+            phy_set_rate = true;
+            break;
+        case LINK_RATE_HBR:
+            phy_link_rate = 2700;
+            phy_set_rate = true;
+            break;
+        case LINK_RATE_HBR2:
+            phy_link_rate = 5400;
+            phy_set_rate = true;
+            break;
+        case LINK_RATE_HBR3:
+            phy_link_rate = 8100;
+            phy_set_rate = true;
+            break;
+        case 0:
+            phy_link_rate = 0;
+            phy_set_rate = true;
+            break;
+        default:
+            printf("DPTXPort: Unsupported link rate 0x%x requested\n", link_rate);
+            link_rate = 0;
+            phy_set_rate = false;
+            break;
+    }
+
+    if (phy_set_rate) {
+        dptx_phy_set_link_rate(port->phy, phy_link_rate);
+
+        port->link_rate = port->pending_link_rate = link_rate;
+    }
+
+    // dptx->pending_link_rate = link_rate;
+    reply->retcode = 0;
+    reply->link_rate = link_rate;
+
+    return 0;
+}
+
+static int dptxport_call_get_supports_hpd(afk_epic_service_t *service, void *reply_,
+                                          size_t reply_size)
+{
+    UNUSED(service);
+    struct dptxport_apcall_get_support *reply = reply_;
+
+    if (reply_size < sizeof(*reply))
+        return -1;
+
+    reply->retcode = 0;
+    reply->supported = 0;
+    return 0;
+}
+
+static int dptxport_call_get_supports_downspread(afk_epic_service_t *service, void *reply_,
+                                                 size_t reply_size)
+{
+    UNUSED(service);
+    struct dptxport_apcall_get_support *reply = reply_;
+
+    if (reply_size < sizeof(*reply))
+        return -1;
+
+    reply->retcode = 0;
+    reply->supported = 0;
+    return 0;
+}
+
+static int dptxport_call_set_tiled_display_hint(afk_epic_service_t *service, void *reply_,
+                                                size_t reply_size)
+{
+    UNUSED(service);
+    struct dptxport_apcall_set_tiled *reply = reply_;
+
+    if (reply_size < sizeof(*reply))
+        return -1;
+
+    reply->retcode = 1;
+    return 0;
+}
+
+static int dptxport_call(afk_epic_service_t *service, u32 idx, const void *data, size_t data_size,
+                         void *reply, size_t reply_size)
+{
+    dcp_dptx_if_t *dptx = (dcp_dptx_if_t *)service->intf;
+
+    switch (idx) {
+        case DPTX_APCALL_WILL_CHANGE_LINKG_CONFIG:
+            return dptxport_call_will_change_link_config(service);
+        case DPTX_APCALL_DID_CHANGE_LINK_CONFIG:
+            return dptxport_call_did_change_link_config(service);
+        case DPTX_APCALL_GET_MAX_LINK_RATE:
+            return dptxport_call_get_max_link_rate(service, reply, reply_size);
+        case DPTX_APCALL_GET_LINK_RATE:
+            return dptxport_call_get_link_rate(service, reply, reply_size);
+        case DPTX_APCALL_SET_LINK_RATE:
+            return dptxport_call_set_link_rate(service, data, data_size, reply, reply_size);
+        case DPTX_APCALL_GET_MAX_LANE_COUNT:
+            return dptxport_call_get_max_lane_count(service, reply, reply_size);
+        case DPTX_APCALL_SET_ACTIVE_LANE_COUNT:
+            return dptxport_call_set_active_lane_count(service, data, data_size, reply, reply_size);
+        case DPTX_APCALL_GET_SUPPORTS_HPD:
+            return dptxport_call_get_supports_hpd(service, reply, reply_size);
+        case DPTX_APCALL_GET_SUPPORTS_DOWN_SPREAD:
+            return dptxport_call_get_supports_downspread(service, reply, reply_size);
+        case DPTX_APCALL_GET_MAX_DRIVE_SETTINGS:
+            return dptxport_call_get_max_drive_settings(service, reply, reply_size);
+        case DPTX_APCALL_SET_TILED_DISPLAY_HINTS:
+            memcpy(reply, data, min(reply_size, data_size));
+            return dptxport_call_set_tiled_display_hint(service, reply, reply_size);
+        case DPTX_APCALL_ACTIVATE:
+            dptx_phy_activate(dptx->phy);
+            memcpy(reply, data, min(reply_size, data_size));
+            if (reply_size > 4)
+                memset(reply, 0, 4);
+            return 0;
+        default:
+            /* just try to ACK and hope for the best... */
+            printf("DPTXPort: unhandled call %d\n", idx);
+            // fallthrough
+        /* we can silently ignore and just ACK these calls */
+        case DPTX_APCALL_DEACTIVATE:
+        case DPTX_APCALL_SET_DRIVE_SETTINGS:
+        case DPTX_APCALL_GET_DRIVE_SETTINGS:
+            memcpy(reply, data, min(reply_size, data_size));
+            if (reply_size > 4)
+                memset(reply, 0, 4);
+            return 0;
+    }
+}
+
+static void dptxport_init(afk_epic_service_t *service, const char *name, const char *eclass,
+                          s64 unit)
+{
+    dcp_dptx_if_t *dptx = (dcp_dptx_if_t *)service->intf;
+
+    if (strcmp(name, "dcpdptx-port-epic"))
+        return;
+    if (strcmp(eclass, "AppleDCPDPTXRemotePort"))
+        return;
+
+    switch (unit) {
+        case 0:
+        case 1:
+            if (dptx->port[unit].enabled) {
+                printf("DPTXPort: unit %ld already exists\n", unit);
+                return;
+            }
+            dptx->port[unit].unit = unit;
+            dptx->port[unit].service = service;
+            dptx->port[unit].enabled = true;
+            service->cookie = (void *)&dptx->port[unit];
+            break;
+        default:
+            printf("DPTXPort: invalid unit %ld\n", unit);
+            return;
+    }
+}
+
+static const afk_epic_service_ops_t dcp_dptx_ops[] = {
+    {
+        .name = "AppleDCPDPTXRemotePort",
+        .init = dptxport_init,
+        .call = dptxport_call,
+    },
+    {},
+};
+
+int dcp_dptx_connect(dcp_dptx_if_t *dptx, dptx_phy_t *phy, u32 port)
+{
+    if (port > 1)
+        return -1;
+    if (!dptx->port[port].service) {
+        printf("DPTXPort: port %u not initialized. enabled:%d\n", port, dptx->port[port].enabled);
+        return -1;
+    }
+
+    dptx->port[port].phy = dptx->phy = phy;
+
+    dptxport_connect(dptx->port[port].service, 0, dptx_phy_dcp_output(phy), 0);
+    dptxport_request_display(dptx->port[port].service);
+
+    return 0;
+}
+
+int dcp_dptx_hpd(dcp_dptx_if_t *dptx, u32 port, bool hpd)
+{
+    if (!dptx->port[port].service)
+        return -1;
+
+    dptxport_set_hpd(dptx->port[port].service, hpd);
+
+    return 0;
+}
+
+int dcp_dptx_disconnect(dcp_dptx_if_t *dptx, u32 port)
+{
+    dptxport_release_display(dptx->port[port].service);
+    dptxport_set_hpd(dptx->port[port].service, false);
+
+    return 0;
+}
+
+dcp_dptx_if_t *dcp_dptx_init(dcp_dev_t *dcp)
+{
+    dcp_dptx_if_t *dptx = calloc(1, sizeof(dcp_dptx_if_t));
+    if (!dptx)
+        return NULL;
+
+    dptx->dcp = dcp;
+    dptx->epic = afk_epic_start_ep(dcp->afk, DCP_DPTX_PORT_ENDPOINT, dcp_dptx_ops, true);
+    if (!dptx->epic) {
+        printf("dcp-dptx: failed to initialize EPIC\n");
+        goto err_free;
+    }
+
+    int err = afk_epic_start_interface(dptx->epic, dptx, TXBUF_LEN, RXBUF_LEN);
+    if (err < 0) {
+        printf("dcp-dptx: failed to initialize DPTXRemotePort interface\n");
+        goto err_shutdown;
+    }
+
+    return dptx;
+
+err_shutdown:
+    afk_epic_shutdown_ep(dptx->epic);
+err_free:
+    free(dptx);
+    return NULL;
+}
+
+int dcp_dptx_shutdown(dcp_dptx_if_t *dptx)
+{
+    if (dptx) {
+        afk_epic_shutdown_ep(dptx->epic);
+        free(dptx);
+    }
+    return 0;
+}

--- a/src/dcp/dptx_port_ep.h
+++ b/src/dcp/dptx_port_ep.h
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+/* Copyright 2022 Sven Peter <sven@svenpeter.dev> */
+
+#ifndef __APPLE_DCP_DPTX_PORT_EP_H__
+#define __APPLE_DCP_DPTX_PORT_EP_H__
+
+#include "../types.h"
+
+typedef struct dcp_dev dcp_dev_t;
+
+typedef struct dptx_phy dptx_phy_t;
+
+typedef struct dcp_dptx_if dcp_dptx_if_t;
+
+enum dptx_apcall {
+    DPTX_APCALL_ACTIVATE = 0,
+    DPTX_APCALL_DEACTIVATE = 1,
+    DPTX_APCALL_GET_MAX_DRIVE_SETTINGS = 2,
+    DPTX_APCALL_SET_DRIVE_SETTINGS = 3,
+    DPTX_APCALL_GET_DRIVE_SETTINGS = 4,
+    DPTX_APCALL_WILL_CHANGE_LINKG_CONFIG = 5,
+    DPTX_APCALL_DID_CHANGE_LINK_CONFIG = 6,
+    DPTX_APCALL_GET_MAX_LINK_RATE = 7,
+    DPTX_APCALL_GET_LINK_RATE = 8,
+    DPTX_APCALL_SET_LINK_RATE = 9,
+    DPTX_APCALL_GET_MAX_LANE_COUNT = 10,
+    DPTX_APCALL_GET_ACTIVE_LANE_COUNT = 11,
+    DPTX_APCALL_SET_ACTIVE_LANE_COUNT = 12,
+    DPTX_APCALL_GET_SUPPORTS_DOWN_SPREAD = 13,
+    DPTX_APCALL_GET_DOWN_SPREAD = 14,
+    DPTX_APCALL_SET_DOWN_SPREAD = 15,
+    DPTX_APCALL_GET_SUPPORTS_LANE_MAPPING = 16,
+    DPTX_APCALL_SET_LANE_MAP = 17,
+    DPTX_APCALL_GET_SUPPORTS_HPD = 18,
+    DPTX_APCALL_FORCE_HOTPLUG_DETECT = 19,
+    DPTX_APCALL_INACTIVE_SINK_DETECTED = 20,
+    DPTX_APCALL_SET_TILED_DISPLAY_HINTS = 21,
+    DPTX_APCALL_DEVICE_NOT_RESPONDING = 22,
+    DPTX_APCALL_DEVICE_BUSY_TIMEOUT = 23,
+    DPTX_APCALL_DEVICE_NOT_STARTED = 24,
+};
+
+#define DCPDPTX_REMOTE_PORT_CORE      GENMASK(3, 0)
+#define DCPDPTX_REMOTE_PORT_DFP       GENMASK(7, 4)
+#define DCPDPTX_REMOTE_PORT_DIE       GENMASK(11, 8)
+#define DCPDPTX_REMOTE_PORT_CONNECTED BIT(15)
+
+enum dptx_link_rate {
+    LINK_RATE_RBR = 0x06,
+    LINK_RATE_HBR = 0x0a,
+    LINK_RATE_HBR2 = 0x14,
+    LINK_RATE_HBR3 = 0x1e,
+};
+
+dcp_dptx_if_t *dcp_dptx_init(dcp_dev_t *dcp);
+int dcp_dptx_shutdown(dcp_dptx_if_t *dptx);
+
+int dcp_dptx_connect(dcp_dptx_if_t *dptx, dptx_phy_t *phy, u32 port);
+int dcp_dptx_hpd(dcp_dptx_if_t *dptx, u32 port, bool hpd);
+int dcp_dptx_disconnect(dcp_dptx_if_t *dptx, u32 port);
+int dcp_dptx_hpd(dcp_dptx_if_t *dptx, u32 port, bool hpd);
+
+#endif

--- a/src/dcp/parser.c
+++ b/src/dcp/parser.c
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+/* Copyright 2021 Alyssa Rosenzweig <alyssa@rosenzweig.io> */
+
+#include "malloc.h"
+#include "parser.h"
+#include "string.h"
+
+#include "../utils.h"
+
+#define DCP_PARSE_HEADER 0xd3
+
+enum dcp_parse_type {
+    DCP_TYPE_DICTIONARY = 1,
+    DCP_TYPE_ARRAY = 2,
+    DCP_TYPE_INT64 = 4,
+    DCP_TYPE_STRING = 9,
+    DCP_TYPE_BLOB = 10,
+    DCP_TYPE_BOOL = 11
+};
+
+struct dcp_parse_tag {
+    unsigned int size : 24;
+    enum dcp_parse_type type : 5;
+    unsigned int padding : 2;
+    bool last : 1;
+} __packed;
+
+static void *parse_bytes(struct dcp_parse_ctx *ctx, size_t count)
+{
+    void *ptr = ctx->blob + ctx->pos;
+
+    if (ctx->pos + count > ctx->len)
+        return NULL;
+
+    ctx->pos += count;
+    return ptr;
+}
+
+static u32 *parse_u32(struct dcp_parse_ctx *ctx)
+{
+    return parse_bytes(ctx, sizeof(u32));
+}
+
+static struct dcp_parse_tag *parse_tag(struct dcp_parse_ctx *ctx)
+{
+    struct dcp_parse_tag *tag;
+
+    /* Align to 32-bits */
+    ctx->pos = ALIGN_UP(ctx->pos, 4);
+
+    tag = parse_bytes(ctx, sizeof(struct dcp_parse_tag));
+
+    if (!tag)
+        return NULL;
+
+    if (tag->padding)
+        return NULL;
+
+    return tag;
+}
+
+static struct dcp_parse_tag *parse_tag_of_type(struct dcp_parse_ctx *ctx, enum dcp_parse_type type)
+{
+    struct dcp_parse_tag *tag = parse_tag(ctx);
+
+    if (!tag)
+        return NULL;
+
+    if (tag->type != type)
+        return NULL;
+
+    return tag;
+}
+
+static int skip(struct dcp_parse_ctx *handle)
+{
+    struct dcp_parse_tag *tag = parse_tag(handle);
+    int ret = 0;
+    int i;
+
+    if (!tag)
+        return -1;
+
+    switch (tag->type) {
+        case DCP_TYPE_DICTIONARY:
+            for (i = 0; i < tag->size; ++i) {
+                ret |= skip(handle); /* key */
+                ret |= skip(handle); /* value */
+            }
+
+            return ret;
+
+        case DCP_TYPE_ARRAY:
+            for (i = 0; i < tag->size; ++i)
+                ret |= skip(handle);
+
+            return ret;
+
+        case DCP_TYPE_INT64:
+            handle->pos += sizeof(s64);
+            return 0;
+
+        case DCP_TYPE_STRING:
+        case DCP_TYPE_BLOB:
+            handle->pos += tag->size;
+            return 0;
+
+        case DCP_TYPE_BOOL:
+            return 0;
+
+        default:
+            return -1;
+    }
+}
+
+/* Caller must free the result */
+static char *parse_string(struct dcp_parse_ctx *handle)
+{
+    struct dcp_parse_tag *tag = parse_tag_of_type(handle, DCP_TYPE_STRING);
+    const char *in;
+    char *out;
+
+    if (!tag)
+        return NULL;
+
+    in = parse_bytes(handle, tag->size);
+    if (!in)
+        return NULL;
+
+    out = malloc(tag->size + 1);
+
+    memcpy(out, in, tag->size);
+    out[tag->size] = '\0';
+    return out;
+}
+
+static int parse_int(struct dcp_parse_ctx *handle, s64 *value)
+{
+    void *tag = parse_tag_of_type(handle, DCP_TYPE_INT64);
+    s64 *in;
+
+    if (!tag)
+        return -1;
+
+    in = parse_bytes(handle, sizeof(s64));
+
+    if (!in)
+        return -1;
+
+    memcpy(value, in, sizeof(*value));
+    return 0;
+}
+
+// currently unused
+#if 0
+static int parse_bool(struct dcp_parse_ctx *handle, bool *b)
+{
+    struct dcp_parse_tag *tag = parse_tag_of_type(handle, DCP_TYPE_BOOL);
+
+    if (!tag)
+        return -1;
+
+    *b = !!tag->size;
+    return 0;
+}
+#endif
+
+struct iterator {
+    struct dcp_parse_ctx *handle;
+    u32 idx, len;
+};
+
+static int iterator_begin(struct dcp_parse_ctx *handle, struct iterator *it, bool dict)
+{
+    struct dcp_parse_tag *tag;
+    enum dcp_parse_type type = dict ? DCP_TYPE_DICTIONARY : DCP_TYPE_ARRAY;
+
+    *it = (struct iterator){.handle = handle, .idx = 0};
+
+    tag = parse_tag_of_type(it->handle, type);
+    if (!tag)
+        return -1;
+
+    it->len = tag->size;
+    return 0;
+}
+
+#define dcp_parse_foreach_in_array(handle, it)                                                     \
+    for (iterator_begin(handle, &it, false); it.idx < it.len; ++it.idx)
+#define dcp_parse_foreach_in_dict(handle, it)                                                      \
+    for (iterator_begin(handle, &it, true); it.idx < it.len; ++it.idx)
+
+int parse(void *blob, size_t size, struct dcp_parse_ctx *ctx)
+{
+    u32 *header;
+
+    *ctx = (struct dcp_parse_ctx){
+        .blob = blob,
+        .len = size,
+        .pos = 0,
+    };
+
+    header = parse_u32(ctx);
+    if (!header)
+        return -1;
+
+    if (*header != DCP_PARSE_HEADER)
+        return -1;
+
+    return 0;
+}
+
+int parse_epic_service_init(struct dcp_parse_ctx *handle, char **name, char **class, s64 *unit)
+{
+    int ret = 0;
+    struct iterator it;
+    bool parsed_unit = false;
+    bool parsed_name = false;
+    bool parsed_class = false;
+
+    *name = NULL;
+    *class = NULL;
+
+    dcp_parse_foreach_in_dict(handle, it)
+    {
+        char *key = parse_string(it.handle);
+
+        if (!key) {
+            ret = -1;
+            break;
+        }
+
+        if (!strcmp(key, "EPICName")) {
+            *name = parse_string(it.handle);
+            if (!*name)
+                ret = -1;
+            else
+                parsed_name = true;
+        } else if (!strcmp(key, "EPICProviderClass")) {
+            *class = parse_string(it.handle);
+            if (!*class)
+                ret = -1;
+            else
+                parsed_class = true;
+        } else if (!strcmp(key, "EPICUnit")) {
+            ret = parse_int(it.handle, unit);
+            if (!ret)
+                parsed_unit = true;
+        } else {
+            skip(it.handle);
+        }
+
+        free(key);
+        if (ret)
+            break;
+    }
+
+    if (!parsed_unit || !parsed_name || !parsed_class)
+        ret = -1;
+
+    if (ret) {
+        if (*name) {
+            free(*name);
+            *name = NULL;
+        }
+        if (*class) {
+            free(*class);
+            *class = NULL;
+        }
+    }
+
+    return ret;
+}

--- a/src/dcp/parser.h
+++ b/src/dcp/parser.h
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+/* Copyright 2021 Alyssa Rosenzweig <alyssa@rosenzweig.io> */
+
+#ifndef __APPLE_DCP_PARSER_H__
+#define __APPLE_DCP_PARSER_H__
+
+#include "../types.h"
+
+struct dcp_parse_ctx {
+    void *blob;
+    u32 pos, len;
+};
+
+int parse(void *blob, size_t size, struct dcp_parse_ctx *ctx);
+
+int parse_epic_service_init(struct dcp_parse_ctx *handle, char **name, char **class, s64 *unit);
+
+#endif

--- a/src/dcp/system_ep.c
+++ b/src/dcp/system_ep.c
@@ -1,0 +1,147 @@
+
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+/* Copyright 2022 Sven Peter <sven@svenpeter.dev> */
+
+#include <stdbool.h>
+#include <string.h>
+
+#include "system_ep.h"
+#include "malloc.h"
+#include "parser.h"
+
+#include "../afk.h"
+#include "../dcp.h"
+#include "../types.h"
+#include "../utils.h"
+
+#define DCP_SYSTEM_ENDPOINT 0x20
+#define TXBUF_LEN           0x4000
+#define RXBUF_LEN           0x4000
+
+typedef struct dcp_system_if {
+    afk_epic_ep_t *epic;
+    dcp_dev_t *dcp;
+
+    afk_epic_service_t *sys_service;
+    afk_epic_service_t *powerlog;
+} dcp_system_if_t;
+
+static void system_service_init(afk_epic_service_t *service, const char *name, const char *eclass,
+                                s64 unit)
+{
+    UNUSED(name);
+    UNUSED(unit);
+    dcp_system_if_t *system = (dcp_system_if_t *)service->intf;
+    if (strcmp(eclass, "system") == 0) {
+        if (system->sys_service) {
+            printf("SYSTEM[%p]: system services already started!\n", system);
+            return;
+        }
+        system->sys_service = service;
+        service->cookie = system;
+    }
+}
+
+static void powerlog_service_init(afk_epic_service_t *service, const char *name, const char *eclass,
+                                  s64 unit)
+{
+    UNUSED(name);
+    UNUSED(unit);
+    dcp_system_if_t *system = (dcp_system_if_t *)service->intf;
+    if (strcmp(eclass, "powerlog-service") == 0) {
+        if (system->powerlog) {
+            printf("SYSTEM[%p]: powerlog service already started!\n", system);
+            return;
+        }
+        system->powerlog = service;
+        service->cookie = system;
+    }
+}
+
+struct OSSerializedInt {
+    u32 code; // constant little endian 0xd3
+    u32 tag;  // 24 bit size in bits, 8 bit type (constant 4 for integers)
+    u64 value;
+} PACKED;
+
+int dcp_system_set_property_u64(dcp_system_if_t *system, const char *name, u64 value)
+{
+    size_t name_len = strlen(name);
+    u32 aligned_len = ALIGN_UP(name_len, 4);
+    struct OSSerializedInt val = {
+        .code = 0xd3,
+        .tag = 0x80000000 | (4 << 24) | 64,
+        .value = value,
+    };
+    size_t bfr_len = sizeof(aligned_len) + aligned_len + sizeof(val);
+
+    u8 *bfr = calloc(1, bfr_len);
+    if (!bfr)
+        return -1;
+
+    memcpy(bfr, &aligned_len, sizeof(aligned_len));
+    memcpy(bfr + sizeof(aligned_len), name, name_len);
+    memcpy(bfr + sizeof(aligned_len) + aligned_len, &val, sizeof(val));
+
+    afk_epic_service_t *service = system->sys_service;
+    if (!service) {
+        free(bfr);
+        printf("SYSTEM: sys_service-service not started\n");
+        return -1;
+    }
+    int ret = afk_epic_command(service->epic, service->channel, 0x43, bfr, bfr_len, NULL, NULL);
+
+    free(bfr);
+
+    return ret;
+}
+
+static const afk_epic_service_ops_t dcp_system_ops[] = {
+    {
+        .name = "system",
+        .init = system_service_init,
+    },
+    {
+        .name = "powerlog-service",
+        .init = powerlog_service_init,
+    },
+    {},
+};
+
+dcp_system_if_t *dcp_system_init(dcp_dev_t *dcp)
+{
+    dcp_system_if_t *system = calloc(1, sizeof(dcp_system_if_t));
+    if (!system)
+        return NULL;
+
+    system->dcp = dcp;
+    system->epic = afk_epic_start_ep(dcp->afk, DCP_SYSTEM_ENDPOINT, dcp_system_ops, true);
+    if (!system->epic) {
+        // printf("system: failed to initialize EPIC\n");
+        goto err_free;
+    }
+
+    int err = afk_epic_start_interface(system->epic, system, TXBUF_LEN, RXBUF_LEN);
+
+    if (err < 0 || !system->sys_service) {
+        printf("dcp-system: failed to initialize system-service\n");
+        goto err_shutdown;
+    }
+
+    return system;
+
+err_shutdown:
+    afk_epic_shutdown_ep(system->epic);
+err_free:
+    free(system);
+    return NULL;
+}
+
+int dcp_system_shutdown(dcp_system_if_t *system)
+{
+    if (system) {
+        afk_epic_shutdown_ep(system->epic);
+        free(system);
+    }
+    return 0;
+}

--- a/src/dcp/system_ep.h
+++ b/src/dcp/system_ep.h
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+/* Copyright 2023 Janne Grunau <j@jannau.net> */
+
+#ifndef DCP_SYSTEM_EP_H
+#define DCP_SYSTEM_EP_H
+
+#include "../types.h"
+
+typedef struct dcp_dev dcp_dev_t;
+
+typedef struct dcp_system_if dcp_system_if_t;
+
+dcp_system_if_t *dcp_system_init(dcp_dev_t *dcp);
+int dcp_system_set_property_u64(dcp_system_if_t *system, const char *name, u64 value);
+int dcp_system_shutdown(dcp_system_if_t *system);
+
+#endif

--- a/src/dcp_iboot.c
+++ b/src/dcp_iboot.c
@@ -44,6 +44,7 @@ struct dcp_iboot_if {
 };
 
 enum IBootCmd {
+    IBOOT_SET_SURFACE = 1,
     IBOOT_SET_POWER = 2,
     IBOOT_GET_HPD = 3,
     IBOOT_GET_TIMING_MODES = 4,
@@ -144,6 +145,14 @@ static int dcp_ib_cmd(dcp_iboot_if_t *iboot, int op, size_t in_size)
 
     return afk_epic_command(iboot->epic, iboot->channel, 0xc0, iboot->txbuf,
                             sizeof(struct txcmd) + in_size, iboot->rxbuf, &rxsize);
+}
+
+int dcp_ib_set_surface(dcp_iboot_if_t *iboot, dcp_layer_t *layer)
+{
+    dcp_layer_t *cmd = (void *)iboot->txcmd.payload;
+    *cmd = *layer;
+
+    return dcp_ib_cmd(iboot, IBOOT_SET_SURFACE, sizeof(*layer));
 }
 
 int dcp_ib_set_power(dcp_iboot_if_t *iboot, bool power)

--- a/src/dcp_iboot.c
+++ b/src/dcp_iboot.c
@@ -105,7 +105,7 @@ dcp_iboot_if_t *dcp_ib_init(dcp_dev_t *dcp)
         return NULL;
 
     iboot->dcp = dcp;
-    iboot->epic = afk_epic_init(dcp->rtkit, DCP_IBOOT_ENDPOINT);
+    iboot->epic = afk_epic_start_ep(dcp->afk, DCP_IBOOT_ENDPOINT, false);
     if (!iboot->epic) {
         printf("dcp-iboot: failed to initialize EPIC\n");
         goto err_free;
@@ -121,7 +121,7 @@ dcp_iboot_if_t *dcp_ib_init(dcp_dev_t *dcp)
     return iboot;
 
 err_shutdown:
-    afk_epic_shutdown(iboot->epic);
+    afk_epic_shutdown_ep(iboot->epic);
 err_free:
     free(iboot);
     return NULL;
@@ -129,7 +129,7 @@ err_free:
 
 int dcp_ib_shutdown(dcp_iboot_if_t *iboot)
 {
-    afk_epic_shutdown(iboot->epic);
+    afk_epic_shutdown_ep(iboot->epic);
 
     free(iboot);
     return 0;

--- a/src/dcp_iboot.h
+++ b/src/dcp_iboot.h
@@ -98,6 +98,7 @@ typedef struct {
 dcp_iboot_if_t *dcp_ib_init(dcp_dev_t *dcp);
 int dcp_ib_shutdown(dcp_iboot_if_t *iboot);
 
+int dcp_ib_set_surface(dcp_iboot_if_t *iboot, dcp_layer_t *layer);
 int dcp_ib_set_power(dcp_iboot_if_t *iboot, bool power);
 int dcp_ib_get_hpd(dcp_iboot_if_t *iboot, int *timing_cnt, int *color_cnt);
 int dcp_ib_get_timing_modes(dcp_iboot_if_t *iboot, dcp_timing_mode_t **modes);

--- a/src/display.c
+++ b/src/display.c
@@ -250,11 +250,6 @@ int display_parse_mode(const char *config, dcp_timing_mode_t *mode, struct displ
 static int display_swap(u64 iova, u32 stride, u32 width, u32 height)
 {
     int ret;
-    int swap_id = ret = dcp_ib_swap_begin(iboot);
-    if (swap_id < 0) {
-        printf("display: failed to start swap\n");
-        return -1;
-    }
 
     dcp_layer_t layer = {
         .planes = {{
@@ -271,19 +266,12 @@ static int display_swap(u64 iova, u32 stride, u32 width, u32 height)
         .transform = XFRM_NONE,
     };
 
-    dcp_rect_t rect = {width, height, 0, 0};
-
-    if ((ret = dcp_ib_swap_set_layer(iboot, 0, &layer, &rect, &rect)) < 0) {
-        printf("display: failed to set layer\n");
+    if ((ret = dcp_ib_set_surface(iboot, &layer)) < 0) {
+        printf("display: failed to set surface\n");
         return -1;
     }
 
-    if ((ret = dcp_ib_swap_end(iboot)) < 0) {
-        printf("display: failed to complete swap\n");
-        return -1;
-    }
-
-    return swap_id;
+    return 0;
 }
 
 int display_configure(const char *config)

--- a/src/nvme.c
+++ b/src/nvme.c
@@ -335,7 +335,7 @@ bool nvme_init(void)
     if (!nvme_sart)
         goto out_asc;
 
-    nvme_rtkit = rtkit_init("nvme", nvme_asc, NULL, NULL, nvme_sart);
+    nvme_rtkit = rtkit_init("nvme", nvme_asc, NULL, NULL, nvme_sart, false);
     if (!nvme_rtkit)
         goto out_sart;
 
@@ -446,7 +446,7 @@ void nvme_ensure_shutdown(void)
     if (!nvme_sart)
         goto fail;
 
-    nvme_rtkit = rtkit_init("nvme", nvme_asc, NULL, NULL, nvme_sart);
+    nvme_rtkit = rtkit_init("nvme", nvme_asc, NULL, NULL, nvme_sart, false);
     if (!nvme_rtkit)
         goto fail;
 

--- a/src/rtkit.c
+++ b/src/rtkit.c
@@ -345,6 +345,14 @@ static void rtkit_crashed(rtkit_dev_t *rtk)
     }
 }
 
+bool rtkit_can_recv(rtkit_dev_t *rtk)
+{
+    if (rtk->crashed)
+        return false;
+
+    return asc_can_recv(rtk->asc);
+}
+
 int rtkit_recv(rtkit_dev_t *rtk, struct rtkit_message *msg)
 {
     struct asc_message asc_msg;

--- a/src/rtkit.h
+++ b/src/rtkit.h
@@ -31,6 +31,8 @@ void rtkit_free(rtkit_dev_t *rtk);
 bool rtkit_start_ep(rtkit_dev_t *rtk, u8 ep);
 bool rtkit_boot(rtkit_dev_t *rtk);
 
+bool rtkit_can_recv(rtkit_dev_t *rtk);
+
 int rtkit_recv(rtkit_dev_t *rtk, struct rtkit_message *msg);
 bool rtkit_send(rtkit_dev_t *rtk, const struct rtkit_message *msg);
 

--- a/src/rtkit.h
+++ b/src/rtkit.h
@@ -23,7 +23,7 @@ struct rtkit_buffer {
 };
 
 rtkit_dev_t *rtkit_init(const char *name, asc_dev_t *asc, dart_dev_t *dart,
-                        iova_domain_t *dart_iovad, sart_dev_t *sart);
+                        iova_domain_t *dart_iovad, sart_dev_t *sart, bool sram);
 bool rtkit_quiesce(rtkit_dev_t *rtk);
 bool rtkit_sleep(rtkit_dev_t *rtk);
 void rtkit_free(rtkit_dev_t *rtk);

--- a/src/smc.c
+++ b/src/smc.c
@@ -1,0 +1,181 @@
+/* SPDX-License-Identifier: MIT */
+
+#include "assert.h"
+#include "malloc.h"
+#include "smc.h"
+#include "string.h"
+#include "types.h"
+#include "utils.h"
+
+#define SMC_READ_KEY         0x10
+#define SMC_WRITE_KEY        0x11
+#define SMC_GET_KEY_BY_INDEX 0x12
+#define SMC_GET_KEY_INFO     0x13
+#define SMC_INITIALIZE       0x17
+#define SMC_NOTIFICATION     0x18
+#define SMC_RW_KEY           0x20
+
+#define SMC_MSG_TYPE GENMASK(7, 0)
+#define SMC_MSG_ID   GENMASK(15, 12)
+
+#define SMC_WRITE_KEY_SIZE GENMASK(23, 16)
+#define SMC_WRITE_KEY_KEY  GENMASK(63, 32)
+
+#define SMC_RESULT_RESULT GENMASK(7, 0)
+#define SMC_RESULT_ID     GENMASK(15, 12)
+#define SMC_RESULT_SIZE   GENMASK(31, 16)
+#define SMC_RESULT_VALUE  GENMASK(63, 32)
+
+#define SMC_NUM_IDS 16
+
+#define SMC_ENDPOINT 0x20
+
+struct smc_dev {
+    asc_dev_t *asc;
+    rtkit_dev_t *rtkit;
+
+    void *shmem;
+    u32 msgid;
+
+    bool outstanding[SMC_NUM_IDS];
+    u64 ret[SMC_NUM_IDS];
+};
+
+static void smc_handle_msg(smc_dev_t *smc, u64 msg)
+{
+    if (!smc->shmem)
+        smc->shmem = (void *)msg;
+    else {
+        u8 result = FIELD_GET(SMC_RESULT_RESULT, msg);
+        u8 id = FIELD_GET(SMC_RESULT_ID, msg);
+        if (result == SMC_NOTIFICATION) {
+            printf("SMC: Notification: 0x%08lx\n", FIELD_GET(SMC_RESULT_VALUE, msg));
+            return;
+        }
+        smc->outstanding[id] = false;
+        smc->ret[id] = msg;
+    }
+}
+
+static int smc_work(smc_dev_t *smc)
+{
+    int ret;
+    struct rtkit_message msg;
+
+    while ((ret = rtkit_recv(smc->rtkit, &msg)) == 0)
+        ;
+
+    if (ret < 0) {
+        printf("SMC: rtkit_recv failed!\n");
+        return ret;
+    }
+
+    if (msg.ep != SMC_ENDPOINT) {
+        printf("SMC: received message for unexpected endpoint 0x%02x\n", msg.ep);
+        return 0;
+    }
+
+    smc_handle_msg(smc, msg.msg);
+
+    return 0;
+}
+
+static void smc_send(smc_dev_t *smc, u64 message)
+{
+    struct rtkit_message msg;
+
+    msg.ep = SMC_ENDPOINT;
+    msg.msg = message;
+
+    rtkit_send(smc->rtkit, &msg);
+}
+
+static int smc_cmd(smc_dev_t *smc, u64 message)
+{
+    u8 id = smc->msgid++ & 0xF;
+    assert(!smc->outstanding[id]);
+    smc->outstanding[id] = true;
+
+    message |= FIELD_PREP(SMC_MSG_ID, id);
+
+    smc_send(smc, message);
+    while (smc->outstanding[id])
+        smc_work(smc);
+
+    u64 result = smc->ret[id];
+    u32 ret = FIELD_GET(SMC_RESULT_RESULT, result);
+    if (ret) {
+        printf("SMC: smc_cmd[0x%x] failed: %u\n", id, ret);
+        return ret;
+    }
+
+    return 0;
+}
+
+void smc_shutdown(smc_dev_t *smc)
+{
+    rtkit_quiesce(smc->rtkit);
+    rtkit_free(smc->rtkit);
+    asc_free(smc->asc);
+    free(smc);
+}
+
+smc_dev_t *smc_init()
+{
+    smc_dev_t *smc = calloc(1, sizeof(smc_dev_t));
+    if (!smc)
+        return NULL;
+
+    smc->asc = asc_init("/arm-io/smc");
+    if (!smc->asc) {
+        printf("SMC: failed to initialize ASC\n");
+        goto out_free;
+    }
+
+    smc->rtkit = rtkit_init("smc", smc->asc, NULL, NULL, NULL, true);
+    if (!smc->rtkit) {
+        printf("SMC: failed to initialize RTKit\n");
+        goto out_asc;
+    }
+
+    if (!rtkit_boot(smc->rtkit)) {
+        printf("SMC: failed to boot RTKit\n");
+        goto out_rtkit;
+    }
+
+    if (!rtkit_start_ep(smc->rtkit, SMC_ENDPOINT)) {
+        printf("SMC: failed start SMC endpoint\n");
+        goto out_rtkit;
+    }
+
+    u64 initialize =
+        FIELD_PREP(SMC_MSG_TYPE, SMC_INITIALIZE) | FIELD_PREP(SMC_MSG_ID, smc->msgid++);
+
+    smc_send(smc, initialize);
+
+    while (!smc->shmem) {
+        int ret = smc_work(smc);
+        if (ret < 0)
+            goto out_rtkit;
+    }
+
+    return smc;
+
+out_rtkit:
+    rtkit_free(smc->rtkit);
+out_asc:
+    asc_free(smc->asc);
+out_free:
+    free(smc);
+    return NULL;
+}
+
+int smc_write_u32(smc_dev_t *smc, u32 key, u32 value)
+{
+    memcpy(smc->shmem, &value, sizeof(value));
+    u64 msg = FIELD_PREP(SMC_MSG_TYPE, SMC_WRITE_KEY);
+    msg |= FIELD_PREP(SMC_WRITE_KEY_SIZE, sizeof(value));
+    msg |= FIELD_PREP(SMC_WRITE_KEY_KEY, key);
+
+    return smc_cmd(smc, msg);
+}

--- a/src/smc.h
+++ b/src/smc.h
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: MIT */
+
+#ifndef SMC_H
+#define SMC_H
+
+#include "asc.h"
+#include "rtkit.h"
+#include "types.h"
+
+typedef struct smc_dev smc_dev_t;
+
+int smc_write_u32(smc_dev_t *smc, u32 key, u32 value);
+
+smc_dev_t *smc_init(void);
+void smc_shutdown(smc_dev_t *smc);
+
+#endif


### PR DESCRIPTION
Initialize the HDMI output of M2+ desktop Macs releases in 2023.

- Mac mini (M2/M2 Pro) and Mac studio (M2 Max) should work (tested on both mini models)
- Mac Pro / studio (M2 Ultra) are different but I would expect it to work as well
- only one HDMI port on the Mac Pro works (the one driven by die 1), no idea which
- high res displays might not work if they require different phy parameters