### PR TITLE
hv: macOS EL1 fixups for M3 devices

### DIFF
--- a/proxyclient/m1n1/apple_regs.json
+++ b/proxyclient/m1n1/apple_regs.json
@@ -169,6 +169,7 @@
     {"index": 0, "name": "CTRR_A_UPR_EL2",              "fullname": "CTRR A Upper Address (EL2)",                                   "enc": [3, 4, 15, 11, 1 ], "width": 64},
     {"index": 0, "name": "CTRR_CTL_EL2",                "fullname": "CTRR Control (EL2)",                                           "enc": [3, 4, 15, 11, 4 ], "width": 64},
     {"index": 0, "name": "CTRR_LOCK_EL2",               "fullname": "CTRR Lock",                                                    "enc": [3, 4, 15, 11, 5 ], "width": 64},
+    {"index": 0, "name": "AHCR_EL2",                    "fullname": "AHCR (Apple HCR?)",                                                    "enc": [3, 4, 15, 12, 1 ], "width": 64},
     {"index": 0, "name": "JCTL_EL0",                    "fullname": "JITBox Control (EL0)",                                         "enc": [3, 4, 15, 15, 6 ], "width": 64},
     {"index": 0, "name": "IPI_RR_LOCAL_EL1",            "fullname": "IPI Request Register (Local)",                                 "enc": [3, 5, 15, 0, 0  ], "width": 64},
     {"index": 0, "name": "IPI_RR_GLOBAL_EL1",           "fullname": "IPI Request Register (Global)",                                "enc": [3, 5, 15, 0, 1  ], "width": 64},

--- a/proxyclient/m1n1/hv/__init__.py
+++ b/proxyclient/m1n1/hv/__init__.py
@@ -1835,8 +1835,59 @@ class HV(Reloadable):
             print("Done.")
             return a.tobytes()
 
