### PR TITLE
Makefile: Optionally build rust code with -Z build-std

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,12 @@ CFG += CHAINLOADING
 RUST_LIBS += $(RUST_LIB)
 endif
 
+ifeq ($(BUILDSTD),1)
+CARGO_FLAGS := -Z build-std=alloc,core
+else
+CARGO_FLAGS :=
+endif
+
 LDFLAGS := -EL -maarch64elf --no-undefined -X -Bsymbolic \
 	-z notext --no-apply-dynamic-relocs --orphan-handling=warn \
 	-z nocopyreloc --gc-sections -pie
@@ -197,7 +203,7 @@ build/$(RUST_LIB): rust/src/* rust/*
 	$(QUIET)echo "  RS    $@"
 	$(QUIET)mkdir -p $(DEPDIR)
 	$(QUIET)mkdir -p "$(dir $@)"
-	$(QUIET)cargo build --target $(RUSTARCH) --lib --release --manifest-path rust/Cargo.toml --target-dir build
+	$(QUIET)cargo build $(CARGO_FLAGS) --target $(RUSTARCH) --lib --release --manifest-path rust/Cargo.toml --target-dir build
 	$(QUIET)cp "build/$(RUSTARCH)/release/${RUST_LIB}" "$@"
 
 build/%.o: src/%.S


### PR DESCRIPTION
Allows building m1n1's rust components on systems without rustup support.  Removes the need to install the
aarch64-unknown-node-softfloat toolchain.  But it does require the rust-src component to be installed.