### PR TITLE
kboot: Unconditionally mark dt_transfer_virtios() as unused

### DIFF
--- a/src/kboot.c
+++ b/src/kboot.c
@@ -2403,11 +2403,7 @@ err:
     return ret;
 }
 
-#ifdef RELEASE
-__attribute__((unused))
-#endif
-static int
-dt_transfer_virtios(void)
+__attribute__((unused)) static int dt_transfer_virtios(void)
 {
     int path[3];
     path[0] = adt_path_offset(adt, "/arm-io/");


### PR DESCRIPTION
```
kboot: Unconditionally mark dt_transfer_virtios() as unused

Avoid formatting clashes between clang-format 20 and 21. The attribute
means that the function is possibly unused [1] so it can be used
unconditionally. Compare Linux' `__maybe_unused`.

1: https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-unused-function-attribute
```