### PR TITLE
build/kmutil: pass input to base64 on stdin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ endif
 build/kmutil: build/$(NAME).bin tools/kmutil.sh
 	$(QUIET)echo "  PASTE $@"
 	$(QUIET)awk -v out=1 -e '/^BASE64_DATA/ {out=0; next}; { if(out == 1) { print $0} }' < tools/kmutil.sh > $@
-	$(QUIET)base64 -w 60 $< >> $@
+	$(QUIET)base64 -w 60 < $< >> $@
 	$(QUIET)awk -v out=0 -e '/^BASE64_DATA/ {out=1; next}; { if(out == 1) { print $0} }' < tools/kmutil.sh >> $@
 
 .INTERMEDIATE: build-tag build-cfg


### PR DESCRIPTION
base64 on macOS 26.5 as the build host does not like passing a filename.

Fixes: e046a4ba build/kmutil: Replace uuencode with base64