### PR TITLE
kboot_atc: increase t8122 axi2af reg_size

### DIFF
--- a/src/kboot_atc.c
+++ b/src/kboot_atc.c
@@ -101,7 +101,7 @@ static const struct adt_tunable_info atc_tunables[] = {
 };
 
 static const struct adt_tunable_info atc_tunables_t8122[] = {
-    {"tunable_ATC0AXI2AF", "apple,tunable-axi2af", 0x0, 0x4000, true},
+    {"tunable_ATC0AXI2AF", "apple,tunable-axi2af", 0x0, 0x8000, true},
     {"tunable_ATC_FABRIC", "apple,tunable-common-b", 0x44000, 0x4000, true},
 
     {"tunable_CIO3PLL_CORE", "apple,tunable-common-b", 0x2a00, 0x200, true},


### PR DESCRIPTION
The reg is of size 0x1000000 according to the adt, and t6031 has tunables up to an offset of +0x4008