### PR TITLE
proxyclient: add missing xml namespace declaration

### DIFF
--- a/proxyclient/m1n1/hv/gdbserver/features/target.xml
+++ b/proxyclient/m1n1/hv/gdbserver/features/target.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!-- SPDX-License-Identifier: MIT -->
 <!DOCTYPE target SYSTEM "gdb-target.dtd">
-<target version="1.0">
+<target version="1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
   <architecture>aarch64</architecture>
   <xi:include href="aarch64-core.xml" />
   <xi:include href="aarch64-fpu.xml" />


### PR DESCRIPTION
This should make the XML validate properly, which is needed for rpminspect to pass:
https://artifacts.dev.testing-farm.io/90d12277-5b49-4343-aa1e-e9f8645cf997/