### PR TITLE
build: support building using MacPorts LLVM on Darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,24 +3,31 @@ RUSTARCH ?= aarch64-unknown-none-softfloat
 ifeq ($(shell uname),Darwin)
 USE_CLANG ?= 1
 $(info INFO: Building on Darwin)
+
+ifeq ($(shell command -v llvm-config 2>/dev/null),)
 BREW ?= $(shell command -v brew)
-TOOLCHAIN ?= $(shell $(BREW) --prefix llvm)/bin/
-ifeq ($(shell ls $(TOOLCHAIN)/ld.lld 2>/dev/null),)
+LLVMCONFIG ?= $(shell $(BREW) --prefix llvm)/bin/llvm-config
+else
+LLVMCONFIG ?= $(shell command -v llvm-config)
+endif
+TOOLCHAIN ?= $(shell $(LLVMCONFIG) --bindir)/
+$(info INFO: Toolchain path: $(TOOLCHAIN))
+
+ifeq ($(shell ls $(TOOLCHAIN)ld.lld 2>/dev/null),)
+BREW ?= $(shell command -v brew)
 LLDDIR ?= $(shell $(BREW) --prefix lld)/bin/
 else
 LLDDIR ?= $(TOOLCHAIN)
 endif
-$(info INFO: Toolchain path: $(TOOLCHAIN))
+ifneq ($(TOOLCHAIN),$(LLDDIR))
+$(info INFO: LLD path: $(LLDDIR))
+endif
 endif
 
 ifeq ($(shell uname -m),aarch64)
 ARCH ?=
 else
 ARCH ?= aarch64-linux-gnu-
-endif
-
-ifneq ($(TOOLCHAIN),$(LLDDIR))
-$(info INFO: LLD path: $(LLDDIR))
 endif
 
 ifeq ($(USE_CLANG),1)

--- a/README.md
+++ b/README.md
@@ -10,20 +10,23 @@ $ cd m1n1
 $ make
 ```
 
-The output will be in build/m1n1.macho.
-
-To build on a native arm64 machine, use `make ARCH=`.
-
-To build verbosely, use `make V=1`.
-
-Building on ARM64 macOS is supported with clang and LLVM; you need to use Homebrew to
-install the required dependencies:
-
+To build on a native ARM64 machine:
+* On Linux, use `make ARCH=`.
+* On macOS using Homebrew:
 ```shell
 $ brew install llvm lld
+$ make
+```
+* On macOS using MacPorts:
+```shell
+$ sudo port install llvm clang
+$ sudo port select llvm llvm-mp-<version>
+$ make
 ```
 
-After that, just type `make`.
+The output will be in `build/m1n1.macho`.
+
+To build verbosely, use `make V=1`.
 
 ### Building using the container setup
 


### PR DESCRIPTION
This PR implements support for building on Darwin using MacPorts, by first querying if `llvm-config` is available and using that. This should be a generic approach that works on multiple kinds of environments.
The Homebrew approach is also changed to use Homebrew's `llvm-config`.