### PR TITLE
A few pmgr_adt2dt.py fixes

### DIFF
--- a/proxyclient/tools/pmgr_adt2dt.py
+++ b/proxyclient/tools/pmgr_adt2dt.py
@@ -45,8 +45,8 @@ for i, dev in enumerate(pmgr.devices):
     maxaddr[block[0]] = max(maxaddr.get(block[0], 0), offset)
 
 pmgr_compat = pmgr.compatible[0].split(",")[1]
-compatible = f'"apple,{pmgr_compat}-pmgr", "apple,pmgr", "syscon", "simple-mfd"'
-ps_compatible = f'"apple,{pmgr_compat}-pmgr-pwrstate", "apple,pmgr-pwrstate"'
+compatible = f'"apple,{pmgr_compat}-pmgr", "apple,t8103-pmgr", "syscon", "simple-mfd"'
+ps_compatible = f'"apple,{pmgr_compat}-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate"'
 
 for i, ((base, size), devices) in enumerate(sorted(blocks.items())):
 

--- a/proxyclient/tools/pmgr_adt2dt.py
+++ b/proxyclient/tools/pmgr_adt2dt.py
@@ -34,7 +34,7 @@ def die_label(s):
     if args.multidie:
         return f"DIE_LABEL({s})"
     else:
-        return s
+        return f'"{s}"'
 
 for i, dev in enumerate(pmgr.devices):
     if dev.flags.no_ps:

--- a/proxyclient/tools/pmgr_adt2dt.py
+++ b/proxyclient/tools/pmgr_adt2dt.py
@@ -7,6 +7,7 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 import argparse, pathlib
 
 from m1n1 import adt
+from m1n1.utils import align_up
 
 parser = argparse.ArgumentParser(description='Convert ADT PMGR nodes to Device Tree format')
 parser.add_argument("-m", "--multidie", action="store_true")
@@ -50,7 +51,7 @@ ps_compatible = f'"apple,{pmgr_compat}-pmgr-pwrstate", "apple,t8103-pmgr-pwrstat
 
 for i, ((base, size), devices) in enumerate(sorted(blocks.items())):
 
-    size = min(size, (maxaddr[base] + 0x3fff) & ~0x3fff)
+    size = min(size, align_up(maxaddr[base] + 4, 0x4000))
 
     print(f"pmgr{i}: power-management@{base:x} {{")
     print(f"\tcompatible = {compatible};")


### PR DESCRIPTION
- adapt to the new fallback compatibles
- quote labels in the non multi-chip case
- include the register size of the max offset power-state when calculating the pmgr reg size 