### PR TITLE
Use dcpext for all M2 desktop devices.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ AS := $(TOOLCHAIN)$(ARCH)gcc
 LD := $(TOOLCHAIN)$(ARCH)ld
 OBJCOPY := $(TOOLCHAIN)$(ARCH)objcopy
 CLANG_FORMAT := clang-format
-EXTRA_CFLAGS ?= -Wstack-usage=1024
+EXTRA_CFLAGS ?= -Wstack-usage=2048
 endif
 
 BASE_CFLAGS := -O2 -Wall -g -Wundef -Werror=strict-prototypes -fno-common -fno-PIE \

--- a/config.h
+++ b/config.h
@@ -12,6 +12,8 @@
 
 // Minimal build for bring-up
 //#define BRINGUP
+// Disable display configuration / bringup on desktop devices
+//#define NO_DISPLAY
 
 // Print RTKit logs to the console
 //#define RTKIT_SYSLOG

--- a/proxyclient/hv/trace_dcp.py
+++ b/proxyclient/hv/trace_dcp.py
@@ -868,16 +868,18 @@ class DCPEp(EP):
         self.state.ch = {}
         self.state.dumpfile = None
 
-        self.ch_cb = DCPCallChannel(self, "CB", 0x60000, 0x8000)
-        self.ch_cmd = DCPCallChannel(self, "CMD", 0, 0x8000)
-        self.ch_async = DCPCallChannel(self, "ASYNC", 0x40000, 0x20000)
-        self.ch_oobcb = DCPCallChannel(self, "OOBCB", 0x68000, 0x8000)
-        self.ch_oobcmd = DCPCallChannel(self, "OOBCMD", 0x8000, 0x8000)
+        self.ch_cmd      = DCPCallChannel(self, "CMD",      0x00000, 0x8000)
+        self.ch_oobcmd   = DCPCallChannel(self, "OOBCMD",   0x08000, 0x8000)
+        self.ch_async    = DCPCallChannel(self, "ASYNC",    0x40000, 0x8000)
+        self.ch_oobasync = DCPCallChannel(self, "OOBASYNC", 0x48000, 0x8000)
+        self.ch_cb       = DCPCallChannel(self, "CB",       0x60000, 0x8000)
+        self.ch_oobcb    = DCPCallChannel(self, "OOBCB",    0x68000, 0x8000)
 
         self.cmd_ch = {
             CallContext.CB: self.ch_cmd,
             CallContext.CMD: self.ch_cmd,
             CallContext.ASYNC: None, # unknown
+            CallContext.OOBASYNC: None, # unknown
             CallContext.OOBCB: self.ch_oobcmd,
             CallContext.OOBCMD: self.ch_oobcmd,
         }
@@ -886,6 +888,7 @@ class DCPEp(EP):
             CallContext.CB: self.ch_cb,
             CallContext.CMD: None,
             CallContext.ASYNC: self.ch_async,
+            CallContext.OOBASYNC: self.ch_oobasync,
             CallContext.OOBCB: self.ch_oobcb,
             CallContext.OOBCMD: None,
         }

--- a/proxyclient/m1n1/fw/dcp/dcpep.py
+++ b/proxyclient/m1n1/fw/dcp/dcpep.py
@@ -25,6 +25,7 @@ class CallContext(IntEnum):
     ASYNC       = 3
     OOBCB       = 4
     OOBCMD      = 6
+    OOBASYNC    = 7
 
 class DCPEp_Msg(DCPMessage):
     LEN         = 63, 32
@@ -124,7 +125,8 @@ class DCPEndpoint(ASCBaseEndpoint):
 
         self.ch_cb = DCPCallbackChannel(self, "CB", 0x60000, 0x8000)
         self.ch_cmd = DCPCallChannel(self, "CMD", 0, 0x8000)
-        self.ch_async = DCPCallbackChannel(self, "ASYNC", 0x40000, 0x20000)
+        self.ch_async = DCPCallbackChannel(self, "ASYNC", 0x40000, 0x8000)
+        self.ch_oobasync = DCPCallbackChannel(self, "OOBASYNC", 0x48000, 0x8000)
         self.ch_oobcb = DCPCallbackChannel(self, "OOBCB", 0x68000, 0x8000)
         self.ch_oobcmd = DCPCallChannel(self, "OOBCMD", 0x8000, 0x8000)
 
@@ -144,6 +146,8 @@ class DCPEndpoint(ASCBaseEndpoint):
                 self.ch_oobcb.cb(msg)
             elif msg.CTX == CallContext.ASYNC:
                 self.ch_async.cb(msg)
+            elif msg.CTX == CallContext.OOBASYNC:
+                self.ch_oobasync.cb(msg)
             else:
                 raise Exception(f"Unknown RX callback channel {msg.CTX}")
         return True

