### PR TITLE
hw/aes.py: Fix python error after 183991ca1983

### DIFF
--- a/proxyclient/m1n1/hw/aes.py
+++ b/proxyclient/m1n1/hw/aes.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from ..utils import *
 from enum import IntEnum
-from .dart import DART, DARTRegs
+from .dart import DART
 import struct
 from enum import IntEnum
 


### PR DESCRIPTION
Fixes: 183991ca1983 ("m1n1.hw.dart: Hide all DART variants behind common interface")