### PR TITLE
Add 26.3 to firmware versions

### DIFF
--- a/src/firmware.c
+++ b/src/firmware.c
@@ -197,6 +197,7 @@ const struct fw_version_info fw_versions[NUM_FW_VERSIONS] = {
     [V26_2]      = {V26_2,      "26.2",        {26, 2, 0},     3, "iBoot-13822.61.10"},
     [V26_3B1]    = {V26_3B1,    "26.3 beta",   {26, 2, 98, 1}, 4, "iBoot-13822.80.393"},
     [V26_3B2]    = {V26_3B2,    "26.3 beta2",  {26, 2, 98, 2}, 4, "iBoot-13822.80.406"},
+    [V26_3]      = {V26_3,      "26.3",        {26, 3, 0},     3, "iBoot-13822.81.10"},
     // clang-format on
 };
 

--- a/src/firmware.h
+++ b/src/firmware.h
@@ -182,6 +182,7 @@ enum fw_version {
     V26_2,
     V26_3B1,
     V26_3B2,
+    V26_3,
     NUM_FW_VERSIONS,
 };
 


### PR DESCRIPTION
This version was taken from an M4 MacBook Air.