--- a/proxyclient/m1n1/fw/dcp/ipc.py
+++ b/proxyclient/m1n1/fw/dcp/ipc.py
@@ -656,7 +656,7 @@ class UnifiedPipeline2(IPCObject):
         D109 = cb_create_PMU_service
         D110 = cb_create_iomfb_service
         D111 = cb_create_backlight_service
-        D112 = set_idle_caching_state_ap
+        D112 = cb_set_idle_caching_state_ap
         D116 = cb_start_hardware_boot
         D117 = cb_is_dark_boot
         D118 = cb_is_waking_from_hibernate
@@ -860,6 +860,7 @@ class IOMobileFramebufferAP(IPCObject):
     D589 = Callback(void, "swap_complete_ap_gated", swap_id=uint, unkBool=bool_, swap_data=InPtr(SwapCompleteData), swap_info=SwapInfoBlob, unkUint=uint)
 
     D591 = Callback(void, "swap_complete_intent_gated", swap_id=uint, unkB=bool_, unkInt=uint32_t, width=uint, height=uint)
+    D592 = Callback(void, "abort_swap_ap_gated", swap_id=uint)
     D593 = Callback(void, "enable_backlight_message_ap_gated", bool_)
     D594 = Callback(void, "setSystemConsoleMode", bool_)
 

--- a/src/dcp.c
+++ b/src/dcp.c
@@ -55,6 +55,8 @@ static int dcp_hdmi_dptx_init(dcp_dev_t *dcp, const display_config_t *cfg)
         }
     }
 
