### PR TITLE
main: reinstate get_device_info() call

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -147,6 +147,7 @@ void m1n1_main(void)
 
     printf("Running in EL%lu\n\n", mrs(CurrentEL) >> 2);
 
+    get_device_info();
     firmware_init();
 
     heapblock_init();


### PR DESCRIPTION
This was inadvertently dropped in
869d2ae ("Skip over features unsupported in A7-A11 SoCs."). Put it back.