### PR TITLE
convert -> magick

### DIFF
--- a/data/makelogo.sh
+++ b/data/makelogo.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
-convert bootlogo_48.png -background black -flatten -depth 8 rgba:bootlogo_48.bin
-convert bootlogo_128.png -background black -flatten -depth 8 rgba:bootlogo_128.bin
-convert bootlogo_256.png -background black -flatten -depth 8 rgba:bootlogo_256.bin
+magick bootlogo_48.png -background black -flatten -depth 8 rgba:bootlogo_48.bin
+magick bootlogo_128.png -background black -flatten -depth 8 rgba:bootlogo_128.bin
+magick bootlogo_256.png -background black -flatten -depth 8 rgba:bootlogo_256.bin

--- a/font/makefont.sh
+++ b/font/makefont.sh
@@ -10,7 +10,7 @@ shift 5
 for ord in $(seq 32 126); do
     printf "\\x$(printf %x $ord)\\n"
 done
-) | convert \
+) | magick \
     -page ${width}x$((height*95)) \
     -background black \
     -fill white \

--- a/proxyclient/m1n1/agx/render.py
+++ b/proxyclient/m1n1/agx/render.py
@@ -1329,7 +1329,7 @@ class GPURenderer:
 
             #unswizzle(agx, obj._paddr, work.width, work.height, 4, "fb.bin", grid=False)
             #open("fb.bin", "wb").write(self.agx.u.iface.readmem(obj._paddr, work.width*work.height*4))
-            #os.system(f"convert -size {work.width}x{work.height} -depth 8 rgba:fb.bin -alpha off frame{self.frames}.png")
+            #os.system(f"magick -size {work.width}x{work.height} -depth 8 rgba:fb.bin -alpha off frame{self.frames}.png")
             self.agx.p.fb_blit(0, 0, work.width, work.height, obj._paddr, work.width, PIX_FMT.XBGR)
 
         if False: #work.depth is not None:
@@ -1342,7 +1342,7 @@ class GPURenderer:
             chexdump(obj.val)
 
             unswizzle(self.agx, obj._paddr, work.width, work.height, 4, "depth.bin", grid=False)
-            os.system(f"convert -size {work.width}x{work.height} -depth 8 rgba:depth.bin -alpha off depth.png")
+            os.system(f"magick -size {work.width}x{work.height} -depth 8 rgba:depth.bin -alpha off depth.png")
 
         for i in self.work:
             i.free()


### PR DESCRIPTION
ImageMagick 7 and later deprecate the convert command, which now prints a warning. Use the new magick one instead, which takes the same arguments.