### PR TITLE
fb: Add custom boot logo support

### DIFF
--- a/src/fb.c
+++ b/src/fb.c
@@ -421,20 +421,6 @@ void fb_init(bool clear)
         console.font.height = 16;
     }
 
-    if (!orig_logo.ptr) {
-        orig_logo = *logo;
-        orig_logo.ptr = malloc(orig_logo.width * orig_logo.height * 4);
-        fb_unblit_image((fb.width - orig_logo.width) / 2, (fb.height - orig_logo.height) / 2,
-                        &orig_logo);
-    }
-
-    if (clear) {
-        memset32(fb.ptr, 0, fb.size);
-    } else {
-        // Workaround for m1n1 stage 1 framebuffer UAF bug
-        memset32(fb.ptr, 0, min(256, fb.size));
-    }
-
     console.margin.rows = 2;
     console.margin.cols = 4;
     console.cursor.col = 0;
@@ -453,6 +439,20 @@ void fb_init(bool clear)
 
     console.initialized = true;
     console.active = false;
+
+    if (!orig_logo.ptr) {
+        orig_logo = *logo;
+        orig_logo.ptr = malloc(orig_logo.width * orig_logo.height * 4);
+        fb_unblit_image((fb.width - orig_logo.width) / 2, (fb.height - orig_logo.height) / 2,
+                        &orig_logo);
+    }
+
+    if (clear) {
+        memset32(fb.ptr, 0, fb.size);
+    } else {
+        // Workaround for m1n1 stage 1 framebuffer UAF bug
+        memset32(fb.ptr, 0, min(256, fb.size));
+    }
 
     fb_clear_console();
 

--- a/src/fb.c
+++ b/src/fb.c
@@ -5,6 +5,7 @@
 #include "iodev.h"
 #include "malloc.h"
 #include "memory.h"
+#include "payload.h"
 #include "string.h"
 #include "types.h"
 #include "utils.h"
@@ -61,6 +62,8 @@ const struct image logo_256 = {
     .width = 256,
     .height = 256,
 };
+
+struct image custom_logo = {};
 
 const struct image *logo;
 struct image orig_logo;
@@ -395,6 +398,7 @@ void fb_clear_direct(void)
 
 void fb_init(bool clear)
 {
+    void *custom_128, *custom_256;
     fb.hwptr = (void *)cur_boot_args.video.base;
     fb.stride = cur_boot_args.video.stride / 4;
     fb.width = cur_boot_args.video.width;
@@ -445,6 +449,19 @@ void fb_init(bool clear)
         orig_logo.ptr = malloc(orig_logo.width * orig_logo.height * 4);
         fb_unblit_image((fb.width - orig_logo.width) / 2, (fb.height - orig_logo.height) / 2,
                         &orig_logo);
+    }
+
+    if (payload_logo(&custom_128, &custom_256)) {
+        custom_logo = *logo;
+        if (custom_logo.width == 256) {
+            custom_logo.ptr = custom_256;
+            logo = &custom_logo;
+        } else if (custom_logo.width == 128) {
+            custom_logo.ptr = custom_128;
+            logo = &custom_logo;
+        } else {
+            printf("fb: unexpected logo dimensions %ux%u\n", custom_logo.width, custom_logo.height);
+        }
     }
 
     if (clear) {

--- a/src/payload.h
+++ b/src/payload.h
@@ -3,6 +3,10 @@
 #ifndef __PAYLOAD_H__
 #define __PAYLOAD_H__
 
+#include "types.h"
+
+bool payload_logo(void **custom_128, void **custom_256);
+
 int payload_run(void);
 
 #endif


### PR DESCRIPTION
Supports a custom logo appended as first payload.

Build system integration currently requires that the custom logo PNGs are copied to 'data/${CUSTOM_{128,256}.png` and ImageMagick is installed.  
`make LOGO=${CUSTOM}` will then create a m1n1.bin with the custom logo. In addition m1n1-asahi.bin is built which carries the Asahi Linux logo.