### PR TITLE
utils/proxy: Fix cpu_sleep global sleep handling

### DIFF
--- a/src/smp.c
+++ b/src/smp.c
@@ -192,7 +192,7 @@ static void smp_stop_cpu(int index, int die, int cluster, int core, u64 impl, u6
 
     u64 dsleep = deep_sleep;
     // Put the CPU to sleep
-    smp_call2(index, cpu_sleep, dsleep, cpufeat_global_sleep);
+    smp_call1(index, cpu_sleep, dsleep);
 
     // If going into deep sleep, powering off the last core in a cluster kills our register
     // access, so just wait a bit.

--- a/src/utils_asm.S
+++ b/src/utils_asm.S
@@ -179,13 +179,16 @@ deep_wfi:
 
     ret
 
+.extern cpufeat_global_sleep
 .globl cpu_sleep
 .type cpu_sleep, @function
 cpu_sleep:
+    adrp x4, cpufeat_global_sleep
+    add x4, x4, :lo12:cpufeat_global_sleep
+    ldrb w4, [x4]
+
     cmp x0, #0
     bne 1f
-
-    mov x4, x1
 
     mrs x1, SYS_IMP_APL_CYC_OVRD
     and x1, x1, #~CYC_OVRD_IRQ_MODE_MASK


### PR DESCRIPTION
da3519de142 introduced the additional argument cpufeat_global_sleep to cpu_sleep but did neither update its prototype nor the call inside proxy.c. Instead of adding a new argument just directly load the value of cpufeat_global_sleep and use it instead.

Fixes: da3519de142