### PR TITLE
experiments/cpu_pstate_latencies: Fix with 1GHz clock

### DIFF
--- a/proxyclient/experiments/cpu_pstate_latencies.py
+++ b/proxyclient/experiments/cpu_pstate_latencies.py
@@ -47,6 +47,9 @@ elif chip_id in (0x8112, 0x6020, 0x6021, 0x6022):
 
 code = u.malloc(0x1000)
 
+make_imm = lambda x : x & (0b11111 << (x.bit_length() - 5))
+eigthy_six_us = make_imm(round(87 * (tfreq / 1_000_000)))
+
 util = asm.ARMAsm(f"""
 bench:
     mrs x1, CNTPCT_EL0
@@ -61,11 +64,11 @@ bench:
 signal_and_write:
     sev
     mrs x2, CNTPCT_EL0
-    add x2, x2, #0x800
+    add x2, x2, #{hex(eigthy_six_us)}
 1:
     mrs x3, CNTPCT_EL0
-    sub x4, x3, x2
-    cbnz x4, 1b
+    cmp x3, x2
+    blt 1b
     str x1, [x0]
     mov x0, x3
     ret


### PR DESCRIPTION
signal_and_write waits 2048 24MHz cycles ~= 85μs for the cpu under test
to start logging.
    
This commit fixes 2 issues regarding the wait:
    
1. The number of cycles was not accurate on systems which use a 1GHz
   clock for CNTPCT_EL0. Changed it to dynamically calculate the cycles
   for a 100μs wait (to be sure) based on tfreq.
2. The loop expected the timer value to land exactly on the target,
   which usually worked with a clock which is much slower than the CPU
   freq. But with both the CPU and CNTPCT_EL0 being clocked close to
   1GHz there is some chance that we go past the value. Changed it to
   stop if we are past the target value.