### PR TITLE
proxyclient: add validation check for re-serialized ADT size

### DIFF
--- a/proxyclient/m1n1/hv/__init__.py
+++ b/proxyclient/m1n1/hv/__init__.py
@@ -1904,6 +1904,7 @@ class HV(Reloadable):
 
         adt_blob = self.adt.build()
         print(f"Uploading ADT (0x{len(adt_blob):x} bytes)...")
+        assert len(adt_blob) <= align(self.u.ba.devtree_size)
         self.iface.writemem(self.adt_base, adt_blob)
 
         print("Improving logo...")


### PR DESCRIPTION
This has not happened in practice yet, but it could very well be that the re-serialized ADT is bigger than the size originally carved out for it. Catch such a case if it occurs.