### PR TITLE
hv: Adjust ADT default-serial to uart0

### DIFF
--- a/proxyclient/m1n1/hv/__init__.py
+++ b/proxyclient/m1n1/hv/__init__.py
@@ -1600,6 +1600,10 @@ class HV(Reloadable):
         soc_name = "Virtual " + self.adt["product"].product_soc_name + " on m1n1 hypervisor"
         self.adt["product"].product_soc_name = soc_name
 
+        # change default serial to uart0 instead of UART-via-dockchannel
+        # to re-enable XNU serial output for newer macOS versions
+        self.adt["defaults"].serial_device = getattr(self.adt["/arm-io/uart0"], "AAPL,phandle")
+
         if self.iodev >= IODEV.USB0:
             idx = self.iodev - IODEV.USB0
             for prefix in ("/arm-io/dart-usb%d",


### PR DESCRIPTION
As figured out by @dhinakg [1] recent XNU defaults to serial via Dockchannel which we currently don't virtualize inside the HV. Switch back to the Samsung UART by adjusting the defaults inside the ADT passed to the guest.

[1] https://gist.github.com/dhinakg/3fcd9ad43c82c96964b4f64eb05e6a5e