### PR TITLE
pmgr: Fix false positive u8 pmgr ID detection on modern SoCs

### DIFF
--- a/src/pmgr.c
+++ b/src/pmgr.c
@@ -374,12 +374,14 @@ int pmgr_init(void)
 
     printf("pmgr: Cleaning up device states...\n");
 
+    // detect whether u8 or u16 PMGR IDs are used by comparing the IDs of the
+    // first 2 devices
+    if (pmgr_devices_len >= 2)
+        pmgr_u8id = pmgr_devices[0].id1 != pmgr_devices[1].id1;
+
     for (u8 die = 0; die < pmgr_dies; ++die) {
         for (size_t i = 0; i < pmgr_devices_len; ++i) {
             const struct pmgr_device *device = &pmgr_devices[i];
-
-            if (device->id1)
-                pmgr_u8id = true;
 
             if ((device->flags & PMGR_FLAG_VIRTUAL))
                 continue;


### PR DESCRIPTION
The id1 field used on oder SoCs is not constant 0 for all devices on t8122. Instead just compare the id1 fields of the two first devices. Fixes "pmgr: Failed to find parent #36 for IOA0\n" errors in pmgr_init().

Fixes: fb59dc03ca9a ("pmgr: Fix struct for older SoCs")