### PR TITLE
kboot: disable touchbar on missing calibration data

### DIFF
--- a/src/kboot.c
+++ b/src/kboot.c
@@ -671,8 +671,12 @@ static int dt_set_multitouch(void)
 
     u32 len;
     const u8 *cal_blob = adt_getprop(adt, anode, "multi-touch-calibration", &len);
-    if (!cal_blob || !len)
-        bail("ADT: Failed to get multi-touch-calibration\n");
+    if (!cal_blob || !len) {
+        printf("ADT: Failed to get multi-touch-calibration from %s, disable %s\n", adt_touchbar,
+               fdt_get_name(dt, node, NULL));
+        fdt_setprop_string(dt, node, "status", "disabled");
+        return 0;
+    }
 
     fdt_setprop(dt, node, "apple,z2-cal-blob", cal_blob, len);
     return 0;


### PR DESCRIPTION
There is at least on Macbook Pro (M1, 13-inch) with missing "multi-touch-calibration" in the ADT. Disabling the device as error handling instead of refusing to boot the kernel.