### PR TITLE
Support non-constant unknown values in adt.py

### DIFF
--- a/proxyclient/m1n1/adt.py
+++ b/proxyclient/m1n1/adt.py
@@ -112,11 +112,11 @@ PMGRClocks = SafeGreedyRange(Struct(
 ))
 
 PMGRPowerDomains = SafeGreedyRange(Struct(
-    "unk" / Const(0, Int8ul),
+    "unk" / Int8ul,
     "perf_idx" / Int8ul,
     "perf_block" / Int8ul,
     "id" / Int8ul,
-    Const(0, Int32ul),
+    "flags" / Int32ul,
     "name" / PaddedString(16, "ascii"),
 ))
 


### PR DESCRIPTION
On m3, these previouly expected-to-be-constant fields have exciting
non-constant values.  This updates adt.py to allow them to be
non-constant.  The second field is also really a flags field,
though i could not tell you all the flags involved.

Signed-off-by: Daniel Berlin <dberlin@dberlin.org>
