### PR TITLE
CI: build/installer: Install aarch64-unknown-none-softfloat target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y gcc-aarch64-linux-gnu
 
-      - name: Install nightly rust
+      - name: Install aarch64-unknown-none-softfloat rust target
         run: |
-          export RUSTUP_TOOLCHAIN=stable
           rustup target install aarch64-unknown-none-softfloat
 
       - name: Build

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -51,9 +51,8 @@ jobs:
                                libgnutls28-dev \
                                device-tree-compiler
 
-      - name: Install nightly rust
+      - name: Install aarch64-unknown-none-softfloat rust target
         run: |
-          export RUSTUP_TOOLCHAIN=stable
           rustup target install aarch64-unknown-none-softfloat
 
       # env vars to include date and kernel tag in artifact name


### PR DESCRIPTION
Do not explicitily request rustup's stable toolchain as that will not be fully installed when it diverges from the rust install in github's CI runner image.