### PR TITLE
 m1n1.adt: introduce yet another DAPFT8110 variant 

### DIFF
--- a/proxyclient/m1n1/adt.py
+++ b/proxyclient/m1n1/adt.py
@@ -232,6 +232,20 @@ DAPFT8110B = Struct(
     "pad" / Hex(Int32ul),
 )
 
+DAPFT8110C = Struct(
+    "start" / Hex(Int64ul),
+    "end" / Hex(Int64ul),
+    "r20" / Hex(Int32ul),
+    "unk1" / Hex(Int32ul),
+    "r4" / Hex(Int32ul),
+    "unk2" / Array(5, Hex(Int32ul)),
+    "unk3" / Hex(Int8ul),
+    "r0h" / Hex(Int8ul),
+    "r0l" / Hex(Int8ul),
+    "unk4" / Hex(Int8ul),
+    "pad" / Array(3, Hex(Int8ul)),
+)
+
 DEV_PROPERTIES = {
     "pmgr": {
         "*": {
@@ -412,7 +426,11 @@ def parse_prop(node, path, node_name, name, v, is_template=False):
         except AttributeError:
             return None, v
         if flags & 0x40:
-            t = GreedyRange(DAPFT8110B)
+            if len(v) % DAPFT8110B.sizeof() == 0:
+                if len(v) % DAPFT8110C.sizeof() != 0:
+                    t = GreedyRange(DAPFT8110B)
+            else:
+                t = GreedyRange(DAPFT8110C)
         else:
             t = GreedyRange(DAPFT8110)
 


### PR DESCRIPTION
When I tried to use the proxyclient shell, I got:
"Exception parsing /device-tree/arm-io/dart-dcp.dapf-instance-0 value […]"

I laid out the hex dump in a text editor, and added line breaks every 56 bytes (the former size of DAPFT8110B):

```
0000703b020000000080713b0200000020000000000000000000000000000000000000000000000000000000000000000003010000000000
40723b020000000080723b020000002000000000000000000000000000000000000000000000000000000000000000000301000000000000
003b020000007f73073b02000000200000000000000000000000000000000000000000000000000000000000000000030100000000000028
3d020000000040283d020000002000000000000000000000000000000000000000000000000000000000000000000301000000000080003d
020000000380003d020000002000000000000000000000000000000000000000000000000000000000000000000301000000000000e03f02
000000ffffef3f0200000020000000000000000000000000000000000000000000000000000000000000000003010000000000c0403e0200
0000ffff403e020000002000000000000000000000000000000000000000000000000000000000000000000301000000000000433e020000
00ff3f433e020000002000000000000000000000000000000000000000000000000000000000000000000301000000000000783d02000000
03417a3d0200000020000000000000000000000000000000000000000000000000000000000000000003010000000000003c3b0200000000
003e3b020000002000000000000000000000000000000000000000000000000000000000000000000301000000000000403c02000000ffff
473c020000002000000000000000000000000000000000000000000000000000000000000000000301000000000000103c020000004f0c10
3c020000002000000000000000000000000000000000000000000000000000000000000000000301000000000000703d020000000341723d
02000000200000000000000000000000000000000000000000000000000000000000000000030100000000
```

Looking at the patterns shared by all struct instances (r0h = 3, r0l = 1, for example), each row appeared to be shifted one byte to the left compared to its predecessor.  This suggests that DAPFT8110B has only three extra bytes of padding compared to DAPFT8110.

Removing the one byte of unknown data in the DAPFT8110B fixed the problem, allowing me to start the shell.

This seems to be how the device I have works, anyway.  I'm not able to test others.