### PR TITLE
z2: Deal with missing calibration data

### DIFF
--- a/src/kboot.c
+++ b/src/kboot.c
@@ -674,9 +674,7 @@ static int dt_set_multitouch(void)
     u32 len;
     const u8 *cal_blob = adt_getprop(adt, anode, "multi-touch-calibration", &len);
     if (!cal_blob || !len) {
-        printf("ADT: Failed to get multi-touch-calibration from %s, disable %s\n", adt_touchbar,
-               fdt_get_name(dt, node, NULL));
-        fdt_setprop_string(dt, node, "status", "disabled");
+        printf("ADT: Failed to get multi-touch-calibration from %s\n", adt_touchbar);
         return 0;
     }
 


### PR DESCRIPTION
(by not sending anything in that case)