+    dcp->die = cfg->die;
+
     dcp->phy = dptx_phy_init(cfg->dptx_phy, cfg->dcp_index);
     if (!dcp->phy) {
         printf("dcp: failed to init (lp)dptx-phy '%s'\n", cfg->dptx_phy);
@@ -93,7 +95,7 @@ static int dcp_hdmi_dptx_init(dcp_dev_t *dcp, const display_config_t *cfg)
 int dcp_connect_dptx(dcp_dev_t *dcp)
 {
     if (dcp->dptx_ep && dcp->phy) {
-        return dcp_dptx_connect(dcp->dptx_ep, dcp->phy, 0);
+        return dcp_dptx_connect(dcp->dptx_ep, dcp->phy, dcp->die, 0);
     }
 
     return 0;

--- a/src/dcp.c
+++ b/src/dcp.c
@@ -204,12 +204,7 @@ out_free:
 
 int dcp_shutdown(dcp_dev_t *dcp, bool sleep)
 {
-    if (dcp->dptx_ep) {
-        if (sleep) {
-            printf("DCP: dcp_shutdown(sleep=true) is broken with dptx-port, quiesce instead\n");
-            sleep = false;
-        }
-    }
+    /* dcp/dcp0 on desktop M2 and M2 Pro/Max devices do not wake from sleep */
     dcp_system_shutdown(dcp->system_ep);
     dcp_dptx_shutdown(dcp->dptx_ep);
     dcp_dpav_shutdown(dcp->dpav_ep);

--- a/src/dcp.h
+++ b/src/dcp.h
@@ -35,6 +35,7 @@ typedef struct dcp_dev {
     dcp_dpav_if_t *dpav_ep;
     dcp_dptx_if_t *dptx_ep;
     dptx_phy_t *phy;
+    u32 die;
     u32 dp2hdmi_pwr_gpio;
     u32 hdmi_pwr_gpio;
 } dcp_dev_t;

--- a/src/dcp.h
+++ b/src/dcp.h
@@ -19,6 +19,7 @@ typedef struct {
     const char dptx_phy[24];
     const char dp2hdmi_gpio[24];
     const char pmgr_dev[24];
+    const char dcp_alias[8];
     u32 dcp_index;
     u8 num_dptxports;
     u8 die;

--- a/src/dcp/dptx_port_ep.c
+++ b/src/dcp/dptx_port_ep.c
@@ -510,7 +510,7 @@ static const afk_epic_service_ops_t dcp_dptx_ops[] = {
     {},
 };
 
-int dcp_dptx_connect(dcp_dptx_if_t *dptx, dptx_phy_t *phy, u32 port)
+int dcp_dptx_connect(dcp_dptx_if_t *dptx, dptx_phy_t *phy, u32 die, u32 port)
 {
     if (port > 1)
         return -1;
@@ -521,7 +521,7 @@ int dcp_dptx_connect(dcp_dptx_if_t *dptx, dptx_phy_t *phy, u32 port)
 
     dptx->port[port].phy = dptx->phy = phy;
 
-    dptxport_connect(dptx->port[port].service, 0, dptx_phy_dcp_output(phy), 0);
+    dptxport_connect(dptx->port[port].service, 0, dptx_phy_dcp_output(phy), die);
     dptxport_request_display(dptx->port[port].service);
 
     return 0;

--- a/src/dcp/dptx_port_ep.h
+++ b/src/dcp/dptx_port_ep.h
@@ -55,7 +55,7 @@ enum dptx_link_rate {
 dcp_dptx_if_t *dcp_dptx_init(dcp_dev_t *dcp, u32 num_dptxports);
 int dcp_dptx_shutdown(dcp_dptx_if_t *dptx);
 
-int dcp_dptx_connect(dcp_dptx_if_t *dptx, dptx_phy_t *phy, u32 port);
+int dcp_dptx_connect(dcp_dptx_if_t *dptx, dptx_phy_t *phy, u32 die, u32 port);
 int dcp_dptx_hpd(dcp_dptx_if_t *dptx, u32 port, bool hpd);
 int dcp_dptx_disconnect(dcp_dptx_if_t *dptx, u32 port);
 int dcp_dptx_hpd(dcp_dptx_if_t *dptx, u32 port, bool hpd);

--- a/src/display.c
+++ b/src/display.c
@@ -1,5 +1,7 @@
 /* SPDX-License-Identifier: MIT */
 
+#include "../build/build_cfg.h"
+
 #include "display.h"
 #include "adt.h"
 #include "assert.h"
@@ -225,6 +227,11 @@ int display_start_dcp(void)
     if (iboot)
         return 0;
 
+#ifdef NO_DISPLAY
+    printf("display: NO_DISPLAY!\n");
+    return 0;
+#endif
+
     const display_config_t *disp_cfg = &display_config_m1;
 
     if (adt_is_compatible(adt, 0, "J473AP"))
@@ -349,6 +356,11 @@ int display_configure(const char *config)
 {
     dcp_timing_mode_t want;
     struct display_options opts = {0};
+
+#ifdef NO_DISPLAY
+    printf("display: skip configuration (NO_DISPLAY)\n");
+    return 0;
+#endif
 
     display_parse_mode(config, &want, &opts);
 

--- a/src/display.h
+++ b/src/display.h
@@ -3,6 +3,7 @@
 #ifndef DISPLAY_H
 #define DISPLAY_H
 
+#include "dcp.h"
 #include "types.h"
 
 typedef enum _dcp_shutdown_mode {
@@ -17,5 +18,6 @@ int display_init(void);
 int display_start_dcp(void);
 int display_configure(const char *config);
 void display_shutdown(dcp_shutdown_mode mode);
+const display_config_t *display_get_config(void);
 
 #endif

--- a/src/kboot.c
+++ b/src/kboot.c
@@ -8,6 +8,7 @@
 #include "clk.h"
 #include "dapf.h"
 #include "devicetree.h"
+#include "display.h"
 #include "exception.h"
 #include "firmware.h"
 #include "isp.h"
@@ -1774,7 +1775,6 @@ static int dt_set_display(void)
      * they are missing. */
 
     int ret = 0;
-    char dcp_alias[8] = "dcp";
 
     if (!fdt_node_check_compatible(dt, 0, "apple,t8103")) {
         ret = dt_carveout_reserved_regions("dcp", "disp0", "disp0_piodma",
@@ -1818,9 +1818,7 @@ static int dt_set_display(void)
         if (ret)
             return ret;
     } else if (!fdt_node_check_compatible(dt, 0, "apple,t6022")) {
-        // Set dcp_alias to "dcpext4" on  M2 Ultra, cmp. display.c
-        strncpy(dcp_alias, "dcpext4", sizeof(dcp_alias));
-        dcp_alias[sizeof(dcp_alias) - 1] = '\0';
+        /* noop */
     } else {
         printf("FDT: unknown compatible, skip display reserved-memory setup\n");
         return 0;
@@ -1838,7 +1836,9 @@ static int dt_set_display(void)
         !fdt_node_check_compatible(dt, 0, "apple,t6022"))
         dt_reserve_dcpext_firmware();
 
-    return dt_vram_reserved_region(dcp_alias, "disp0");
+    const display_config_t *disp_cfg = display_get_config();
+
+    return dt_vram_reserved_region(disp_cfg->dcp_alias, "disp0");
 }
 
 static int dt_set_sio_fwdata(void)


### PR DESCRIPTION
This switches j473, j474s and j475c to dcpext(0) as display co-processor for HDMI out. Main reason is that dcpext(0) wakes up after sleep + reset. This simplifies handling in m1n1 a little.

This contains the tracing/m1n1.dcp changes for the rarely used OOB ASYNC callback channel.

In addition holds some minor fixes. The die number fix should be cosmetically, dcp firmware doesn't seem use it for something essential in a dptx connection.