### PR TITLE
docker: install rust toolchain for stage1 builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
 FROM debian:buster-slim
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y build-essential bash git locales gcc-aarch64-linux-gnu libc6-dev-arm64-cross device-tree-compiler \
+RUN apt-get update && apt-get install -y build-essential bash curl git locales gcc-aarch64-linux-gnu libc6-dev-arm64-cross device-tree-compiler \
     && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+RUN curl -s https://sh.rustup.rs | bash -s -- -y --target aarch64-unknown-none-softfloat
+
 ENV LANG en_US.utf8
+ENV PATH "/root/.cargo/bin:${PATH}"
 
 WORKDIR /m1n1
 COPY . .


### PR DESCRIPTION
Install the rust toolchain in the Docker container so it can be used when building with `CHAINLOADING=1` too