### PR TITLE
Fix build failure in Fedora

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2,7 +2,7 @@
 #![no_std]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![feature(alloc_error_handler)]
-#![feature(new_uninit)]
+#![feature(new_zeroed_alloc)]
 
 #[macro_use]
 extern crate alloc;


### PR DESCRIPTION
```
warning: the feature `new_uninit` has been stable since 1.82.0 and no longer requires an attribute to enable
 --> src/lib.rs:5:12
  |
5 | #![feature(new_uninit)]
  |            ^^^^^^^^^^
  |
  = note: `#[warn(stable_features)]` on by default
error[E0658]: use of unstable library feature 'new_zeroed_alloc'
  --> src/nvme.rs:20:41
   |
20 |     let p: Box<SectorBuffer> = unsafe { Box::new_zeroed().assume_init() };
   |                                         ^^^^^^^^^^^^^^^
   |
   = note: see issue #129396 <https://github.com/rust-lang/rust/issues/129396> for more information
   = help: add `#![feature(new_zeroed_alloc)]` to the crate attributes to enable
```