### PR TITLE
Only compile assembly codes as armv8.2-a

### DIFF
--- a/src/hv.h
+++ b/src/hv.h
@@ -106,6 +106,8 @@ u64 hv_get_far(void);
 u64 hv_get_elr(void);
 u64 hv_get_afsr1(void);
 void hv_set_elr(u64 val);
+void hv_spin_lock(spinlock_t *lock);
+void hv_spin_unlock(spinlock_t *lock);
 
 /* HV main */
 void hv_init(void);

--- a/src/utils.h
+++ b/src/utils.h
@@ -266,7 +266,9 @@ static inline void write64_lo_hi(u64 addr, u64 val)
 #define __mrs(reg)                                                                                 \
     ({                                                                                             \
         u64 val;                                                                                   \
-        __asm__ volatile("mrs\t%0, " #reg : "=r"(val));                                            \
+        __asm__ volatile(".arch armv8.2-a\n"                                                       \
+                         "mrs\t%0, " #reg                                                          \
+                         : "=r"(val));                                                             \
         val;                                                                                       \
     })
 #define _mrs(reg) __mrs(reg)
@@ -274,7 +276,10 @@ static inline void write64_lo_hi(u64 addr, u64 val)
 #define __msr(reg, val)                                                                            \
     ({                                                                                             \
         u64 __val = (u64)val;                                                                      \
-        __asm__ volatile("msr\t" #reg ", %0" : : "r"(__val));                                      \
+        __asm__ volatile(".arch armv8.2-a\n"                                                       \
+                         "msr\t" #reg ", %0"                                                       \
+                         :                                                                         \
+                         : "r"(__val));                                                            \
     })
 #define _msr(reg, val) __msr(reg, val)
 


### PR DESCRIPTION
Compile C code as base armv8-a, and compile assembly codes as armv8.2-a to allow m1n1 to be properly compiled for older SoCs.