### PR TITLE
CI: bump clang-format from 18 to 20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,18 +27,18 @@ jobs:
           rm -f ~/.cargo/bin/cargo-fmt
           rustup toolchain install nightly --component rustfmt --component clippy --allow-downgrade
 
-      - name: install clang-format-18
+      - name: install clang-format-20
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main'
           sudo apt update
-          sudo apt install clang-format-18
+          sudo apt install clang-format-20
 
       - name: Run format-check
         run: |
           . "$HOME/.cargo/env"
-          make format CLANG_FORMAT=clang-format-18
+          make format CLANG_FORMAT=clang-format-20
           git diff
           git reset --hard
-          make format-check CLANG_FORMAT=clang-format-18
+          make format-check CLANG_FORMAT=clang-format-20
           make rustfmt-check

--- a/src/exception.c
+++ b/src/exception.c
@@ -313,7 +313,7 @@ void exc_sync(u64 *regs)
         u32 imm = mrs(ESR_EL3) & 0xffff;
         switch (imm) {
             case 42:
-                regs[0] = ((uint64_t(*)(uint64_t, uint64_t, uint64_t, uint64_t))regs[0])(
+                regs[0] = ((uint64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t))regs[0])(
                     regs[1], regs[2], regs[3], regs[4]);
                 return;
             default:

--- a/src/smp.c
+++ b/src/smp.c
@@ -94,8 +94,8 @@ void smp_secondary_entry(void)
         sysop("dmb sy");
         me->flag++;
         sysop("dmb sy");
-        me->retval = ((u64(*)(u64 a, u64 b, u64 c, u64 d))target)(me->args[0], me->args[1],
-                                                                  me->args[2], me->args[3]);
+        me->retval = ((u64 (*)(u64 a, u64 b, u64 c, u64 d))target)(me->args[0], me->args[1],
+                                                                   me->args[2], me->args[3]);
         sysop("dmb sy");
         me->target = 0;
         sysop("dmb sy");


### PR DESCRIPTION
20 is the default shipped with fedora and also what i have on macOS and I've been annoyed by the two small things it does differently than 18 for a while now. 