### PR TITLE
Fix type error in PMU reset_panic_counter for M3 chips

### DIFF
--- a/proxyclient/m1n1/hw/pmu.py
+++ b/proxyclient/m1n1/hw/pmu.py
@@ -27,7 +27,8 @@ class PMU:
 
     def reset_panic_counter(self):
         if self.primary and self.bus_type == "spmi":
-            leg_scrpad = self.node.info_leg__scrpad[0]
+            leg_scrpad_val = self.node.info_leg__scrpad
+            leg_scrpad = leg_scrpad_val if isinstance(leg_scrpad_val, int) else leg_scrpad_val[0]
             self.spmi.write8(self.reg, leg_scrpad + 2, 0) # error counts
         elif self.primary and self.bus_type == "i2c":
             if self.node.compatible[0] in ["pmu,d2255", "pmu,d2257", "pmu,d2333", "pmu,d2365", "pmu,d2400"]:


### PR DESCRIPTION
On M3 Max and potentially other newer chips, the `info_leg__scrpad` ADT property is an integer rather than an array. This causes a `TypeError: 'int' object is not subscriptable` when the code attempts to access `self.node.info_leg__scrpad[0]`.

This PR adds type checking to handle both cases - if the value is already an integer, it uses it directly; otherwise, it takes the first element of the array.

Fixes #449