### PR TITLE
Contain all display init logic within display.c

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -51,7 +51,6 @@ void get_device_info(void)
         printf("  Target: %s\n", target);
 
     is_mac = !!strstr(model, "Mac");
-    has_dcp = adt_path_offset(adt, "/arm-io/dcp") > 0;
 
     int chosen = adt_path_offset(adt, "/chosen");
     if (chosen > 0) {
@@ -165,8 +164,7 @@ void m1n1_main(void)
     display_init();
     // Kick DCP to sleep, so dodgy monitors which cause reconnect cycles don't cause us to lose the
     // framebuffer.
-    if (has_dcp)
-        display_shutdown(DCP_SLEEP_IF_EXTERNAL);
+    display_shutdown(DCP_SLEEP_IF_EXTERNAL);
     // On idevice we need to always clear, because otherwise it looks scuffed on white devices
     fb_init(!is_mac);
     fb_display_logo();

--- a/src/utils.c
+++ b/src/utils.c
@@ -12,7 +12,7 @@
 #include "vsprintf.h"
 #include "xnuboot.h"
 
-bool is_mac, has_dcp;
+bool is_mac;
 
 static char ascii(char s)
 {

--- a/src/utils.h
+++ b/src/utils.h
@@ -464,7 +464,7 @@ struct vector_args {
 
 extern u32 board_id, chip_id;
 
-extern bool is_mac, has_dcp;
+extern bool is_mac;
 extern bool cpufeat_actlr_el2, cpufeat_fast_ipi, cpufeat_mmu_sprr;
 extern bool cpufeat_global_sleep, cpufeat_workaround_cyclone_cache;
 


### PR DESCRIPTION
Supersedes #428. Not sure if the changes to `display_get_config()` are the right thing to do here.