### PR TITLE
Enable proxyclient operations on A7-A11, T2 SoCs.

### DIFF
--- a/proxyclient/experiments/mmio_sweep.py
+++ b/proxyclient/experiments/mmio_sweep.py
@@ -22,7 +22,10 @@ if args.print:
 		print(dev.name)
 	sys.exit(0)
 
-granule = 0x4000
+if chip_id in (0x8960, 0x7000, 0x7001):
+	granule = 0x1000
+else:
+	granule = 0x4000
 
 lp = LinkedProgram(u)
 lp.load_inline_c(f'''
@@ -96,7 +99,7 @@ else:
 
 pd_did_enable = set()
 pmgr = u.adt["/arm-io/pmgr"]
-ps_dev_by_id = {dev.id: dev for dev in pmgr.devices}
+ps_dev_by_id = {u.adt.pmgr_dev_get_id(dev): dev for dev in pmgr.devices}
 ps_deps = dict()
 ps_addrs = dict()
 
@@ -110,7 +113,7 @@ for dev in pmgr.devices:
 	ps_addrs[dev.name] = addr
 	ps_deps[dev.name] = [
 		ps_dev_by_id[idx].name for idx
-		in dev.parents if idx in ps_dev_by_id
+		in u.adt.pmgr_dev_get_parents(dev) if idx in ps_dev_by_id
 	]
 
 if lp.is_t6000():

--- a/proxyclient/m1n1/hv/__init__.py
+++ b/proxyclient/m1n1/hv/__init__.py
@@ -1482,7 +1482,7 @@ class HV(Reloadable):
 
         pmgr = self.adt["/arm-io/pmgr"]
         dev_by_name = {dev.name: dev for dev in pmgr.devices}
-        dev_by_id = {dev.id: dev for dev in pmgr.devices}
+        dev_by_id = {self.adt.pmgr_dev_get_id(dev): dev for dev in pmgr.devices}
 
         pmgr_hooks = []
 
@@ -1491,7 +1491,7 @@ class HV(Reloadable):
             if dev.psidx or dev.psreg:
                 addr = pmgr.get_reg(ps.reg)[0] + ps.offset + dev.psidx * 8
                 pmgr_hooks.append(addr)
-                for idx in dev.parents:
+                for idx in self.adt.pmgr_dev_get_parents(dev):
                     if idx in dev_by_id:
                         hook_pmgr_dev(dev_by_id[idx])
 

--- a/proxyclient/m1n1/hw/pmu.py
+++ b/proxyclient/m1n1/hw/pmu.py
@@ -3,6 +3,7 @@ import struct
 
 from ..utils import *
 from .spmi import SPMI
+from .i2c import I2C
 
 __all__ = ["PMU"]
 
@@ -11,26 +12,46 @@ class PMU:
     def __init__(self, u, adt_path=None):
         self.u = u
         if adt_path is None:
-            adt_path = PMU.find_primary_pmu(u.adt)
+            (adt_path, bus_type) = PMU.find_primary_pmu(u.adt)
 
         self.node = u.adt[adt_path]
-        self.spmi = SPMI(u, adt_path.rpartition('/')[0])
+        self.bus_type = bus_type
+        if bus_type == "spmi":
+            self.spmi = SPMI(u, adt_path.rpartition('/')[0])
+            self.primary = u.adt[adt_path].is_primary == 1
+        elif bus_type == "i2c":
+            self.i2c = I2C(u, adt_path.rpartition('/')[0])
+            self.primary = u.adt[adt_path].name == "pmu"
         self.adt_path = adt_path
-        self.primary = u.adt[adt_path].is_primary == 1
         self.reg = u.adt[adt_path].reg[0]
 
     def reset_panic_counter(self):
-        if self.primary:
+        if self.primary and self.bus_type == "spmi":
             leg_scrpad = self.node.info_leg__scrpad[0]
             self.spmi.write8(self.reg, leg_scrpad + 2, 0) # error counts
+        elif self.primary and self.bus_type == "i2c":
+            if self.node.compatible[0] in ["pmu,d2255", "pmu,d2257", "pmu,d2333", "pmu,d2365", "pmu,d2400"]:
+                counter = 0x5002
+            elif self.node.compatible[0] in ["pmu,d2045", "pmu,d2089", "pmu,d2186", "pmu,d2207"]:
+                counter = 0x4002
+            else:
+                print("Reset panic unsupported")
+                return
+            self.i2c.write_reg(self.reg, counter, [0], regaddrlen=2)
+        else:
+            raise ValueError("Unsupported bus type") # should never happen
 
     @staticmethod
     def find_primary_pmu(adt):
         for child in adt["/arm-io"]:
-            if child.name.startswith("nub-spmi"):
+            if child.name.startswith("nub-spmi") or child.name.startswith("spmi"):
                 for pmu in child:
                     compat = getattr(pmu, "compatible")[0] if hasattr(pmu, "compatible") else "unset"
                     primary = (getattr(pmu, "is-primary") == 1) if hasattr(pmu, "is-primary")  else False
-                    if compat == "pmu,spmi" and primary:
-                        return pmu._path.removeprefix('/device-tree')
-        raise KeyError(f"primary 'pmu,spmi' node not found")
+                    if compat in ("pmu,spmi", "pmu,d2422", "pmu,d2449") and primary:
+                        return (pmu._path.removeprefix('/device-tree'), "spmi")
+            elif child.name.startswith("i2c"):
+                for dev in child:
+                    if dev.name == "pmu":
+                        return (dev._path.removeprefix('/device-tree'), "i2c")
+        raise KeyError(f"primary pmu node not found")

--- a/proxyclient/m1n1/proxy.py
+++ b/proxyclient/m1n1/proxy.py
@@ -495,6 +495,7 @@ class M1N1Proxy(Reloadable):
     P_REBOOT = 0x010
     P_SLEEP = 0x011
     P_EL3_CALL = 0x012
+    P_GET_CHIPID = 0x013
 
     P_WRITE64 = 0x100
     P_WRITE32 = 0x101
@@ -769,6 +770,8 @@ class M1N1Proxy(Reloadable):
         if len(args) > 4:
             raise ValueError("Too many arguments")
         return self.request(self.P_EL3_CALL, addr, *args)
+    def get_chipid(self):
+        return self.request(self.P_GET_CHIPID)
 
     def write64(self, addr, data):
         '''write 8 byte value to given address'''

--- a/proxyclient/m1n1/proxyutils.py
+++ b/proxyclient/m1n1/proxyutils.py
@@ -555,6 +555,14 @@ def bootstrap_port(iface, proxy):
 
     if do_baud:
         try:
+            chip_id = proxy.get_chipid()
+            # These chips are too slow for baudrate 1500000 at their default frequency
+            if chip_id in (0x8960, 0x7000, 0x7001, 0x8000, 0x8001, 0x8003, 0x8010, 0x8011, 0x8015):
+                proxy.cpufreq_init()
+        # Old m1n1 version, assume they are not one of those chips
+        except ProxyCommandError: {}
+
+        try:
             iface.nop()
             proxy.set_baud(1500000)
         except UartTimeout:

--- a/proxyclient/tools/dump_pmgr.py
+++ b/proxyclient/tools/dump_pmgr.py
@@ -11,7 +11,7 @@ dt = u.adt
 
 pmgr = dt["/arm-io/pmgr"]
 
-dev_by_id = {dev.id: dev for dev in pmgr.devices}
+dev_by_id = {dt.pmgr_dev_get_id(dev): dev for dev in pmgr.devices}
 pd_by_id = {pd.id: pd for pd in pmgr.power_domains}
 clk_by_id = {clk.id: clk for clk in pmgr.clocks}
 
@@ -47,8 +47,8 @@ print()
 print("=== Devices ===")
 for i, dev in enumerate(pmgr.devices):
     flags = ", ".join(k for k in dev.flags if k[0] != "_" and dev.flags[k])
-    s = f" #{i:3d} {dev.name:20s} id: {dev.id:3d} psreg: {dev.psreg:2d}:{dev.psidx:2d} "
-    s += f" flags: {flags:24s} unk1_0: {dev.unk1_0} unk1_1: {dev.unk1_1} unk1_2: {dev.unk1_2} "
+    s = f" #{i:3d} {dev.name:20s} id: {u.adt.pmgr_dev_get_id(dev):3d} psreg: {dev.psreg:2d}:{dev.psidx:2d} "
+    s += f" flags: {flags:24s} unk1_0: {dev.unk1_0} unk1_1: {dev.unk1_1} id1: {dev.id1} "
     s += f" perf_reg: {dev.perf_block}:{dev.perf_idx:#04x} unk3: {dev.unk3:3d} {dev.unk2_0:2d} {dev.ps_cfg16:2d} {dev.unk2_3:3d}"
 
     if not dev.flags.no_ps:
@@ -63,10 +63,10 @@ for i, dev in enumerate(pmgr.devices):
         s += f" pd: {pd.name:20s}"
     else:
         s += "                         "
-    if any(dev.parents):
-        s += " parents: " + ", ".join(dev_by_id[idx].name if idx in dev_by_id else f"#{idx}" for idx in dev.parents if idx)
+    if any(dt.pmgr_dev_get_parents(dev)):
+        s += " parents: " + ", ".join(dev_by_id[idx].name if idx in dev_by_id else f"#{idx}" for idx in dt.pmgr_dev_get_parents(dev) if idx)
     print(s)
-    for i in dev_users.get(dev.id, []):
+    for i in dev_users.get(dt.pmgr_dev_get_id(dev), []):
         print(f"  User: {i}")
 
 print()
@@ -107,6 +107,10 @@ for clk in range(256):
             print(f"  User: {j}")
 
 print()
+
+if chip_id in (0x8960, 0x7000, 0x7001, 0x8000, 0x8001, 0x8003, 0x8010, 0x8012, 0x8015):
+    exit(0)
+
 print("=== Boot clocks ===")
 for i, (freq, reg, nclk) in enumerate(zip(arm_io.clock_frequencies,
                                           arm_io.clock_frequencies_regs,

--- a/proxyclient/tools/pmgr_adt2dt.py
+++ b/proxyclient/tools/pmgr_adt2dt.py
@@ -18,7 +18,7 @@ dt = adt.load_adt(adt_data)
 
 pmgr = dt["/arm-io/pmgr"]
 
-dev_by_id = {dev.id: dev for dev in pmgr.devices}
+dev_by_id = {dt.pmgr_dev_get_id(dev): dev for dev in pmgr.devices}
 
 blocks = {}
 maxaddr = {}
@@ -83,8 +83,8 @@ for i, ((base, size), devices) in enumerate(sorted(blocks.items())):
         if dev.flags.critical:
             print("\t\tapple,always-on;")
 
-        if any(dev.parents):
-            domains = [f"<&{die_node('ps_'+dev_by_id[idx].name.lower())}>" for idx in dev.parents if idx]
+        if any(dt.pmgr_dev_get_parents(dev)):
+            domains = [f"<&{die_node('ps_'+dev_by_id[idx].name.lower())}>" for idx in dt.pmgr_dev_get_parents(dev) if idx]
             print(f"\t\tpower-domains = {', '.join(domains)};")
 
         print( "\t};")

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -119,6 +119,7 @@ int proxy_process(ProxyRequest *request, ProxyReply *reply)
         case P_EL3_CALL:
             reply->retval = el3_call((void *)request->args[0], request->args[1], request->args[2],
                                      request->args[3], request->args[4]);
+            break;
 
         case P_WRITE64:
             exc_guard = GUARD_SKIP;

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -120,6 +120,9 @@ int proxy_process(ProxyRequest *request, ProxyReply *reply)
             reply->retval = el3_call((void *)request->args[0], request->args[1], request->args[2],
                                      request->args[3], request->args[4]);
             break;
+        case P_GET_CHIPID:
+            reply->retval = chip_id;
+            break;
 
         case P_WRITE64:
             exc_guard = GUARD_SKIP;

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -25,6 +25,7 @@ typedef enum {
     P_REBOOT,
     P_SLEEP,
     P_EL3_CALL,
+    P_GET_CHIPID,
 
     P_WRITE64 = 0x100, // Generic register functions
     P_WRITE32,


### PR DESCRIPTION
This PR enables the proxyclient to be used through the physical UART on A7-A11, T2 SoCs.

On A7-A11, the default frequency is too slow for baudrate 1500000, so change the CPU frequency before going into that baud rate. (T2 default frequency is fast enough)

Support the PMU in A7-A10X, which is over I2C, and the PMU in A11, T2, which is over "spmi,gen0" SPMI. In either case, the panic counter does not seem to exist.

Finally, add support for /arm-io/pmgr with 8-bit IDs. Do note that any hypervisor modifications are not tested.