### PR TITLE
Update MacOS-native build instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ install the required dependencies:
 
 ```shell
 $ brew install llvm
+$ brew install lld    # Necessary as of recent versions of llvm
 ```
 
 After that, just type `make`.


### PR DESCRIPTION
Brew no longer includes lld with llvm, so now it has to be installed separately.

Not really _that_ important  since brew includes a notice about it after you install llvm, but either way that makes the current build instructions outdated.