### PR TITLE
Add ADT and m1n1 stage 2 log as MTD phram reserved memory nodes

### DIFF
--- a/src/iodev.c
+++ b/src/iodev.c
@@ -18,17 +18,19 @@
 
 extern struct iodev iodev_uart;
 extern struct iodev iodev_fb;
+extern struct iodev iodev_log;
 extern struct iodev iodev_usb_vuart;
 
-struct iodev *iodevs[IODEV_MAX] = {
+struct iodev *iodevs[IODEV_NUM] = {
     [IODEV_UART] = &iodev_uart,
     [IODEV_FB] = &iodev_fb,
     [IODEV_USB_VUART] = &iodev_usb_vuart,
+    [IODEV_LOG] = &iodev_log,
 };
 
 char con_buf[CONSOLE_BUFFER_SIZE];
 size_t con_wp;
-size_t con_rp[IODEV_MAX];
+size_t con_rp[IODEV_NUM];
 
 void iodev_register_device(iodev_id_t id, struct iodev *dev)
 {
@@ -173,7 +175,7 @@ void iodev_console_write(const void *buf, size_t length)
     in_iodev++;
 
     dprintf("  iodev_console_write() wp=%d\n", con_wp);
-    for (iodev_id_t id = 0; id < IODEV_MAX; id++) {
+    for (iodev_id_t id = 0; id < IODEV_NUM; id++) {
         if (!iodevs[id])
             continue;
 
@@ -275,7 +277,7 @@ void iodev_console_kick(void)
 {
     iodev_console_write(NULL, 0);
 
-    for (iodev_id_t id = 0; id < IODEV_MAX; id++) {
+    for (iodev_id_t id = 0; id < IODEV_NUM; id++) {
         if (!iodevs[id])
             continue;
         if (!(iodevs[id]->usage & USAGE_CONSOLE))
@@ -287,7 +289,7 @@ void iodev_console_kick(void)
 
 void iodev_console_flush(void)
 {
-    for (iodev_id_t id = 0; id < IODEV_MAX; id++) {
+    for (iodev_id_t id = 0; id < IODEV_NUM; id++) {
         if (!iodevs[id])
             continue;
         if (!(iodevs[id]->usage & USAGE_CONSOLE))

--- a/src/iodev.h
+++ b/src/iodev.h
@@ -14,6 +14,8 @@ typedef enum _iodev_id_t {
     IODEV_USB_VUART,
     IODEV_USB0,
     IODEV_MAX = IODEV_USB0 + USB_IODEV_COUNT,
+    IODEV_LOG = IODEV_MAX, // hidden log buffer iodev
+    IODEV_NUM,
 } iodev_id_t;
 
 typedef enum _iodev_usage_t {


### PR DESCRIPTION
Requires for easy access `CONFIG_MTD_PHRAM` but I guess can be still accesses through /dev/mem on systems missing this.

The additional IODEV for the log console is a little bit ugly since it can't be added before `IODEV_USB0` to keep backwards compatibility with python m1n1 but it shouldn't be handled like the USB IODEVs.