### PR TITLE
m1n1.shell: carry on if saving history fails

### DIFF
--- a/proxyclient/m1n1/shell.py
+++ b/proxyclient/m1n1/shell.py
@@ -30,7 +30,10 @@ class HistoryConsole(code.InteractiveConsole):
 
     def save_history(self):
         readline.set_history_length(10000)
-        readline.write_history_file(self.histfile)
+        try:
+            readline.write_history_file(self.histfile)
+        except OSError as e:
+            print(f"Failed writing history to {self.histfile}: {e}", file=sys.stderr)
 
     def showtraceback(self):
         type, value, tb = sys.exc_info()


### PR DESCRIPTION
This shouldn't crash the shell — it's enough to warn about it and carry on.