### PR TITLE
T8132 smp

### DIFF
--- a/proxyclient/m1n1/hv/__init__.py
+++ b/proxyclient/m1n1/hv/__init__.py
@@ -1785,8 +1785,13 @@ class HV(Reloadable):
             if cpu.state == "running":
                 continue
             addr, size = cpu.cpu_impl_reg
-            print(f"  {cpu.name}: [0x{addr:x}] = 0x{rvbar:x}")
-            self.p.write64(addr, rvbar)
+            val = self.p.read64(addr)
+            if val & 0xffff_ffff_f000 != rvbar:
+                if val & 1:
+                    raise Exception(f"RVBAR for {cpu.name} (={val:x}) is locked but differs from entry point (={rvbar:x})")
+
+                print(f"  {cpu.name}: [0x{addr:x}] = 0x{rvbar:x}")
+                self.p.write64(addr, rvbar)
 
     def _load_macho_symbols(self):
         self.symbol_dict = self.macho.symbols

--- a/proxyclient/tools/chainload.py
+++ b/proxyclient/tools/chainload.py
@@ -99,8 +99,13 @@ for cpu in u.adt["cpus"]:
     if cpu.state == "running":
         continue
     addr, size = cpu.cpu_impl_reg
-    print(f"  {cpu.name}: [0x{addr:x}] = 0x{rvbar:x}")
-    p.write64(addr, rvbar)
+    val = p.read64(addr)
+    if val & 0xffff_ffff_f000 != rvbar:
+        if val & 1:
+            raise Exception(f"RVBAR for {cpu.name} (={val:x}) is locked but differs from entry point (={rvbar:x})")
+
+        print(f"  {cpu.name}: [0x{addr:x}] = 0x{rvbar:x}")
+        p.write64(addr, rvbar)
 
 u.push_adt()
 

--- a/src/smp.c
+++ b/src/smp.c
@@ -267,6 +267,7 @@ void smp_start_secondaries(void)
             break;
         case T8112:
         case T8122:
+        case T8132:
             cpu_start_off = CPU_START_OFF_T8112;
             break;
         case T6020:

--- a/src/smp.c
+++ b/src/smp.c
@@ -24,6 +24,9 @@
 #define CPU_REG_CLUSTER GENMASK(10, 8)
 #define CPU_REG_DIE     GENMASK(14, 11)
 
+#define RVBAR_LOCK BIT(0)
+#define RVBAR_ADDR GENMASK(47, 12)
+
 struct spin_table {
     u64 mpidr;
     u64 flag;
@@ -123,6 +126,14 @@ static void smp_start_cpu(int index, int die, int cluster, int core, u64 impl, u
 
     printf("Starting CPU %d (%d:%d:%d)... ", index, die, cluster, core);
 
+    u64 rvbar_value = read64(impl);
+    bool write_rvbar = FIELD_GET(RVBAR_ADDR, rvbar_value) != (u64)_vectors_start;
+    if (FIELD_GET(RVBAR_LOCK, rvbar_value) && write_rvbar) {
+        printf("Failed! \n    RVBAR (=0x%lx) is locked and differs from entry point (=0x%lx)\n",
+               rvbar_value, (u64)_vectors_start);
+        return;
+    }
+
     memset(&spin_table[index], 0, sizeof(struct spin_table));
 
     target_cpu = index;
@@ -140,7 +151,9 @@ static void smp_start_cpu(int index, int die, int cluster, int core, u64 impl, u
 
     sysop("dsb sy");
 
-    write64(impl, (u64)_vectors_start);
+    if (write_rvbar) {
+        write64(impl, (u64)_vectors_start);
+    }
 
     cpu_start_base += die * PMGR_DIE_OFFSET;
 


### PR DESCRIPTION
According to the discussion [here](https://oftc.catirclogs.org/asahi-re/2025-04-06#34157602), the RVBAR at cpu_impl_reg+0x00 is already set to the m1n1 entrypoint and locked by iBoot _for all cores_ on M4.

Indeed, I can see the following values:

m1n1 base: `0x100034f4000`
E-Cores cpu_impl_reg at `0x210X50000`: `0x100100034f4001`
P-Cores cpu_impl_reg at `0x211X50000`: `0x1100100034f4001`

And voila, when skipping the writes when the value is already correct (which previously produced SErrors when writing to the P-Core cpu_impl_reg), `smp_start_secondaries()` now works as expected.
