### PR TITLE
Give AMX context reg a name.

### DIFF
--- a/src/chickens.c
+++ b/src/chickens.c
@@ -144,8 +144,7 @@ const char *init_cpu(void)
 
     int core = mrs(MPIDR_EL1) & 0xff;
 
-    // Unknown, related to SMP?
-    msr(s3_4_c15_c5_0, core);
+    msr(SYS_IMP_APL_AMX_CTX_EL1, core);
     msr(SYS_IMP_APL_AMX_CTL_EL1, 0x100);
 
     // Enable IRQs (at least necessary on t600x)

--- a/src/cpu_regs.h
+++ b/src/cpu_regs.h
@@ -9,6 +9,7 @@
 
 #define SYS_IMP_APL_ACTLR_EL12 sys_reg(3, 6, 15, 14, 6)
 
+#define SYS_IMP_APL_AMX_CTX_EL1  sys_reg(3, 4, 15, 5, 0)
 #define SYS_IMP_APL_AMX_CTL_EL1  sys_reg(3, 4, 15, 1, 4)
 #define SYS_IMP_APL_AMX_CTL_EL2  sys_reg(3, 4, 15, 4, 7)
 #define SYS_IMP_APL_AMX_CTL_EL12 sys_reg(3, 4, 15, 4, 6)


### PR DESCRIPTION
This register is used to store AMX context information.

Signed-off-by: Daniel Berlin <dberlin@dberlin.org>
