### PR TITLE
Add initial M3 values for CPU_START_OFF

### DIFF
--- a/src/smp.c
+++ b/src/smp.c
@@ -10,6 +10,7 @@
 #include "types.h"
 #include "utils.h"
 
+#define CPU_START_OFF_T6031 0x88000
 #define CPU_START_OFF_T8103 0x54000
 #define CPU_START_OFF_T8112 0x34000
 #define CPU_START_OFF_T6020 0x28000
@@ -205,6 +206,7 @@ void smp_start_secondaries(void)
         case T6002:
             cpu_start_off = CPU_START_OFF_T8103;
             break;
+        case T8122:
         case T8112:
             cpu_start_off = CPU_START_OFF_T8112;
             break;
@@ -212,6 +214,10 @@ void smp_start_secondaries(void)
         case T6021:
         case T6022:
             cpu_start_off = CPU_START_OFF_T6020;
+            break;
+        case T6031:
+        case T6034:
+            cpu_start_off = CPU_START_OFF_T6031;
             break;
         default:
             printf("CPU start offset is unknown for this SoC!\n");

--- a/src/soc.h
+++ b/src/soc.h
@@ -7,12 +7,15 @@
 
 #define T8103 0x8103
 #define T8112 0x8112
+#define T8122 0x8122
 #define T6000 0x6000
 #define T6001 0x6001
 #define T6002 0x6002
 #define T6020 0x6020
 #define T6021 0x6021
 #define T6022 0x6022
+#define T6031 0x6031
+#define T6034 0x6034
 
 #ifdef TARGET
 


### PR DESCRIPTION
I only can easily find the T6031/T6034/T8122 values.
If there is a T6030, the value is not in the same place I found these.

Signed-off-by: Daniel Berlin <dberlin@dberlin.org>
