### PR TITLE
pcie: Add t6030 support

### DIFF
--- a/src/pcie.c
+++ b/src/pcie.c
@@ -253,6 +253,10 @@ static int pcie_init_controller(int controller, const char *path)
         fuse_bits = NULL;
         state->pcie_regs = &regs_t8122;
         printf("pcie: Initializing t8122 PCIe controller\n");
+    } else if (adt_is_compatible(adt, adt_offset, "apcie,t6030")) {
+        fuse_bits = NULL;
+        state->pcie_regs = &regs_t8122;
+        printf("pcie: Initializing t6030 PCIe controller\n");
     } else if (adt_is_compatible(adt, adt_offset, "apcie,t6020")) {
         fuse_bits = NULL;
         state->pcie_regs = &regs_t602x;


### PR DESCRIPTION
T6030's PCIe controller and ADT data is similar to t8122 and using the same initialization flow works.

possibly depends on #581 for PCIe power state enabling.