### PR TITLE
Fix up desktop display init regression

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -51,7 +51,7 @@ void get_device_info(void)
         printf("  Target: %s\n", target);
 
     is_mac = !!strstr(model, "Mac");
-    has_dcp = adt_path_offset(adt, "/arm-io/dcp") > 0;
+    has_dcp = !!adt_path_offset(adt, "/arm-io/dcp") || !!adt_path_offset(adt, "/arm-io/dcpext0");
 
     int chosen = adt_path_offset(adt, "/chosen");
     if (chosen > 0) {


### PR DESCRIPTION
Commit 869d2ae ~inadvertently dropped the call to `get_device_info()` and also~ prevented DCP from initialising on Mac desktops. This series fixes ~both of those things~.

I'm not entirely happy with the way we're checking for a DCP, it's a bit ugly.