### PR TITLE
Handle missing WLAN/BT calibration data gracefully

### DIFF
--- a/src/kboot.c
+++ b/src/kboot.c
@@ -787,8 +787,10 @@ static int dt_set_bluetooth_cal(int anode, int node, const char *adt_name, const
     u32 len;
     const u8 *cal_blob = adt_getprop(adt, anode, adt_name, &len);
 
-    if (!cal_blob || !len)
-        bail("ADT: Failed to get %s\n", adt_name);
+    if (!cal_blob || !len) {
+        printf("ADT: Failed to get %s. Replaced module?\n", adt_name);
+        return 0;
+    }
 
     fdt_setprop(dt, node, fdt_name, cal_blob, len);
     return 0;

--- a/src/kboot.c
+++ b/src/kboot.c
@@ -993,8 +993,10 @@ static int dt_set_wifi(void)
     u32 len;
     const u8 *cal_blob = adt_getprop(adt, anode, "wifi-calibration-msf", &len);
 
-    if (!cal_blob || !len)
-        bail("ADT: Failed to get wifi-calibration-msf\n");
+    if (!cal_blob || !len) {
+        printf("ADT: Failed to get wifi-calibration-msf. Replaced module?\n");
+        return 0;
+    }
 
     fdt_setprop(dt, node, "brcm,cal-blob", cal_blob, len);
 


### PR DESCRIPTION
Devices with exchanged WLAN/BT omit calibration data in the ADT. The calibration data isa stored in Facory Data Recovery partition instead. Continue booting in such cases. WLAN and BT driver will fail to probe until an alternative way to provide the calibration data is implemented.
The only models with replaceable WLAN/BT modules are to my knowledge Mac Pro (M2 Ultra) and Mac mini (M4/M4 Pro).