+        def load_hook_m3(data, segname, size, fileoff, dest):
+            if segname != "__TEXT_EXEC":
+                return data
+
+            inst = 0xd503201f # noop
+            print(f"Patching segment {segname}...")
+
+            a = array.array("I", data)
+
+            # search for msr instructons with following system regs:
+            # - AGTCNTRDIR_EL12 (s3_4_c15_c14_6)
+            # - AHCR_EL2 (s3_4_c15_c12_1)
+            p = 0
+            while (p := data.find(b"\x1c\xd5", p)) != -1:
+                if (p & 3) != 2:
+                    p += 1
+                    continue
+
+                # mask source register from msr opcode
+                opcode = a[p // 4] & ~0x1f
+                if opcode == 0xd51cfec0 or opcode == 0xd51cfc20:
+                    off = fileoff + (p & ~3)
+                    if off >= 0xbfcfc0:
+                        print(f"  0x{off:x}: 0x{opcode:04x} -> noop(0x{inst:x})")
+                        a[p // 4] = inst
+                p += 4
+
+            # search for mrs instructons with following system regs:
+            # - AHCR_EL2 (s3_4_c15_c12_1)
+            p = 0
+            while (p := data.find(b"\x3c\xd5", p)) != -1:
+                if (p & 3) != 2:
+                    p += 1
+                    continue
+
+                # mask source register from msr opcode
+                opcode = a[p // 4] & ~0x1f
+                if opcode == 0xd53cfc20:
+                    off = fileoff + (p & ~3)
+                    if off >= 0xbfcfc0:
+                        print(f"  0x{off:x}: 0x{opcode:04x} -> noop(0x{inst:x})")
+                        a[p // 4] = inst
+                p += 4
+
+            print("Done.")
+            return a.tobytes()
+
         #image = macho.prepare_image(load_hook)
-        image = macho.prepare_image()
+        chip_id = self.u.adt["/chosen"].chip_id
+        if chip_id in (0x8122, 0x6030, 0x6031, 0x6032, 0x6034):
+            image = macho.prepare_image(load_hook_m3)
+        else:
+            image = macho.prepare_image()
         self.load_raw(image, entryoffset=(macho.entry - macho.vmin), use_xnu_symbols=self.xnu_mode and symfile is not None, vmin=macho.vmin)
 
     def update_pac_mask(self):

--- a/proxyclient/tools/run_guest.py
+++ b/proxyclient/tools/run_guest.py
@@ -33,6 +33,7 @@ from m1n1.proxy import *
 from m1n1.proxyutils import *
 from m1n1.utils import *
 from m1n1.shell import run_shell
+from m1n1.sysreg import *
 from m1n1.hv import HV
 from m1n1.hv.virtio import Virtio9PTransport
 from m1n1.hw.pmu import PMU
@@ -41,6 +42,13 @@ iface = UartInterface()
 p = M1N1Proxy(iface, debug=False)
 bootstrap_port(iface, p)
 u = ProxyUtils(p, heap_size = 128 * 1024 * 1024)
+
+# Setup counter redirect / AHCR_EL2 as expected by macOS for macho payloads
+if not args.raw:
+    chip_id = u.adt["/chosen"].chip_id
+    if chip_id in (0x6030, 0x6031, 0x6032, 0x6034, 0x8122):
+        u.msr(AGTCNTRDIR_EL1, 3)
+        u.msr(AGTCNTRDIR_EL12, 3)
 
 hv = HV(iface, p, u)
 

--- a/src/cpu_regs.h
+++ b/src/cpu_regs.h
@@ -741,6 +741,9 @@
 #define SYS_IMP_APL_APCTL_EL2  sys_reg(3, 6, 15, 12, 2)
 #define SYS_IMP_APL_APCTL_EL12 sys_reg(3, 6, 15, 15, 0)
 
+/* Hypervisor registers? */
+#define SYS_IMPL_APL_AHCR_EL2 sys_reg(3, 4, 15, 12, 1)
+
 /* VM registers */
 #define SYS_IMP_APL_VM_TMR_FIQ_ENA_EL2 sys_reg(3, 5, 15, 1, 3)
 #define VM_TMR_FIQ_ENA_ENA_V           BIT(0)

--- a/src/hv.c
+++ b/src/hv.c
@@ -47,6 +47,8 @@ struct hv_secondary_info_t {
     uint64_t cnthctl;
     uint64_t sprr_config;
     uint64_t gxf_config;
+    uint64_t agt_cnt_rdir_el1;
+    uint64_t agt_cnt_rdir_el12;
 };
 
 static struct hv_secondary_info_t hv_secondary_info;
@@ -145,6 +147,10 @@ void hv_start(void *entry, u64 regs[4])
     hv_secondary_info.cnthctl = mrs(CNTHCTL_EL2);
     hv_secondary_info.sprr_config = mrs(SYS_IMP_APL_SPRR_CONFIG_EL1);
     hv_secondary_info.gxf_config = mrs(SYS_IMP_APL_GXF_CONFIG_EL1);
+    if (cpu_features->counter_redirect) {
+        hv_secondary_info.agt_cnt_rdir_el1 = mrs(SYS_IMP_APL_AGTCNTRDIR_EL1);
+        hv_secondary_info.agt_cnt_rdir_el12 = mrs(SYS_IMP_APL_AGTCNTRDIR_EL12);
+    }
 
     hv_arm_tick(false);
     hv_pinned_cpu = -1;
@@ -209,6 +215,10 @@ static void hv_init_secondary(struct hv_secondary_info_t *info)
     msr(CNTHCTL_EL2, info->cnthctl);
     msr(SYS_IMP_APL_SPRR_CONFIG_EL1, info->sprr_config);
     msr(SYS_IMP_APL_GXF_CONFIG_EL1, info->gxf_config);
+    if (cpu_features->counter_redirect) {
+        msr(SYS_IMP_APL_AGTCNTRDIR_EL1, info->agt_cnt_rdir_el1);
+        msr(SYS_IMP_APL_AGTCNTRDIR_EL12, info->agt_cnt_rdir_el12);
+    }
 
     if (cpu_features->cyc_ovrd)
         reg_mask(SYS_IMP_APL_CYC_OVRD, CYC_OVRD_WFI_MODE_MASK, CYC_OVRD_WFI_MODE(0));


### PR DESCRIPTION
Replace known EL2-only mrs/msr instructions out of MachO payloads and manually initialize them to the expected values on guest startup.