### PR TITLE
ci: Replace unsupported macos-13 runner with macos-15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,9 @@ jobs:
             compiler: gcc
           - os: ubuntu-latest
             compiler: llvm
-          - os: macos-13
-            compiler: llvm-brew
           - os: macos-14
+            compiler: llvm-brew
+          - os: macos-15
             compiler: llvm-brew
 
     steps:


### PR DESCRIPTION
The macos-13 runner is unsupported since 2025-12-04  
https://github.com/actions/runner-images/issues/13046