### PR TITLE
kboot_gpu: Fix booting with v6.17-rc1 upstream DT

### DIFF
--- a/src/kboot_gpu.c
+++ b/src/kboot_gpu.c
@@ -500,6 +500,23 @@ int dt_set_gpu(void *dt)
         return 0;
     }
 
+    /* check for old-style downstream compatibles */
+    bool downstream_dtb = false;
+    downstream_dtb |= fdt_node_check_compatible(dt, gpu, "apple,agx-t8103") == 0;
+    downstream_dtb |= fdt_node_check_compatible(dt, gpu, "apple,agx-t8112") == 0;
+    downstream_dtb |= fdt_node_check_compatible(dt, gpu, "apple,agx-t6000") == 0;
+    downstream_dtb |= fdt_node_check_compatible(dt, gpu, "apple,agx-t6001") == 0;
+    downstream_dtb |= fdt_node_check_compatible(dt, gpu, "apple,agx-t6002") == 0;
+    downstream_dtb |= fdt_node_check_compatible(dt, gpu, "apple,agx-t6020") == 0;
+    downstream_dtb |= fdt_node_check_compatible(dt, gpu, "apple,agx-t6021") == 0;
+    downstream_dtb |= fdt_node_check_compatible(dt, gpu, "apple,agx-t6022") == 0;
+
+    if (!downstream_dtb) {
+        printf("FDT: no old style agx compatible found, disabling GPU node\n");
+        fdt_setprop_string(dt, gpu, "status", "disabled");
+        return 0;
+    }
+
     int len;
     const fdt32_t *opps_ph = fdt_getprop(dt, gpu, "operating-points-v2", &len);
     if (!opps_ph || len != 4)


### PR DESCRIPTION
Booting with Linux 6.17-rc1 device trees fails due to missing "operating-points-v2" properties. Check for the downstream only "apple,agx-t*" compatible strings and disable the gpu node if those are not found.
This serves as temporary fix until
https://github.com/AsahiLinux/m1n1/pull/466 is merged.