### PR TITLE
tps6598x: Add compile time config to enable debugusb

### DIFF
--- a/config.h
+++ b/config.h
@@ -23,6 +23,9 @@
 // Some devices like Apple TV HD use other uarts for debug console
 //#define TARGET_BOARD 0x34
 
+// Switch the DFU USB-C port to debugusb
+// #define USE_DEBUG_USB
+
 #ifdef RELEASE
 # define FB_SILENT_MODE
 # ifdef CHAINLOADING

--- a/rust/src/adt.rs
+++ b/rust/src/adt.rs
@@ -458,8 +458,11 @@ impl ADTNode {
     }
 
     pub fn is_compatible(&self, compatible: &str) -> Result<bool, AdtError> {
-        let prop = self.named_prop("compatible")?;
-        Ok(prop.str_iter().any(|c| c == compatible))
+        match self.named_prop("compatible") {
+            Ok(prop) => Ok(prop.str_iter().any(|c| c == compatible)),
+            Err(AdtError::NotFound) => Ok(false),
+            Err(e) => Err(e),
+        }
     }
 
     pub fn compatible(&self, index: usize) -> Option<&str> {

--- a/src/dlmalloc/malloc.c
+++ b/src/dlmalloc/malloc.c
@@ -3994,7 +3994,7 @@ static void add_segment(mstate m, char* tbase, size_t tsize, flag_t mmapped) {
   msegmentptr ss = (msegmentptr)(chunk2mem(sp));
   mchunkptr tnext = chunk_plus_offset(sp, ssize);
   mchunkptr p = tnext;
-  int nfences = 0;
+  __attribute__((unused)) int nfences = 0;
 
   /* reset top to new space */
   init_top(m, (mchunkptr)tbase, tsize - TOP_FOOT_SIZE);

--- a/src/i2c.c
+++ b/src/i2c.c
@@ -117,9 +117,10 @@ static int i2c_xfer_write(i2c_dev_t *dev, u8 addr, u32 start, u32 stop, const u8
     if (!stop)
         return 0;
 
-    if (poll32(dev->base + PASEMI_STATUS, PASEMI_STATUS_XFER_BUSY, 0, 50000)) {
+    if (poll32(dev->base + PASEMI_STATUS, PASEMI_STATUS_XFER_ENDED, PASEMI_STATUS_XFER_ENDED,
+               50000)) {
         printf(
-            "i2c: timeout while waiting for PASEMI_STATUS_XFER_BUSY to clear after write xfer\n");
+            "i2c: timeout while waiting for PASEMI_STATUS_XFER_ENDED to be set after write xfer\n");
         return -1;
     }
 
@@ -151,8 +152,10 @@ int i2c_smbus_read(i2c_dev_t *dev, u8 addr, u8 reg, u8 *bfr, size_t len)
     ret = i2c_xfer_read(dev, bfr, min(len, len_reply));
 
 err:
-    if (poll32(dev->base + PASEMI_STATUS, PASEMI_STATUS_XFER_BUSY, 0, 50000)) {
-        printf("i2c: timeout while waiting for PASEMI_STATUS_XFER_BUSY to clear after read xfer\n");
+    if (poll32(dev->base + PASEMI_STATUS, PASEMI_STATUS_XFER_ENDED, PASEMI_STATUS_XFER_ENDED,
+               50000)) {
+        printf(
+            "i2c: timeout while waiting for PASEMI_STATUS_XFER_ENDED to be set after write xfer\n");
         return -1;
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -23,6 +23,7 @@
 #include "sep.h"
 #include "smp.h"
 #include "string.h"
+#include "tps6598x.h"
 #include "uart.h"
 #include "uartproxy.h"
 #include "usb.h"
@@ -160,6 +161,9 @@ void m1n1_main(void)
     wdt_disable();
 #ifndef BRINGUP
     pmgr_init();
+#ifdef USE_DEBUG_USB
+    tps6598x_enable_debugusb();
+#endif
 #ifdef USE_FB
     display_init();
     // Kick DCP to sleep, so dodgy monitors which cause reconnect cycles don't cause us to lose the

--- a/src/tps6598x.c
+++ b/src/tps6598x.c
@@ -5,9 +5,11 @@
 #include "i2c.h"
 #include "iodev.h"
 #include "malloc.h"
+#include "string.h"
 #include "types.h"
 #include "utils.h"
 
+#define TPS_REG_MODE        0x03
 #define TPS_REG_CMD1        0x08
 #define TPS_REG_DATA1       0x09
 #define TPS_REG_INT_EVENT1  0x14
@@ -15,6 +17,7 @@
 #define TPS_REG_INT_CLEAR1  0x18
 #define TPS_REG_POWER_STATE 0x20
 #define TPS_CMD_INVALID     0x444d4321 // !CMD as LE u32
+#define TPS_MODE_DBMA       ((u32)'D' | ((u32)'B' << 8) | ((u32)'M' << 16) | ((u32)'a' << 24))
 
 struct tps6598x_dev {
     i2c_dev_t *i2c;
@@ -74,6 +77,26 @@ int tps6598x_command(tps6598x_dev_t *dev, const char *cmd, const u8 *data_in, si
         if (i2c_smbus_read(dev->i2c, dev->addr, TPS_REG_DATA1, data_out, len_out) !=
             (ssize_t)len_out)
             return -1;
+    }
+
+    return 0;
+}
+
+int tps6598x_cmd_status(tps6598x_dev_t *dev, const char *cmd)
+{
+    u32 cmd_status;
+
+    if (i2c_smbus_read32(dev->i2c, dev->addr, TPS_REG_CMD1, &cmd_status)) {
+        printf("tps6598x: i2c_smbus_read32 cmd: %s failed\n", cmd);
+        return -1;
+    }
+    if (cmd_status == TPS_CMD_INVALID) {
+        printf("tps6598x: i2c_smbus_read32 cmd: %s status invalid\n", cmd);
+        return -1;
+    }
+    if (cmd_status) {
+        printf("tps6598x: i2c_smbus_read32 cmd: %s status 0x%x\n", cmd, cmd_status);
+        return -1;
     }
 
     return 0;
@@ -167,6 +190,143 @@ int tps6598x_powerup(tps6598x_dev_t *dev)
 
     if (power_state != 0)
         return -1;
+
+    return 0;
+}
+
+int tps6598x_enter_kis(tps6598x_dev_t *dev)
+{
+    u32 target_len = 0;
+    const u8 *target = adt_getprop(adt, 0, "target-type", &target_len);
+    u8 key[4] = {0};
+    const u8 key_null[4] = {0, 0, 0, 0};
+    const u8 vdm[] = {0x06, 0x46, 0x82, 0x01};
+    u32 mode = 0;
+    u8 out = 0;
+    u8 en = 1;
+    int ret;
+
+    if (target_len < 4)
+        return -1;
+
+    // reverse the key
+    for (int i = 0; i < 4; i++)
+        key[i] = target[3 - i];
+
+    // check status and soft reset if it fails
+    if (tps6598x_cmd_status(dev, "LOCK")) {
+        tps6598x_command(dev, "Gaid", NULL, 0, NULL, 0);
+        mdelay(20);
+    }
+
+    ret = tps6598x_command(dev, "LOCK", key, 4, (u8 *)&out, 1);
+    if (ret || (out & 0xf)) {
+        printf("tps6598x_enter_kis: Failed to unlock using '%.4s': ret=%d result=0x%hhx\n", key,
+               ret, out & 0xf);
+        return -1;
+    }
+
+    ret = tps6598x_command(dev, "DBMa", &en, 1, &out, 1);
+    if (ret || (out & 0xf)) {
+        printf("tps6598x_enter_kis: DBMa cmd failed: ret=%d result=0x%hhx\n", ret, out & 0xf);
+        return -1;
+    }
+
+    ret = i2c_smbus_read32(dev->i2c, dev->addr, TPS_REG_MODE, &mode);
+    if (mode != TPS_MODE_DBMA) {
+        printf("tps6598x_enter_kis: Failed to enter DBMa mode, mode=0x%08x\n", mode);
+        return -1;
+    }
+
+    ret = tps6598x_command(dev, "DVEn", vdm, sizeof(vdm), &out, 1);
+    if (ret || (out & 0xf)) {
+        printf("tps6598x_enter_kis: DVEn cmd failed: ret=%d result=0x%hhx\n", ret, out & 0xf);
+        return -1;
+    }
+
+    en = 0;
+    tps6598x_command(dev, "DBMa", &en, 1, NULL, 0);
+    tps6598x_command(dev, "LOCK", key_null, 4, NULL, 0);
+
+    return ret;
+}
+
+int tps6598x_enable_debugusb(void)
+{
+    char hpm_path[64] = {0};
+    char i2c_path[64] = {0};
+    bool found = false;
+    int node;
+    int ret;
+
+    node = adt_path_offset(adt, "/arm-io");
+    if (node < 0)
+        return -1;
+
+    ADT_FOREACH_CHILD(adt, node)
+    {
+        int mngr_node;
+
+        if (!adt_is_compatible(adt, node, "i2c,s5l8940x"))
+            continue;
+
+        mngr_node = adt_first_child_offset(adt, node);
+        if (mngr_node < 0 || !adt_is_compatible(adt, mngr_node, "usbc,manager"))
+            continue;
+
+        int it = mngr_node;
+        ADT_FOREACH_CHILD(adt, it)
+        {
+            if (!adt_is_compatible(adt, it, "usbc,cd3217"))
+                continue;
+
+            const char *name = adt_get_name(adt, it);
+            if (strcmp(name, "hpm0"))
+                continue;
+
+            ret = snprintf(i2c_path, sizeof(i2c_path), "/arm-io/%s", adt_get_name(adt, node));
+            if (ret < 0 || (size_t)ret >= sizeof(i2c_path))
+                continue;
+            ret = snprintf(hpm_path, sizeof(hpm_path), "/arm-io/%s/%s/%s", adt_get_name(adt, node),
+                           adt_get_name(adt, mngr_node), name);
+            if (ret < 0 || (size_t)ret >= sizeof(hpm_path))
+                continue;
+
+            found = true;
+        }
+        if (found)
+            break;
+    }
+    if (!found) {
+        printf("tps6598x_enable_debugusb: i2c / hpm node not found\n");
+        return -1;
+    }
+
+    printf("tps6598x: enable debugusb for %s\n", hpm_path);
+
+    i2c_dev_t *i2c = i2c_init(i2c_path);
+    if (!i2c) {
+        printf("tps6598x_enable_debugusb: i2c_init failed for %s.\n", i2c_path);
+        return -1;
+    }
+
+    tps6598x_dev_t *tps = tps6598x_init(hpm_path, i2c);
+    if (!tps) {
+        printf("tps6598x_enable_debugusb: tps6598x_init failed for %s.\n", hpm_path);
+        return -1;
+    }
+
+    if (tps6598x_powerup(tps) < 0) {
+        printf("tps6598x_enable_debugusb: tps6598x_powerup failed for %s.\n", hpm_path);
+        tps6598x_shutdown(tps);
+        return -1;
+    }
+
+    tps6598x_enter_kis(tps);
+
+    tps6598x_shutdown(tps);
+
+    i2c_shutdown(i2c);
 
     return 0;
 }

--- a/src/tps6598x.c
+++ b/src/tps6598x.c
@@ -14,7 +14,7 @@
 #define TPS_REG_INT_MASK1   0x16
 #define TPS_REG_INT_CLEAR1  0x18
 #define TPS_REG_POWER_STATE 0x20
-#define TPS_CMD_INVALID     0x21434d44 // !CMD
+#define TPS_CMD_INVALID     0x444d4321 // !CMD as LE u32
 
 struct tps6598x_dev {
     i2c_dev_t *i2c;

--- a/src/tps6598x.h
+++ b/src/tps6598x.h
@@ -15,6 +15,9 @@ int tps6598x_command(tps6598x_dev_t *dev, const char *cmd, const u8 *data_in, si
                      u8 *data_out, size_t len_out);
 int tps6598x_powerup(tps6598x_dev_t *dev);
 
+int tps6598x_enter_kis(tps6598x_dev_t *dev);
+int tps6598x_enable_debugusb(void);
+
 #define CD3218B12_IRQ_WIDTH 9
 
 typedef struct tps6598x_irq_state {

--- a/src/usb.c
+++ b/src/usb.c
@@ -25,6 +25,12 @@ struct usb_drd_regs {
 #error "USB_IODEV_COUNT is limited to 100 to prevent overflow in ADT path names"
 #endif
 
+#ifdef USE_DEBUG_USB
+#define FIRST_USB_IODEV 1
+#else
+#define FIRST_USB_IODEV 0
+#endif
+
 // length of the format string is is used as buffer size
 // limits the USB instance numbers to reasonable 2 digits
 #define FMT_DART_PATH        "/arm-io/dart-usb%u"
@@ -419,7 +425,7 @@ void usb_hpm_restore_irqs(bool force)
 
 void usb_iodev_init(void)
 {
-    for (int i = 0; i < USB_IODEV_COUNT; i++) {
+    for (int i = FIRST_USB_IODEV; i < USB_IODEV_COUNT; i++) {
         dwc3_dev_t *opaque;
         struct iodev *usb_iodev;
 
@@ -443,7 +449,7 @@ void usb_iodev_init(void)
 
 void usb_iodev_shutdown(void)
 {
-    for (int i = 0; i < USB_IODEV_COUNT; i++) {
+    for (int i = FIRST_USB_IODEV; i < USB_IODEV_COUNT; i++) {
         struct iodev *usb_iodev = iodev_unregister_device(IODEV_USB0 + i);
         if (!usb_iodev)
             continue;


### PR DESCRIPTION
Add a compile time switch to enable debugusb on the DFU USB-C port for devices with I2C based USB-C port controller.
