### PR TITLE
Makefile: Fix build when using clang as AS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ build/%.o: src/%.S
 	$(QUIET)echo "  AS    $@"
 	$(QUIET)mkdir -p $(DEPDIR)
 	$(QUIET)mkdir -p "$(dir $@)"
-	$(QUIET)$(AS) -c $(CFLAGS) -MMD -MF $(DEPDIR)/$(*F).d -MQ "$@" -MP -o $@ $<
+	$(QUIET)$(AS) -c $(BASE_CFLAGS) -MMD -MF $(DEPDIR)/$(*F).d -MQ "$@" -MP -o $@ $<
 
 $(BUILD_FP_OBJS): build/%.o: src/%.c
 	$(QUIET)echo "  CC FP $@"


### PR DESCRIPTION
Unlike gcc, clang enforces -mgeneral-regs-only when used as the assembler so this removes that flag to fix the error in #393. This is only needed for utils_asm.S which has code saving/restoring SIMD state, but this commit applies it to all asm files for simplicity since code for fp regs shouldn't be generated unless they're explicitly used anyway.