### PR TITLE
t8112/t602x desktop dptx fixes

### DIFF
--- a/src/afk.h
+++ b/src/afk.h
@@ -43,7 +43,8 @@ afk_epic_ep_t *afk_epic_start_ep(afk_epic_t *afk, int endpoint, const afk_epic_s
 int afk_epic_shutdown_ep(afk_epic_ep_t *epic);
 
 int afk_epic_work(afk_epic_t *afk, int endpoint);
-int afk_epic_start_interface(afk_epic_ep_t *epic, void *intf, size_t insize, size_t outsize);
+int afk_epic_start_interface(afk_epic_ep_t *epic, void *intf, int expected, size_t insize,
+                             size_t outsize);
 int afk_epic_command(afk_epic_ep_t *epic, int channel, u16 sub_type, void *txbuf, size_t txsize,
                      void *rxbuf, size_t *rxsize);
 

--- a/src/dcp/dpav_ep.c
+++ b/src/dcp/dpav_ep.c
@@ -14,9 +14,11 @@
 #include "../types.h"
 #include "../utils.h"
 
-#define DCP_DPAV_ENDPOINT 0x24
-#define TXBUF_LEN         0x4000
-#define RXBUF_LEN         0x4000
+#define DCP_DPAV_ENDPOINT     0x24
+#define DCP_DPAV_NUM_SERVICES 4
+
+#define TXBUF_LEN 0x4000
+#define RXBUF_LEN 0x4000
 
 typedef struct dcp_dpav_if {
     afk_epic_ep_t *epic;
@@ -53,7 +55,8 @@ dcp_dpav_if_t *dcp_dpav_init(dcp_dev_t *dcp)
         goto err_free;
     }
 
-    int err = afk_epic_start_interface(dpav->epic, dpav, TXBUF_LEN, RXBUF_LEN);
+    int err =
+        afk_epic_start_interface(dpav->epic, dpav, DCP_DPAV_NUM_SERVICES, TXBUF_LEN, RXBUF_LEN);
     if (err < 0) {
         printf("dpav: failed to initialize DPAV interface\n");
         goto err_shutdown;

--- a/src/dcp/dptx_port_ep.c
+++ b/src/dcp/dptx_port_ep.c
@@ -13,9 +13,11 @@
 #include "../types.h"
 #include "../utils.h"
 
-#define DCP_DPTX_PORT_ENDPOINT 0x2a
-#define TXBUF_LEN              0x4000
-#define RXBUF_LEN              0x4000
+#define DCP_DPTX_PORT_ENDPOINT     0x2a
+#define DCP_DPTX_PORT_NUM_SERVICES 2
+
+#define TXBUF_LEN 0x4000
+#define RXBUF_LEN 0x4000
 
 struct dcpdptx_connection_cmd {
     u32 unk;
@@ -557,7 +559,8 @@ dcp_dptx_if_t *dcp_dptx_init(dcp_dev_t *dcp)
         goto err_free;
     }
 
-    int err = afk_epic_start_interface(dptx->epic, dptx, TXBUF_LEN, RXBUF_LEN);
+    int err = afk_epic_start_interface(dptx->epic, dptx, DCP_DPTX_PORT_NUM_SERVICES, TXBUF_LEN,
+                                       RXBUF_LEN);
     if (err < 0) {
         printf("dcp-dptx: failed to initialize DPTXRemotePort interface\n");
         goto err_shutdown;

--- a/src/dcp/system_ep.c
+++ b/src/dcp/system_ep.c
@@ -14,9 +14,11 @@
 #include "../types.h"
 #include "../utils.h"
 
-#define DCP_SYSTEM_ENDPOINT 0x20
-#define TXBUF_LEN           0x4000
-#define RXBUF_LEN           0x4000
+#define DCP_SYSTEM_ENDPOINT     0x20
+#define DCP_SYSTEM_NUM_SERVICES 2
+
+#define TXBUF_LEN 0x4000
+#define RXBUF_LEN 0x4000
 
 typedef struct dcp_system_if {
     afk_epic_ep_t *epic;
@@ -121,7 +123,8 @@ dcp_system_if_t *dcp_system_init(dcp_dev_t *dcp)
         goto err_free;
     }
 
-    int err = afk_epic_start_interface(system->epic, system, TXBUF_LEN, RXBUF_LEN);
+    int err = afk_epic_start_interface(system->epic, system, DCP_SYSTEM_NUM_SERVICES, TXBUF_LEN,
+                                       RXBUF_LEN);
 
     if (err < 0 || !system->sys_service) {
         printf("dcp-system: failed to initialize system-service\n");

--- a/src/dcp_iboot.c
+++ b/src/dcp_iboot.c
@@ -8,7 +8,8 @@
 #include "string.h"
 #include "utils.h"
 
-#define DCP_IBOOT_ENDPOINT 0x23
+#define DCP_IBOOT_ENDPOINT     0x23
+#define DCP_IBOOT_NUM_SERVICES 1
 
 #define TXBUF_LEN 0x4000
 #define RXBUF_LEN 0x4000
@@ -137,7 +138,8 @@ dcp_iboot_if_t *dcp_ib_init(dcp_dev_t *dcp)
         goto err_free;
     }
 
-    int err = afk_epic_start_interface(iboot->epic, iboot, TXBUF_LEN, RXBUF_LEN);
+    int err =
+        afk_epic_start_interface(iboot->epic, iboot, DCP_IBOOT_NUM_SERVICES, TXBUF_LEN, RXBUF_LEN);
 
     if (err < 0 || !iboot->enabled) {
         printf("dcp-iboot: failed to initialize disp0 service\n");


### PR DESCRIPTION
- dcp: Fix shutdown sequence on dptx errors
- dcp/afk: Retry harder to init afk endpoints/services