### PR TITLE
Fix build with -DDEBUG

### DIFF
--- a/src/adt.c
+++ b/src/adt.c
@@ -320,7 +320,7 @@ int adt_get_reg(const void *adt, int *path, const char *prop, int idx, u64 *padd
         u32 pa_cells = 2;
         ADT_GETPROP(adt, parent, "#address-cells", &pa_cells);
 
-        dprintf(" translate range to address-cells=%d size-cells=%d\n", pa_cells, ps_cells);
+        dprintf(" translate range to address-cells=%d\n", pa_cells);
 
         if (pa_cells < 1 || pa_cells > 2 || s_cells > 2)
             return ADT_ERR_BADNCELLS;

--- a/src/hv_vm.c
+++ b/src/hv_vm.c
@@ -445,7 +445,7 @@ u64 hv_pt_walk(u64 addr)
 
         u64 l1d = hv_Ltop[idx];
 
-        dprintf("  l1d = 0x%lx\n", l2d);
+        dprintf("  l1d = 0x%lx\n", l1d);
 
         if (!L1_IS_TABLE(l1d)) {
             dprintf("  result: 0x%lx\n", l1d);
@@ -871,7 +871,7 @@ bool hv_pa_write(struct exc_info *ctx, u64 addr, u64 *val, int width)
                 write64(addr + 8 * i, val[i]);
             break;
         default:
-            dprintf("HV: unsupported write width %ld\n", width);
+            dprintf("HV: unsupported write width %d\n", width);
             exc_guard = GUARD_OFF;
             return false;
     }
@@ -918,7 +918,7 @@ bool hv_pa_read(struct exc_info *ctx, u64 addr, u64 *val, int width)
             val[3] = read64(addr + 24);
             break;
         default:
-            dprintf("HV: unsupported read width %ld\n", width);
+            dprintf("HV: unsupported read width %d\n", width);
             exc_guard = GUARD_OFF;
             return false;
     }
@@ -982,8 +982,8 @@ static bool hv_emulate_rw_aligned(struct exc_info *ctx, u64 pte, u64 vaddr, u64 
                 hv_hook_t *hook = (hv_hook_t *)target;
                 if (!hook(ctx, ipa, val, true, width))
                     return false;
-                dprintf("HV: SPTE_HOOK[W] @0x%lx 0x%lx -> 0x%lx (w=%d) @%p: 0x%lx\n", elr, far, ipa,
-                        1 << width, hook, wval);
+                dprintf("HV: SPTE_HOOK[W] @0x%lx 0x%lx -> 0x%lx (w=%d) @%p: 0x%lx\n", elr, ipa,
+                        paddr, 1 << width, hook, val);
                 break;
             }
             case SPTE_PROXY_HOOK_RW:
@@ -1021,8 +1021,8 @@ static bool hv_emulate_rw_aligned(struct exc_info *ctx, u64 pte, u64 vaddr, u64 
                 hv_hook_t *hook = (hv_hook_t *)target;
                 if (!hook(ctx, ipa, val, false, width))
                     return false;
-                dprintf("HV: SPTE_HOOK[R] @0x%lx 0x%lx -> 0x%lx (w=%d) @%p: 0x%lx\n", elr, far, ipa,
-                        1 << width, hook, val);
+                dprintf("HV: SPTE_HOOK[R] @0x%lx 0x%lx -> 0x%lx (w=%d) @%p: 0x%lx\n", elr, ipa,
+                        paddr, 1 << width, hook, val);
                 break;
             }
             case SPTE_PROXY_HOOK_RW:


### PR DESCRIPTION
If DEBUG is not defined, the compiler doesn't look at the arguments to dprintf().  This has led to dprintf() bitrotting over time, referring to variables that no longer exist, or by the wrong type, etc.

Here, I've tried to fix all the dprintf() calls to the best of my ability, by comparing them to nearby calls that do compile, and looking through the git history to understand the original intent.

I imagine I've probably got one or two things wrong due to not being familiar with the code, but I think this is mostly right.