### PR TITLE
build/kmutil: fix usage with macOS 13.5 and use base64 on host side

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,9 +267,9 @@ endif
 
 build/kmutil: build/$(NAME).bin tools/kmutil.sh
 	$(QUIET)echo "  PASTE $@"
-	$(QUIET)awk -v out=1 -e '/^UUENCODED_DATA/ {out=0; next}; { if(out == 1) { print $0} }' < tools/kmutil.sh > $@
-	$(QUIET)uuencode -m $(NAME).bin < $< >> $@
-	$(QUIET)awk -v out=0 -e '/^UUENCODED_DATA/ {out=1; next}; { if(out == 1) { print $0} }' < tools/kmutil.sh >> $@
+	$(QUIET)awk -v out=1 -e '/^BASE64_DATA/ {out=0; next}; { if(out == 1) { print $0} }' < tools/kmutil.sh > $@
+	$(QUIET)base64 -w 60 $< >> $@
+	$(QUIET)awk -v out=0 -e '/^BASE64_DATA/ {out=1; next}; { if(out == 1) { print $0} }' < tools/kmutil.sh >> $@
 
 .INTERMEDIATE: build-tag build-cfg
 build-tag src/../build/build_tag.h &:

--- a/tools/kmutil.sh
+++ b/tools/kmutil.sh
@@ -20,7 +20,9 @@ boot_disk=$(bless --getboot)
 system_dir=$(diskutil info -plist ${boot_disk} | plutil -extract MountPoint raw -)
 
 "${system_dir}"/usr/bin/uudecode <<EOF_M1N1
-UUENCODED_DATA # replaced with uuencoded m1n1.bin by make build/kmutil
+begin-base64 644 m1n1.bin
+BASE64_DATA # replaced with `base64 -w 60 m1n1.bin` by make build/kmutil
+====
 EOF_M1N1
 
 # TODO: ensure this is booted into 1TR and check boot policy, see step2.sh from asahi-installer

--- a/tools/kmutil.sh
+++ b/tools/kmutil.sh
@@ -16,12 +16,12 @@
 
 set -e
 
-uudecode <<EOF_M1N1
-UUENCODED_DATA # replaced with uuencoded m1n1.bin by make build/kmutil
-EOF_M1N1
-
 boot_disk=$(bless --getboot)
 system_dir=$(diskutil info -plist ${boot_disk} | plutil -extract MountPoint raw -)
+
+"${system_dir}"/usr/bin/uudecode <<EOF_M1N1
+UUENCODED_DATA # replaced with uuencoded m1n1.bin by make build/kmutil
+EOF_M1N1
 
 # TODO: ensure this is booted into 1TR and check boot policy, see step2.sh from asahi-installer
 


### PR DESCRIPTION
The uuencoded data was already using base64 as encoding. Replace `uuencode` with the more commonly installed base64.

The macOS 13.5 based recoveryOS does not have `uudecode` in PATH, use it from the system partition instead. This potentially causes issues with asahi-installer stub installs but those are not that interesting for the script as they shouild have a competent 1st stage m1n1 image already.