### PR TITLE
Fix PAN issue

### DIFF
--- a/src/memory.c
+++ b/src/memory.c
@@ -542,7 +542,7 @@ void mmu_init(void)
         mmu_init_sprr();
 
     // Enable EL0 memory access by EL1
-    if (supports_pan())
+    if (has_pan)
         msr(PAN, 0);
 
     // RES1 bits
@@ -562,7 +562,7 @@ static void mmu_secondary_setup(void)
         mmu_init_sprr();
 
     // Enable EL0 memory access by EL1
-    if (supports_pan())
+    if (has_pan)
         msr(PAN, 0);
 
     // RES1 bits

--- a/src/start.S
+++ b/src/start.S
@@ -81,6 +81,18 @@ _start:
     mov w0, 'n'
     bl debug_putc
 
+    adrp x1, _bss_start
+    add x1, x1, :lo12:_bss_start
+    adrp x2, _bss_end
+    add x2, x2, :lo12:_bss_end
+    cmp x2, x1
+    beq 1f
+1:
+    str xzr, [x1], #8
+    cmp x1, x2
+    b.lo 1b
+2:
+
     adrp x0, _base
     mov x20, x0
     adrp x1, _rela_start
@@ -95,6 +107,7 @@ _start:
     bl debug_putc
     mov w0, '\n'
     bl debug_putc
+
     bl pan_fixup
 
     mrs x8, CurrentEL

--- a/src/startup.c
+++ b/src/startup.c
@@ -165,7 +165,6 @@ void _start_c(void *boot_args, void *base)
     UNUSED(base);
     u32 cpu_id = 0;
 
-    memset64(_bss_start, 0, _bss_end - _bss_start);
     boot_args_addr = (u64)boot_args;
     memcpy(&cur_boot_args, boot_args, sizeof(cur_boot_args));
 

--- a/src/startup.c
+++ b/src/startup.c
@@ -14,6 +14,7 @@
 u64 boot_args_addr;
 struct boot_args cur_boot_args;
 void *adt;
+bool has_pan;
 
 struct rela_entry {
     uint64_t off, type, addend;
@@ -49,7 +50,8 @@ void apply_rela(uint64_t base, struct rela_entry *rela_start, struct rela_entry 
 extern uint32_t _v_sp0_sync[], _v_sp0_irq[], _v_sp0_fiq[], _v_sp0_serr[];
 void pan_fixup(void)
 {
-    if (supports_pan())
+    has_pan = ((mrs(ID_AA64MMFR1_EL1) >> 20) & 0xf) != 0;
+    if (has_pan)
         return;
 
     /* Patch msr pan, #0 to nop */

--- a/src/utils.c
+++ b/src/utils.c
@@ -197,11 +197,6 @@ bool supports_gxf(void)
     return mrs(AIDR_EL1) & AIDR_EL1_GXF;
 }
 
-bool supports_pan(void)
-{
-    return (mrs(ID_AA64MMFR1_EL1) >> 20) & 0xf;
-}
-
 // TODO: update mapping?
 u64 top_of_memory_alloc(size_t size)
 {

--- a/src/utils.h
+++ b/src/utils.h
@@ -479,6 +479,7 @@ extern u32 board_id, chip_id;
 extern bool is_mac;
 extern bool cpufeat_actlr_el2, cpufeat_fast_ipi, cpufeat_mmu_sprr;
 extern bool cpufeat_global_sleep, cpufeat_workaround_cyclone_cache;
+extern bool has_pan;
 
 extern struct vector_args next_stage;
 extern u64 boot_flags, mem_size_actual;
@@ -489,7 +490,6 @@ void deep_wfi(void);
 bool is_heap(void *addr);
 bool supports_arch_retention(void);
 bool supports_gxf(void);
-bool supports_pan(void);
 u64 top_of_memory_alloc(size_t size);
 
 #endif


### PR DESCRIPTION
It seems like that check if PAN is supported (introduced in [869d2ae35c31e14935a63492070699aa359df717](https://github.com/AsahiLinux/m1n1/commit/869d2ae35c31e14935a63492070699aa359df717)) by reading MSR _ID_AA64MMFR1_EL1_ may fail under some circumstances which happens everytime at least on my Mac Mini 2023 (T8112) that cause early XNU's panic with this exception in m1n1's log:

```
TTY> Running in EL2
TTY> MPIDR: 0x80000001
TTY> Registers: (@0x804ad7dd0)
TTY>   x0-x3: 0000000000000001 0000000000000000 0000000000000000 0000000000000000
TTY>   x4-x7: 0000000000000000 0000000000000000 0000000000000000 0000000000000000
TTY>  x8-x11: 0000000030901085 0000000000000001 a005a500f005f00f f005a500f00ff00f
TTY> x12-x15: 0000000000000000 0000000000000000 0000000000000000 0000000000000000
TTY> x16-x19: 0000000000000000 0000000000000000 00000000fffffff5 0000000803541260
TTY> x20-x23: 000000080353800a 0000000803541000 0000000000000001 0000000000000000
TTY> x24-x27: 0000000000000000 0000000000000000 0000000000000000 0000000000000000
TTY> x28-x30: 0000000000000000 00000008034a8f04 0000000002000000
TTY> PC:       0x2000000 (rel: 0xfffffff7feb80000)
TTY> SP:       0x804ad7ed0
TTY> SPSR:     0x10c9
TTY> FAR:      0x2000000
TTY> ESR:      0x86000006 (instruction abort (current))
TTY> L2C_ERR_STS: 0x0
TTY> L2C_ERR_ADR: 0x0
TTY> L2C_ERR_INF: 0x0
TTY> E_LSU_ERR_STS: 0x0
TTY> E_FED_ERR_STS: 0x0
TTY> E_MMU_ERR_STS: 0x0
```

Fixing this by caching PAN bit value at early m1n1's boot.