### PR TITLE
linker-scripts: Discard .ARM.attributes section

### DIFF
--- a/m1n1-raw.ld
+++ b/m1n1-raw.ld
@@ -102,6 +102,7 @@ SECTIONS {
         *(.gnu.version*)
         *(.note*)
         *(.comment*)
+        *(.ARM.attributes)
     }
 
     .empty (NOLOAD) : {

--- a/m1n1.ld
+++ b/m1n1.ld
@@ -204,6 +204,7 @@ SECTIONS {
         *(.gnu.version*)
         *(.note*)
         *(.comment*)
+        *(.ARM.attributes)
     }
 
     .empty (NOLOAD) : {


### PR DESCRIPTION
Avoids linker warnings "orphan section `.ARM.attributes' from ... being placed in section `.ARM.attributes'" for every object file on Fedora 44.