### PR TITLE
build/kmutil: Add dev script to automate `kmutil configure-boot`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,6 +265,12 @@ build/$(NAME).bin: build/$(NAME)-asahi.bin build/$(LOGO).logo
 	$(QUIET)cat $^ > $@
 endif
 
+build/kmutil: build/$(NAME).bin tools/kmutil.sh
+	$(QUIET)echo "  PASTE $@"
+	$(QUIET)awk -v out=1 -e '/^UUENCODED_DATA/ {out=0; next}; { if(out == 1) { print $0} }' < tools/kmutil.sh > $@
+	$(QUIET)uuencode -m $(NAME).bin < $< >> $@
+	$(QUIET)awk -v out=0 -e '/^UUENCODED_DATA/ {out=1; next}; { if(out == 1) { print $0} }' < tools/kmutil.sh >> $@
+
 .INTERMEDIATE: build-tag build-cfg
 build-tag src/../build/build_tag.h &:
 	$(QUIET)mkdir -p build

--- a/tools/kmutil.sh
+++ b/tools/kmutil.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+#######################################################################
+# kmutil configure-boot script with embedded m1n1.bin for easy setup
+#
+# host dependencies: uuencode (sharutils)
+#
+# Preparations on the host:
+#     make build/kmutil && python3 -m http.server --directory build
+#
+# Usage on the target:
+#     sh <(curl HOST:8000/kmutil)
+#
+# This script can not be piped into the shell since it uses stdin.
+#
+#######################################################################
+
+set -e
+
+uudecode <<EOF_M1N1
+UUENCODED_DATA # replaced with uuencoded m1n1.bin by make build/kmutil
+EOF_M1N1
+
+boot_disk=$(bless --getboot)
+system_dir=$(diskutil info -plist ${boot_disk} | plutil -extract MountPoint raw -)
+
+# TODO: ensure this is booted into 1TR and check boot policy, see step2.sh from asahi-installer
+
+echo
+echo "Set m1n1.bin as custom boot object for \"${system_dir}\"?"
+echo "Use control-c to cancel."
+echo
+read
+
+while ! kmutil configure-boot -c m1n1.bin --raw --entry-point 2048 --lowest-virtual-address 0 -v "${system_dir}"; do
+    echo
+    echo "kmutil failed. Did you mistype your password?"
+    echo "Press enter to try again."
+    read
+done
+
+echo
+echo "Installation complete! Press enter to reboot."
+read
+
+reboot


### PR DESCRIPTION
Initial m1n1 bringup on new targets may require installing m1n1 multiple times via 1TR until chainload is working. Automate it to make it less painful.
Add an optionally built script which embeds m1n1.bin which can be executed fropm 1TR on the target device. The script is not built be default since it requires uuencode (sharutils) which doesn't seem to commonly installed by default.
The script can be served via http and directly executed from curl or copied to and USB stick.
The following demonstrates the use via http:
```
make build/kmutil && python3 -m http.server --directory build
```
The target device must be booted into 1TR for the desired installation. The script can then be executed from the recovery terminal with:
```
sh <(curl HOST:8000/kmutil)
```
The script can not be piped directly into the shell since the script (and kmutil) use stdin.