### PR TITLE
m1n1.adt: Do not embed "pmgr_u8id" into built ADT

### DIFF
--- a/proxyclient/m1n1/adt.py
+++ b/proxyclient/m1n1/adt.py
@@ -810,16 +810,16 @@ class ADTNode:
         return node
 
     def pmgr_init(self):
-        self.pmgr_u8id = (self["/arm-io/pmgr"].devices[0].id1 != self["/arm-io/pmgr"].devices[1].id1)
+        self._pmgr_u8id = (self["/arm-io/pmgr"].devices[0].id1 != self["/arm-io/pmgr"].devices[1].id1)
 
     def pmgr_dev_get_id(self, dev):
-        if self.pmgr_u8id:
+        if self._pmgr_u8id:
             return dev.id1
         else:
             return dev.id2
 
     def pmgr_dev_get_parents(self, dev):
-        if self.pmgr_u8id:
+        if self._pmgr_u8id:
             return dev.parents_un.u8id.parents 
         else:
             return dev.parents_un.u16id.parents 


### PR DESCRIPTION
ADTNode member variables are added as properties into the ADT. Prevent this for pmgr_u8id by prefixing it with '_'.

Fixes: edc2178e5977 ("proxyclient: Add support for /arm-io/pmgr with 8-bit IDs")