### PR TITLE
Revert rvbar changes in smp, chainload and HV of #536

### DIFF
--- a/proxyclient/m1n1/hv/__init__.py
+++ b/proxyclient/m1n1/hv/__init__.py
@@ -1785,13 +1785,8 @@ class HV(Reloadable):
             if cpu.state == "running":
                 continue
             addr, size = cpu.cpu_impl_reg
-            val = self.p.read64(addr)
-            if val & 0xffff_ffff_f000 != rvbar:
-                if val & 1:
-                    raise Exception(f"RVBAR for {cpu.name} (={val:x}) is locked but differs from entry point (={rvbar:x})")
-
-                print(f"  {cpu.name}: [0x{addr:x}] = 0x{rvbar:x}")
-                self.p.write64(addr, rvbar)
+            print(f"  {cpu.name}: [0x{addr:x}] = 0x{rvbar:x}")
+            self.p.write64(addr, rvbar)
 
     def _load_macho_symbols(self):
         self.symbol_dict = self.macho.symbols

--- a/proxyclient/tools/chainload.py
+++ b/proxyclient/tools/chainload.py
@@ -99,13 +99,8 @@ for cpu in u.adt["cpus"]:
     if cpu.state == "running":
         continue
     addr, size = cpu.cpu_impl_reg
-    val = p.read64(addr)
-    if val & 0xffff_ffff_f000 != rvbar:
-        if val & 1:
-            raise Exception(f"RVBAR for {cpu.name} (={val:x}) is locked but differs from entry point (={rvbar:x})")
-
-        print(f"  {cpu.name}: [0x{addr:x}] = 0x{rvbar:x}")
-        p.write64(addr, rvbar)
+    print(f"  {cpu.name}: [0x{addr:x}] = 0x{rvbar:x}")
+    p.write64(addr, rvbar)
 
 u.push_adt()
 

--- a/src/smp.c
+++ b/src/smp.c
@@ -24,9 +24,6 @@
 #define CPU_REG_CLUSTER GENMASK(10, 8)
 #define CPU_REG_DIE     GENMASK(14, 11)
 
-#define RVBAR_LOCK BIT(0)
-#define RVBAR_ADDR GENMASK(47, 12)
-
 struct spin_table {
     u64 mpidr;
     u64 flag;
@@ -126,14 +123,6 @@ static void smp_start_cpu(int index, int die, int cluster, int core, u64 impl, u
 
     printf("Starting CPU %d (%d:%d:%d)... ", index, die, cluster, core);
 
-    u64 rvbar_value = read64(impl);
-    bool write_rvbar = FIELD_GET(RVBAR_ADDR, rvbar_value) != (u64)_vectors_start;
-    if (FIELD_GET(RVBAR_LOCK, rvbar_value) && write_rvbar) {
-        printf("Failed! \n    RVBAR (=0x%lx) is locked and differs from entry point (=0x%lx)\n",
-               rvbar_value, (u64)_vectors_start);
-        return;
-    }
-
     memset(&spin_table[index], 0, sizeof(struct spin_table));
 
     target_cpu = index;
@@ -151,9 +140,7 @@ static void smp_start_cpu(int index, int die, int cluster, int core, u64 impl, u
 
     sysop("dsb sy");
 
-    if (write_rvbar) {
-        write64(impl, (u64)_vectors_start);
-    }
+    write64(impl, (u64)_vectors_start);
 
     cpu_start_base += die * PMGR_DIE_OFFSET;
 


### PR DESCRIPTION
The assumption that BIT(0) locks rvbar was incorrect. The lock is only
active when the CPU core is running. Setting cpu-impl-reg to
_vectors_starts implicitly clears the bit. This is a prerequisit for the
hypervisor which updates rvbar of the secondary cores to the guest entry
point.
