### PR TITLE
Add support for retrieving boot cpu id and mpidr from proxy

### DIFF
--- a/proxyclient/m1n1/proxy.py
+++ b/proxyclient/m1n1/proxy.py
@@ -494,6 +494,8 @@ class M1N1Proxy(Reloadable):
     P_PUT_SIMD_STATE = 0x00f
     P_REBOOT = 0x010
     P_SLEEP = 0x011
+    P_GET_BOOT_CPU_IDX = 0x012
+    P_GET_BOOT_CPU_MPIDR = 0x013
 
     P_WRITE64 = 0x100
     P_WRITE32 = 0x101
@@ -718,6 +720,10 @@ class M1N1Proxy(Reloadable):
                 self.request(self.P_CALL, addr, *args, reboot=True)
     def get_bootargs(self):
         return self.request(self.P_GET_BOOTARGS)
+    def get_boot_cpu_idx(self):
+        return self.request(self.P_GET_BOOT_CPU_IDX) 
+    def get_boot_cpu_mpidr(self):
+        return self.request(self.P_GET_BOOT_CPU_MPIDR)
     def get_base(self):
         return self.request(self.P_GET_BASE)
     def set_baud(self, baudrate):

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -54,6 +54,12 @@ int proxy_process(ProxyRequest *request, ProxyReply *reply)
         case P_GET_BOOTARGS:
             reply->retval = boot_args_addr;
             break;
+        case P_GET_BOOT_CPU_IDX:
+            reply->retval = boot_cpu_idx;
+            break;
+        case P_GET_BOOT_CPU_MPIDR:
+            reply->retval = boot_cpu_mpidr;
+            break;
         case P_GET_BASE:
             reply->retval = (u64)_base;
             break;

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -24,6 +24,8 @@ typedef enum {
     P_PUT_SIMD_STATE,
     P_REBOOT,
     P_SLEEP,
+    P_GET_BOOT_CPU_IDX,
+    P_GET_BOOT_CPU_MPIDR,
 
     P_WRITE64 = 0x100, // Generic register functions
     P_WRITE32,


### PR DESCRIPTION
Uses it to add basic support for non-0,0,0 boot cpu in python hypervisor code

Signed-off-by: Daniel Berlin <dberlin@dberlin.org>
