### PR TITLE
Add 26.4/mBoot to firmware versions

### DIFF
--- a/src/firmware.c
+++ b/src/firmware.c
@@ -198,6 +198,7 @@ const struct fw_version_info fw_versions[NUM_FW_VERSIONS] = {
     [V26_3B1]    = {V26_3B1,    "26.3 beta",   {26, 2, 98, 1}, 4, "iBoot-13822.80.393"},
     [V26_3B2]    = {V26_3B2,    "26.3 beta2",  {26, 2, 98, 2}, 4, "iBoot-13822.80.406"},
     [V26_3]      = {V26_3,      "26.3",        {26, 3, 0},     3, "iBoot-13822.81.10"},
+    [V26_4]      = {V26_4,      "26.4",        {26, 4, 0},     3, "mBoot-18000.101.7"},
     // clang-format on
 };
 

--- a/src/firmware.h
+++ b/src/firmware.h
@@ -183,6 +183,7 @@ enum fw_version {
     V26_3B1,
     V26_3B2,
     V26_3,
+    V26_4,
     NUM_FW_VERSIONS,
 };
 


### PR DESCRIPTION
Tested on an M5 Pro MacBook Pro