### PR TITLE
CI: uefi-only: Run on tags and `releases/*` branches

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -8,7 +8,8 @@ on:
   # build workflow so failures here are likely caused by the external
   # sources. No need to run this on pull-requests unless this file is changed.
   push:
-    branches: [ main ]
+    branches: [ main, 'releases/**' ]
+    tags: [ 'v*' ]
   pull_request:
     branches: [ main ]
     paths: [ .github/workflows/installer.yml ]


### PR DESCRIPTION
Only runs on tags shall be used to update the package for the uefi-only installer target. Testing on release branches ensures that the workflow runs before a tag is created.

Intended for https://github.com/AsahiLinux/m1n1/tree/releases/1.5.1 and a `v1.5.1` tag to be created on that branch.