### PR TITLE
A7-A11, T2 SoC cpufreq support

### DIFF
--- a/src/cpufreq.c
+++ b/src/cpufreq.c
@@ -84,7 +84,7 @@ static int set_pstate(const struct cluster_t *cluster, uint32_t pstate)
                 return -1;
         }
         write64(cluster->base + CLUSTER_PSTATE, val);
-        if (poll32(cluster->base + CLUSTER_PSTATE, CLUSTER_PSTATE_BUSY, 0, CLUSTER_SWITCH_TIMEOUT) <
+        if (poll64(cluster->base + CLUSTER_PSTATE, CLUSTER_PSTATE_BUSY, 0, CLUSTER_SWITCH_TIMEOUT) <
             0) {
             printf("cpufreq: Timed out waiting for cluster %s P-State switch\n", cluster->name);
             return -1;

--- a/src/pmgr.c
+++ b/src/pmgr.c
@@ -341,6 +341,28 @@ int pmgr_reset(int die, const char *name)
     return pmgr_reset_device(die, dev);
 }
 
+int pmgr_power_on(int die, const char *name)
+{
+    const struct pmgr_device *dev = NULL;
+
+    for (unsigned int i = 0; i < pmgr_devices_len; ++i) {
+        if (strncmp(pmgr_devices[i].name, name, 0x10) == 0) {
+            dev = &pmgr_devices[i];
+            break;
+        }
+    }
+
+    if (!dev)
+        return -1;
+
+    uintptr_t addr = pmgr_device_get_addr(die, dev);
+
+    if (!addr)
+        return -1;
+
+    return pmgr_set_mode(addr, PMGR_PS_ACTIVE);
+}
+
 int pmgr_init(void)
 {
     int node = adt_path_offset(adt, "/arm-io");

--- a/src/pmgr.h
+++ b/src/pmgr.h
@@ -26,6 +26,7 @@ int pmgr_adt_power_disable_index(const char *path, u32 index);
 int pmgr_adt_reset(const char *path);
 
 int pmgr_reset(int die, const char *name);
+int pmgr_power_on(int die, const char *name);
 
 int pmgr_set_mode(uintptr_t addr, u8 target_mode);
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -454,6 +454,18 @@ static inline int poll32(u64 addr, u32 mask, u32 target, u32 timeout)
     return -1;
 }
 
+static inline int poll64(u64 addr, u64 mask, u64 target, u32 timeout)
+{
+    while (--timeout > 0) {
+        u32 value = read64(addr) & mask;
+        if (value == target)
+            return 0;
+        udelay(1);
+    }
+
+    return -1;
+}
+
 typedef u64(generic_func)(u64, u64, u64, u64, u64);
 
 struct vector_args {


### PR DESCRIPTION
This adds the tunables required for cpufreq to work properly on A7-A11, T2 SoCs, most prominently a register poke to enable voltage changes when the state is changed, as iBoot leaves the voltage controls disabled.