### PR TITLE
cpufreq: M3 (T8122) support

### DIFF
--- a/src/cpufreq.c
+++ b/src/cpufreq.c
@@ -69,6 +69,7 @@ static u32 pstate_reg_to_pstate(u64 val)
         case T6030:
         case T6031:
         case T6034:
+        case T8122:
             return FIELD_GET(CLUSTER_PSTATE_DESIRED1, val);
         default:
             printf("cpufreq: Chip 0x%x is unsupported\n", chip_id);
@@ -109,6 +110,7 @@ static int set_pstate(const struct cluster_t *cluster, uint32_t pstate)
             case T6030:
             case T6031:
             case T6034:
+            case T8122:
                 val &= ~CLUSTER_PSTATE_DESIRED1;
                 val |= CLUSTER_PSTATE_SET | FIELD_PREP(CLUSTER_PSTATE_DESIRED1, pstate);
                 break;
@@ -205,6 +207,7 @@ int cpufreq_init_cluster(const struct cluster_t *cluster, const struct feat_t *f
         case T6030:
         case T6031:
         case T6034:
+        case T8122:
             /* Unknown */
             write64(cluster->base + 0x440f8, 1);
             break;
@@ -404,6 +407,7 @@ const struct cluster_t *cpufreq_get_clusters(void)
         case T6022:
             return t6022_clusters;
         case T6030:
+        case T8122:
             return t6030_clusters;
         case T6031:
         case T6034:
@@ -458,6 +462,16 @@ static const struct feat_t t8112_features[] = {
     {},
 };
 
+static const struct feat_t t8122_features[] = {
+    {"ppt-thrtl", 0x48400, 0, BIT(63), 0, false},
+    {"ppt-thrtl", 0x48408, 0, BIT(63), 0, false},
+    {"llc-thrtl", 0x40270, 0, BIT(63), 0, false},
+    {"amx-thrtl", 0x40250, 0, BIT(63), 0, false},
+    {"cpu-fixed-freq-pll-relock", CLUSTER_PSTATE, 0, CLUSTER_PSTATE_FIXED_FREQ_PLL_RECLOCK, 0,
+     false},
+    {},
+};
+
 static const struct feat_t t6020_features[] = {
     {"cpu-apsc", CLUSTER_PSTATE, CLUSTER_PSTATE_M2_APSC_DIS, 0, CLUSTER_PSTATE_APSC_BUSY, false},
     {"ppt-thrtl", 0x48400, 0, BIT(63), 0, false},
@@ -503,6 +517,8 @@ const struct feat_t *cpufreq_get_features(void)
             return t8103_features;
         case T8112:
             return t8112_features;
+        case T8122:
+            return t8122_features;
         case T6020:
         case T6021:
         case T6022:


### PR DESCRIPTION
The cpufreq init on T8122 is probably identical to T6030 / T6031. The clearing of CLUSTER_PSTATE_M2_APSC_DIS in `t6030_features` might be just an oversight and if so should be removed.