### PR TITLE
Update Dockerfile to Multi-Stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM debian:buster-slim
+### Build stage
+FROM debian:buster-slim AS builder
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y build-essential bash curl git locales gcc-aarch64-linux-gnu libc6-dev-arm64-cross device-tree-compiler \
@@ -12,5 +13,15 @@ ENV PATH "/root/.cargo/bin:${PATH}"
 
 WORKDIR /m1n1
 COPY . .
+
+### Runtime stage
+FROM debian:buster-slim
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG en_US.utf8
+ENV PATH "/root/.cargo/bin:${PATH}"
+
+COPY --from=builder /m1n1 /m1n1
+
+WORKDIR /m1n1
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
Hi,

Thanks for maintaining m1n1. I represent a research group investigating [multi-stage builds](https://docs.docker.com/build/building/multi-stage/). We recently refactored your Dockerfile to a multi-stage Dockerfile and found that it brings the following benefits: 

✅ Reduced final image size (from 1683MB to 75MB)  
✅ Minimized image vulnerabilities (verified via [Trivy](https://github.com/aquasecurity/trivy), from 3600 to 149)  

We hope this small improvement to the Dockerfile will be useful to you :)

Thanks,