### PR TITLE
kboot: Add ethernet1 alias

### DIFF
--- a/src/kboot.c
+++ b/src/kboot.c
@@ -669,6 +669,10 @@ static struct {
         .fdt_property = "local-mac-address",
     },
     {
+        .alias = "ethernet1",
+        .fdt_property = "local-mac-address",
+    },
+    {
         .alias = "wifi0",
         .fdt_property = "local-mac-address",
     },


### PR DESCRIPTION
The Mac Pro (j180d) has 2 ethernet nics. Add "ethernet1" as alias so the MAC address of the second nic is transferred to the devicetree as well.