### PR TITLE
nvme: t6022: Derive die from nvme_base address

### DIFF
--- a/src/nvme.c
+++ b/src/nvme.c
@@ -302,18 +302,18 @@ bool nvme_init(void)
         return NULL;
     }
 
-    u32 cg;
-    if (ADT_GETPROP(adt, node, "clock-gates", &cg) < 0) {
-        printf("nvme: clock-gates not set\n");
-        cg = 0;
-    }
-    nvme_die = FIELD_GET(PMGR_DIE_ID, cg);
-    printf("nvme: ANS is on die %d\n", nvme_die);
-
     if (adt_get_reg(adt, adt_path, "reg", 3, &nvme_base, NULL) < 0) {
         printf("nvme: Error getting NVMe base address.\n");
         return NULL;
     }
+    u32 cg;
+    if (ADT_GETPROP(adt, node, "clock-gates", &cg) < 0) {
+        printf("nvme: clock-gates not set\n");
+        nvme_die = (nvme_base >> 37) & 3;
+    } else {
+        nvme_die = FIELD_GET(PMGR_DIE_ID, cg);
+    }
+    printf("nvme: ANS is on die %d\n", nvme_die);
 
     if (!alloc_queue(&adminq)) {
         printf("nvme: Error allocating admin queue\n");


### PR DESCRIPTION
For some reason the ans node for t602x devices has an empty "clock-gates" property. Use the MMIO address instead to determine on which die the device is.

Fixes: 34f49a5 ("nvme: assume die 0 if clock-gates not set")