### PR TITLE
fix rustc 1.92.0 warnings

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -4,7 +4,6 @@
 #![feature(cfg_version)]
 #![feature(alloc_error_handler)]
 #![cfg_attr(not(version("1.82")), feature(new_uninit))]
-#![cfg_attr(version("1.82"), feature(new_zeroed_alloc))]
 
 #[macro_use]
 extern crate alloc;


### PR DESCRIPTION
Removing
warning: the feature `new_zeroed_alloc` has been stable since 1.92.0 and no longer requires an attribute to enable
in rust/src/lib.rs