### PR TITLE
wdt: Disarm secondary watchdog on t814x

### DIFF
--- a/src/wdt.c
+++ b/src/wdt.c
@@ -9,6 +9,8 @@
 #define WDT_ALARM 0x14
 #define WDT_CTL   0x1c
 
+#define WDT_2ND_OFFSET 0x8008
+
 static u64 wdt_base = 0;
 
 void wdt_disable(void)
@@ -26,9 +28,17 @@ void wdt_disable(void)
         return;
     }
 
-    printf("WDT registers @ 0x%lx\n", wdt_base);
+    u64 wdt_2nd = 0;
+    if (adt_get_reg(adt, path, "reg", 2, &wdt_2nd, NULL)) {
+        printf("Failed to get WDT reg[2] property!\n");
+    }
+
+    printf("WDT registers @ 0x%lx (0x%lx)\n", wdt_base, wdt_2nd);
 
     write32(wdt_base + WDT_CTL, 0);
+    // disable seconmdary watchdog enabled on M4 / A18 Pro with macOS 26
+    if ((wdt_2nd - wdt_base) == WDT_2ND_OFFSET)
+        write32(wdt_2nd, 0);
 
     printf("WDT disabled\n");
 }


### PR DESCRIPTION
M4 and A18 Pro and reset with iboot from macOS 26.x after 120 seconds. This is caused by secondary watchdogs living at offset 0x8000. The ADT contains for all devices since M1 4 byte sized reg entries at those offsets. This seems to be secondary watchdogs with a different MMIO layout. Setting the offset 0x8008 to 0x0 from its initial value of 0x7b seems to disable the watchdog.
This watchdog doesn't seem to have a programmable count register and uses the raw count at 0x2000. The alarm value might reside at 0x8018. The value there is close to 120 seconds with a clock 2.4 MHz.

Discovered-by: @miyakoyakota