### PR TITLE
Rust ADT fixes and improvements

### DIFF
--- a/rust/src/adt.rs
+++ b/rust/src/adt.rs
@@ -277,17 +277,22 @@ impl ADTNode {
         }
     }
 
+    /// Get a reference to the root node
+    pub fn root() -> Result<&'static ADTNode, AdtError> {
+        let ptr: *const ADTNode = unsafe { adt as *const ADTNode };
+        ADTNode::from_ptr(ptr)
+    }
+
     /// Get a reference to a node at a specified path, tracing the path to the
     /// desired node
     pub fn from_path_trace(
         path: &str,
         mut breadcrumbs: Option<&mut [Option<&'static ADTNode>]>,
     ) -> Result<&'static ADTNode, AdtError> {
-        let ptr: *const ADTNode = unsafe { adt as *const ADTNode };
         let mut p = path;
         let mut bc_idx: usize = 0;
 
-        let head = ADTNode::from_ptr(ptr)?;
+        let head = ADTNode::root()?;
         let mut n = head;
 
         while !p.is_empty() {

--- a/rust/src/adt.rs
+++ b/rust/src/adt.rs
@@ -453,7 +453,8 @@ impl ADTNode {
     }
 
     pub fn is_compatible(&self, compatible: &str) -> Result<bool, AdtError> {
-        Ok(self.named_prop("compatible")?.str()?.contains(compatible))
+        let prop = self.named_prop("compatible")?;
+        Ok(prop.str_iter().any(|c| c == compatible))
     }
 
     pub fn compatible(&self, index: usize) -> Option<&str> {

--- a/src/adt.h
+++ b/src/adt.h
@@ -56,6 +56,7 @@ int adt_getprop_copy(const void *adt, int nodeoffset, const char *name, void *ou
 
 int adt_get_reg(const void *adt, int *path, const char *prop, int idx, u64 *addr, u64 *size);
 bool adt_is_compatible(const void *adt, int nodeoffset, const char *compat);
+bool adt_is_compatible_at(const void *adt, int nodeoffset, const char *compat, size_t index);
 
 #define ADT_FOREACH_CHILD(adt, node)                                                               \
     for (int _child_count = adt_get_child_count(adt, node); _child_count; _child_count = 0)        \

--- a/src/kboot_atc.c
+++ b/src/kboot_atc.c
@@ -293,7 +293,7 @@ static int dt_append_atc_fuses_helper(void *dt, int fdt_node, const struct atc_f
 static int dt_append_fuses(void *dt, int adt_node, int fdt_node, int port)
 {
     for (size_t i = 0; i < ARRAY_SIZE(atc_fuses); ++i) {
-        if (!adt_is_compatible(adt, adt_node, atc_fuses[i].compatible))
+        if (!adt_is_compatible_at(adt, adt_node, atc_fuses[i].compatible, 0))
             continue;
         if (atc_fuses[i].port >= 0 && port != atc_fuses[i].port)
             continue;


### PR DESCRIPTION
```
-------------------------------------------------------------------------------------------------------------
rust: adt: Add adt property string iterator

This will be used to check all compatible strings in
`adt_is_compatible()`. For now use it to implement ADTNode::compatible()
returning the n-th compatible string on rust side and the C wrapper
function adt_is_compatible_at().
-------------------------------------------------------------------------------------------------------------
kboot_atc: fuses: Check only the first compatible

The t602x atc-phy nodes carry "[atc-phy,t6020, atc-phy,t8112]" as
compatible property. This results in trying to read t8112 fuses on those
machines which fails with SError when the adt_is_compatible() regression
is fixed.
-------------------------------------------------------------------------------------------------------------
rust: adt: Test all compatible strings in adt_is_compatible()

Fixes a regression in the ADT rust reimplementation checking only the
first compatible.

Closes: https://github.com/AsahiLinux/m1n1/issues/496
-------------------------------------------------------------------------------------------------------------
rust: adt: Add ADTNode::root() convenience function

Simplifies referencing the root ADT node in rust code.
```