### PR TITLE
Support arbitrary boot CPU core

### DIFF
--- a/proxyclient/m1n1/hv/__init__.py
+++ b/proxyclient/m1n1/hv/__init__.py
@@ -1562,10 +1562,12 @@ class HV(Reloadable):
             chip_id = self.u.adt["/chosen"].chip_id
             if chip_id in (0x8103, 0x6000, 0x6001, 0x6002):
                 cpu_start = 0x54000 + die * 0x20_0000_0000
-            elif chip_id in (0x8112,):
+            elif chip_id in (0x8112, 0x8122):
                 cpu_start = 0x34000 + die * 0x20_0000_0000
             elif chip_id in (0x6020, 0x6021, 0x6022):
                 cpu_start = 0x28000 + die * 0x20_0000_0000
+            elif chip_id in (0x6031,):
+                cpu_start = 0x88000 + die * 0x20_0000_0000
             else:
                 self.log("CPUSTART unknown for this SoC!")
                 break

--- a/proxyclient/tools/chainload.py
+++ b/proxyclient/tools/chainload.py
@@ -85,7 +85,9 @@ for name in ("mtp", "aop"):
 print("Setting secondary CPU RVBARs...")
 
 rvbar = entry & ~0xfff
-for cpu in u.adt["cpus"][1:]:
+for cpu in u.adt["cpus"]:
+    if cpu.state == "running":
+        continue
     addr, size = cpu.cpu_impl_reg
     print(f"  {cpu.name}: [0x{addr:x}] = 0x{rvbar:x}")
     p.write64(addr, rvbar)


### PR DESCRIPTION
M3 devices use the first CPU core in the first performance core cluster for booting while the efficiency core cluster remains the first cluster. Use the CPU core's state property to determine the boot CPU.

Supersedes #369

Tested on M3 MacBook Pro (2023, 14-inch).