### PR TITLE
Handle hpm/cd3217 nodes on the Mac Pro

### DIFF
--- a/proxyclient/m1n1/hv/__init__.py
+++ b/proxyclient/m1n1/hv/__init__.py
@@ -1612,6 +1612,8 @@ class HV(Reloadable):
                            "/arm-io/dart-apciec%d",
                            "/arm-io/apciec%d-piodma",
                            "/arm-io/i2c0/hpmBusManager/hpm%d",
+                           "/arm-io/i2c0/hpmBusManager1/hpm%d",
+                           "/arm-io/i2c3/hpmBusManager0/hpm%d",
                            "/arm-io/nub-spmi-a0/hpm%d",
                            "/arm-io/atc%d-dpxbar",
                            "/arm-io/atc%d-dpphy",


### PR DESCRIPTION
The Mac Pro (M2 Ultra, 2023) splits its eight cd3217 USB-C port
controller chips over two i2c busses with a separate hpmBusmanager. The
rear 6 ports use i2c0 and hpmBusManager1. The top 2 ports use i2c3 and
hpmBusManager0. This clashes with current hard-coded path. Instead use
ADT properties to enumerate all hpm nodes on i2c0 and i2c3 to cover the
Mac Pro.
In m1n1's hypervisor add the additional possible paths for deleted nodes.