### PR TITLE
payload: Fix m1n1 stage 1 version passing

### DIFF
--- a/src/payload.c
+++ b/src/payload.c
@@ -168,7 +168,7 @@ static void *load_kernel(void *p, size_t size)
 #ifdef CHAINLOADING
 static size_t chosen_cnt = 1;
 static char *chosen[MAX_CHOSEN_VARS] = {
-    "chosen.m1n1-stage1-version=" BUILD_TAG,
+    "chosen.asahi,m1n1-stage1-version=" BUILD_TAG,
 };
 #else
 static size_t chosen_cnt = 0;
@@ -303,8 +303,6 @@ int payload_run(void)
         printf("Cannot find target type! %p %p\n", target, adt);
         return -1;
     }
-
-    chosen_cnt = 0;
 
     void *p = _payload_start;
 


### PR DESCRIPTION
The pre-configured property was ignored and lacked the "asahi," prefix that we use for other version properties.