### PR TITLE
Allow !no-map GPU reserved ranges and map them

### DIFF
--- a/src/kboot_gpu.c
+++ b/src/kboot_gpu.c
@@ -398,9 +398,6 @@ static int dt_set_region(void *dt, int sgx, const char *name, const char *path)
     if (fdt_setprop_inplace(dt, node, "reg", reg, sizeof(reg)))
         bail("FDT: GPU: failed to set reg prop for %s\n", path);
 
-    if (fdt_setprop_empty(dt, node, "no-map"))
-        bail("FDT: GPU: failed to set no-map prop for %s\n", path);
-
     return 0;
 }
 


### PR DESCRIPTION
This should make the behavior with and without u-boot (mostly) consistent. I think u-boot also adds mem ranges for `no-map`  reserved ranges (then the kernel doesn't map them as requested), but that shouldn't make much of a difference.