### PR TITLE
DPTX: add 25ms delay to make 1st stage display init reliable

### DIFF
--- a/src/afk.c
+++ b/src/afk.c
@@ -394,7 +394,7 @@ int afk_epic_work(afk_epic_t *afk, int endpoint)
                     if (ret < 0) {
                         return ret;
                     }
-                    printf("EPIC[0x%02x]: ignoring message type %d\n", cur->ep, rmsg->type);
+                    dprintf("EPIC[0x%02x]: ignoring message type %d\n", cur->ep, rmsg->type);
                     afk_epic_rx_ack(cur);
                 }
             }
@@ -488,7 +488,7 @@ static int afk_epic_handle_std_service(afk_epic_ep_t *epic, int channel, u8 cate
         return 0;
     }
 
-    printf("AFK: channel %d received unhandled standard service message: %x\n", channel, category);
+    dprintf("AFK: channel %d received unhandled standard service message: %x\n", channel, category);
 
     return -1;
 }
@@ -597,8 +597,8 @@ static void afk_epic_notify_handler(afk_epic_ep_t *epic)
         return;
 
     if (rmsg->type != TYPE_NOTIFY) {
-        printf("EPIC[0x%02x]: got unexpected message type %d in %s\n", epic->ep, rmsg->type,
-               __func__);
+        dprintf("EPIC[0x%02x]: got unexpected message type %d in %s\n", epic->ep, rmsg->type,
+                __func__);
         afk_epic_rx_ack(epic);
         return;
     }
@@ -612,8 +612,8 @@ static void afk_epic_notify_handler(afk_epic_ep_t *epic)
         afk_epic_handle_std_service(epic, rmsg->channel, sub->category, sub->seq, payload,
                                     payload_size);
     } else {
-        printf("EPIC[0x%02x]: %s: rx: Ch %u, Type:0x%02x sub cat:%x type:%x \n", epic->ep, __func__,
-               rmsg->channel, rmsg->type, sub->category, sub->type);
+        dprintf("EPIC[0x%02x]: %s: rx: Ch %u, Type:0x%02x sub cat:%x type:%x \n", epic->ep,
+                __func__, rmsg->channel, rmsg->type, sub->category, sub->type);
     }
 
     afk_epic_rx_ack(epic);
@@ -738,8 +738,8 @@ int afk_epic_start_interface(afk_epic_ep_t *epic, void *intf, size_t txsize, siz
             return ret;
 
         if (msg->type != TYPE_NOTIFY && msg->type != TYPE_REPLY) {
-            printf("AFK[ep:%02x]: got unexpected message type %d during iface start\n", epic->ep,
-                   msg->type);
+            dprintf("AFK[ep:%02x]: got unexpected message type %d during iface start\n", epic->ep,
+                    msg->type);
             afk_epic_rx_ack(epic);
             continue;
         }
@@ -748,8 +748,8 @@ int afk_epic_start_interface(afk_epic_ep_t *epic, void *intf, size_t txsize, siz
         struct epic_sub_hdr *sub = (void *)(hdr + 1);
 
         if (sub->category != CAT_REPORT || sub->type != SUBTYPE_ANNOUNCE) {
-            printf("AFK[ep:%02x]: got unexpected message %02x:%04x during iface start\n", epic->ep,
-                   sub->category, sub->type);
+            dprintf("AFK[ep:%02x]: got unexpected message %02x:%04x during iface start\n", epic->ep,
+                    sub->category, sub->type);
             afk_epic_rx_ack(epic);
             continue;
         }
@@ -805,8 +805,8 @@ int afk_epic_start_interface(afk_epic_ep_t *epic, void *intf, size_t txsize, siz
         service->seq = 0;
 
         ops->init(service, epic_name, service_name, epic_unit);
-        printf("AFK[ep:%02x]: new service %s on channel %d\n", epic->ep, service_name,
-               msg->channel);
+        dprintf("AFK[ep:%02x]: new service %s on channel %d\n", epic->ep, service_name,
+                msg->channel);
         free(epic_name);
         free(epic_class);
 
@@ -829,7 +829,7 @@ int afk_epic_start_interface(afk_epic_ep_t *epic, void *intf, size_t txsize, siz
         return -1;
     }
 
-    printf("AFK[ep:%02x]: started interface with %d services\n", epic->ep, channels);
+    dprintf("AFK[ep:%02x]: started interface with %d services\n", epic->ep, channels);
 
     return 0;
 }

--- a/src/dcp.c
+++ b/src/dcp.c
@@ -118,6 +118,7 @@ dcp_dev_t *dcp_init(const display_config_t *cfg)
         dcp_die = cfg->die;
         pmgr_adt_power_enable(cfg->dcp);
         pmgr_adt_power_enable(cfg->dptx_phy);
+        mdelay(25);
     }
 
     int dart_node = adt_path_offset(adt, cfg->dcp_dart);

--- a/src/dcp/dpav_ep.c
+++ b/src/dcp/dpav_ep.c
@@ -29,7 +29,7 @@ static void dpav_init(afk_epic_service_t *service, const char *name, const char 
     UNUSED(name);
     UNUSED(eclass);
     UNUSED(unit);
-    // printf("DPAV: init(name='%s', class='%s' unit=%ld:\n", name, eclass, unit);
+    dprintf("DPAV: init(name='%s', class='%s' unit=%ld:\n", name, eclass, unit);
 }
 
 static const afk_epic_service_ops_t dcp_dpav_ops[] = {

--- a/src/dcp/dptx_phy.c
+++ b/src/dcp/dptx_phy.c
@@ -209,8 +209,8 @@ int dptx_phy_set_active_lane_count(dptx_phy_t *phy, u32 num_lanes)
 {
     u32 l;
 
-    printf("DPTX-PHY: set_active_lane_count(%u) phy_regs = {0x%lx, 0x%lx}\n", num_lanes,
-           phy->regs[0], phy->regs[1]);
+    dprintf("DPTX-PHY: set_active_lane_count(%u) phy_regs = {0x%lx, 0x%lx}\n", num_lanes,
+            phy->regs[0], phy->regs[1]);
 
     if (num_lanes == 3 || num_lanes > DPTX_MAX_LANES)
         return -1;

--- a/src/dcp/dptx_port_ep.c
+++ b/src/dcp/dptx_port_ep.c
@@ -459,7 +459,7 @@ static int dptxport_call(afk_epic_service_t *service, u32 idx, const void *data,
             return 0;
         default:
             /* just try to ACK and hope for the best... */
-            printf("DPTXPort: unhandled call %d\n", idx);
+            dprintf("DPTXPort: unhandled call %d\n", idx);
             // fallthrough
         /* we can silently ignore and just ACK these calls */
         case DPTX_APCALL_DEACTIVATE:


### PR DESCRIPTION
Fixes display initialization from stage 1 m1n1. 20ms looked reliable on
 j473 but let's add 25% safety margin. Someone with more motivation (and
HW serial) to do repeated `kmutil configure-boot ...` can try to
minimize this and test on t602x

Also silence some afk/dptx printf() by converting them to dprintf().