### PR TITLE
CI: installer: adjust u-boot DTS paths

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -69,7 +69,7 @@ jobs:
           cp -f linux/arch/arm64/boot/dts/apple/*.dts \
                 linux/arch/arm64/boot/dts/apple/*.dtsi \
                 linux/arch/arm64/boot/dts/apple/*.h \
-                u-boot/arch/arm/dts/
+                u-boot/dts/upstream/src/arm64/apple/
 
       - name: Build u-boot
         run: |
@@ -82,8 +82,8 @@ jobs:
           mkdir -p out/esp/m1n1/
           gzip -k u-boot/u-boot-nodtb.bin
           cat build/m1n1.bin \
-              u-boot/arch/arm/dts/t60*.dtb \
-              u-boot/arch/arm/dts/t81*.dtb \
+              u-boot/dts/upstream/src/arm64/apple/t60*.dtb \
+              u-boot/dts/upstream/src/arm64/apple/t81*.dtb \
               u-boot/u-boot-nodtb.bin.gz \
               > out/esp/m1n1/boot.bin
           cd out


### PR DESCRIPTION
Asahi's downstream u-boot switched to upstream DTS sourtces in asahi-v2026.04-1. Adjust the DTS source and DTB output path accordingly.