### PR TITLE
kboot: Prevent NULL pointer dereference in dt_set_display()

### DIFF
--- a/src/kboot.c
+++ b/src/kboot.c
@@ -1888,7 +1888,10 @@ static int dt_set_display(void)
 
     const display_config_t *disp_cfg = display_get_config();
 
-    return dt_vram_reserved_region(disp_cfg->dcp_alias, "disp0");
+    if (disp_cfg)
+        return dt_vram_reserved_region(disp_cfg->dcp_alias, "disp0");
+    else
+        return dt_vram_reserved_region("dcp", "disp0");
 }
 
 static int dt_set_sep(void)


### PR DESCRIPTION
dt_set_display() relied on display_get_config() returning the default config entry as it is only interested on the device tree alias for the primary dcp. This is always "dcp" except for devices with a config. Since commit 8508526 ("display: contain all display init logic within display.c") it however returns NULL if ADT dcp node specified in the config does not exists. This is the case for M2 Pro and Max macbooks which use "dcp0" instead of "dcp".

Fixes: 8508526 ("display: contain all display init logic within display.c")