### PR TITLE
tools/linux.py: Fix u-boot boot and add support for booting EFI stubs via u-boot

### DIFF
--- a/proxyclient/tools/linux.py
+++ b/proxyclient/tools/linux.py
@@ -94,6 +94,8 @@ if args.u_boot:
     bootenv = list(filter(lambda x: not (
         x.startswith("baudrate") or
         x.startswith("boot_") or
+        x.startswith("bootdelay=") or
+        x.startswith("preboot=") or
         x.startswith("bootcmd")
         ), bootenv))
 
@@ -109,6 +111,7 @@ if args.u_boot:
     if tty_dev is not None:
         bootenv.append("baudrate=%d" % tty_dev.baudrate)
     bootenv.append(bootcmd)
+    bootenv.append("bootdelay=0")
     if args.bootargs is not None:
         bootenv.append("bootargs=" + args.bootargs)
 


### PR DESCRIPTION
Switching from u-boot's distro boot scripts to standard boot broke `./tools/linux.py --u-boot ...` since `distro_bootcmd` is no longer used. Adjust to the new boot method.  Since there was a feature request for booting EFI stub kernel binaries as used by distributions support this via u-boot.
This will not work out of the box because there isn't enough reusable space in the default u-boot environment. This will require trivial fix inside u-boot.