### PR TITLE
proxyclient: Modify FreeBSD loader to use standard U-Boot bootefi cmd

### DIFF
--- a/proxyclient/tools/freebsd.py
+++ b/proxyclient/tools/freebsd.py
@@ -86,9 +86,9 @@ bootenv = list(filter(lambda x: not (x.startswith("baudrate") or (x.startswith("
 if loader is not None:
     # dtb_addr not used here, the prepared fdt's at a different location.  If
     # we use this one, we won't get any of our /chosen additions, for instance.
-    bootcmd = "distro_bootcmd=bootefi 0x%x - 0x%x" % (loader_base, loader_size)
+    bootcmd = "distro_bootcmd=bootefi 0x%x:0x%x" % (loader_base, loader_size)
 else:
-    bootcmd = "distro_bootcmd=devnum=0; run usb_boot"
+    bootcmd = "distro_bootcmd=devnum=0; run nvme_boot"
 
 if tty_dev is not None:
 	bootenv.append("baudrate=%d" % tty_dev.baudrate)


### PR DESCRIPTION
The FreeBSD script added in #185 required patching u-boot since it specified the loader base/size in a non-standard way. This changes the way arguments are passed to the bootefi command so it works with the asahi u-boot fork which I've been using. I also changed the case where the loader isn't specified to have u-boot boot from the nvme since I have that driver functional enough to have it mount the root fs now.