### PR TITLE
chickens: Use init_common_everest() for all M3 variants

### DIFF
--- a/src/chickens_everest.c
+++ b/src/chickens_everest.c
@@ -19,6 +19,8 @@ static void init_common_everest(void)
                  GENMASK(7, 4) | GENMASK(3, 0),
              BIT(40) | BIT(36) | BIT(32) | BIT(28) | BIT(24) | BIT(20) | BIT(16) | 0x2b00uL |
                  BIT(4) | BIT(0));
+
+    reg_clr(s3_0_c15_c2_4, BIT(0) | BIT(1) | BIT(16) | BIT(17) | BIT(18) | BIT(22));
 }
 
 void init_t8122_everest(int rev)
@@ -45,8 +47,6 @@ void init_t8122_everest(int rev)
                             (0x2 << 24) | (0x2 << 28) | (0x2uL << 32)) |
             HID26_GROUP2_OFFSET(0x23 | (0x1 << 8) | (0x1 << 12) | (0x1 << 16) | (0x1 << 20) |
                                 (0x1 << 24)));
-
-    reg_clr(s3_0_c15_c2_4, BIT(0) | BIT(1) | BIT(16) | BIT(17) | BIT(18) | BIT(22));
 
     reg_set(SYS_IMP_APL_HID4, HID4_ENABLE_LFSR_STALL_LOAD_PIPE2_ISSUE);
 }
@@ -80,7 +80,6 @@ void init_t6030_everest(int rev)
     reg_set(SYS_IMP_APL_HID18, BIT(61));
 
     reg_set(s3_0_c15_c2_3, BIT(3));
-    reg_clr(s3_0_c15_c2_4, BIT(0) | BIT(1) | BIT(16) | BIT(17) | BIT(18) | BIT(22));
 
     reg_set(SYS_IMP_APL_HID4, HID4_ENABLE_LFSR_STALL_LOAD_PIPE2_ISSUE);
 }
@@ -108,7 +107,6 @@ void init_t6031_everest(int rev)
     msr(SYS_IMP_APL_HID26, HID26_GROUP1_OFFSET(0xF88F65588LL) | HID26_GROUP2_OFFSET(0x3F28));
     /* This is new to M3 and i have no idea what it is yet */
     reg_set(s3_0_c15_c2_3, BIT(3));
-    reg_clr(s3_0_c15_c2_4, BIT(0) | BIT(1) | BIT(16) | BIT(17) | BIT(18) | BIT(22));
 
     reg_set(SYS_IMP_APL_HID4, HID4_ENABLE_LFSR_STALL_LOAD_PIPE2_ISSUE);
 }

--- a/src/chickens_everest.c
+++ b/src/chickens_everest.c
@@ -6,6 +6,7 @@
 
 static void init_common_everest(void)
 {
+    reg_set(SYS_IMP_APL_HID9, BIT(17));
 }
 
 void init_t8122_everest(int rev)
@@ -15,7 +16,6 @@ void init_t8122_everest(int rev)
 
     reg_clr(SYS_IMP_APL_HID3, BIT(2));
     reg_mask(SYS_IMP_APL_HID3, GENMASK(62, 56), BIT(59));
-    reg_set(SYS_IMP_APL_HID9, BIT(17));
 
     reg_mask(SYS_IMP_APL_HID13,
              HID13_POST_OFF_CYCLES_MASK | HID13_POST_ON_CYCLES_MASK | HID13_GROUP0_FF1_DELAY_MASK |
@@ -57,7 +57,6 @@ void init_t6030_everest(int rev)
     reg_set(SYS_IMP_APL_HID3, HID3_DEV_PCIE_THROTTLE_ENABLE);
     reg_mask(SYS_IMP_APL_HID3, HID3_DEV_PCIE_THROTTLE_LIMIT_MASK, HID3_DEV_PCIE_THROTTLE_LIMIT(60));
     reg_clr(SYS_IMP_APL_HID3, BIT(4));
-    reg_set(SYS_IMP_APL_HID9, BIT(17));
     reg_mask(SYS_IMP_APL_HID13,
              HID13_POST_OFF_CYCLES_MASK | HID13_POST_ON_CYCLES_MASK | HID13_PRE_CYCLES_MASK |
                  HID13_GROUP0_FF0_DELAY_MASK | HID13_GROUP0_FF1_DELAY_MASK |
@@ -100,7 +99,6 @@ void init_t6031_everest(int rev)
     reg_set(SYS_IMP_APL_HID3, HID3_DEV_PCIE_THROTTLE_ENABLE);
     reg_mask(SYS_IMP_APL_HID3, GENMASK(ULONG(62), ULONG(56)), BIT(60) | BIT(59) | BIT(58));
     reg_clr(SYS_IMP_APL_HID3, BIT(4));
-    reg_set(SYS_IMP_APL_HID9, BIT(17));
     reg_mask(SYS_IMP_APL_HID13,
              HID13_POST_OFF_CYCLES_MASK | HID13_POST_ON_CYCLES_MASK | HID13_PRE_CYCLES_MASK |
                  HID13_GROUP0_FF1_DELAY_MASK | HID13_GROUP0_FF2_DELAY_MASK |

--- a/src/chickens_everest.c
+++ b/src/chickens_everest.c
@@ -21,6 +21,8 @@ static void init_common_everest(void)
                  BIT(4) | BIT(0));
 
     reg_clr(s3_0_c15_c2_4, BIT(0) | BIT(1) | BIT(16) | BIT(17) | BIT(18) | BIT(22));
+
+    reg_set(SYS_IMP_APL_HID4, HID4_ENABLE_LFSR_STALL_LOAD_PIPE2_ISSUE);
 }
 
 void init_t8122_everest(int rev)
@@ -47,8 +49,6 @@ void init_t8122_everest(int rev)
                             (0x2 << 24) | (0x2 << 28) | (0x2uL << 32)) |
             HID26_GROUP2_OFFSET(0x23 | (0x1 << 8) | (0x1 << 12) | (0x1 << 16) | (0x1 << 20) |
                                 (0x1 << 24)));
-
-    reg_set(SYS_IMP_APL_HID4, HID4_ENABLE_LFSR_STALL_LOAD_PIPE2_ISSUE);
 }
 
 void init_t6030_everest(int rev)
@@ -80,8 +80,6 @@ void init_t6030_everest(int rev)
     reg_set(SYS_IMP_APL_HID18, BIT(61));
 
     reg_set(s3_0_c15_c2_3, BIT(3));
-
-    reg_set(SYS_IMP_APL_HID4, HID4_ENABLE_LFSR_STALL_LOAD_PIPE2_ISSUE);
 }
 
 void init_t6031_everest(int rev)
@@ -107,6 +105,4 @@ void init_t6031_everest(int rev)
     msr(SYS_IMP_APL_HID26, HID26_GROUP1_OFFSET(0xF88F65588LL) | HID26_GROUP2_OFFSET(0x3F28));
     /* This is new to M3 and i have no idea what it is yet */
     reg_set(s3_0_c15_c2_3, BIT(3));
-
-    reg_set(SYS_IMP_APL_HID4, HID4_ENABLE_LFSR_STALL_LOAD_PIPE2_ISSUE);
 }

--- a/src/chickens_everest.c
+++ b/src/chickens_everest.c
@@ -8,6 +8,8 @@ static void init_common_everest(void)
 {
     reg_set(SYS_IMP_APL_HID9, BIT(17));
 
+    reg_set(SYS_IMP_APL_HID16, BIT(54));
+
     reg_set(SYS_IMP_APL_HID18,
             HID18_GEXIT_EL_SPECULATION_DISABLE | HID18_GENTER_SPECULATION_DISABLE);
 
@@ -45,7 +47,6 @@ void init_t8122_everest(int rev)
                                 (0x1 << 24)));
 
     reg_clr(s3_0_c15_c2_4, BIT(0) | BIT(1) | BIT(16) | BIT(17) | BIT(18) | BIT(22));
-    reg_set(SYS_IMP_APL_HID16, BIT(54));
 
     reg_set(SYS_IMP_APL_HID4, HID4_ENABLE_LFSR_STALL_LOAD_PIPE2_ISSUE);
 }
@@ -55,7 +56,6 @@ void init_t6030_everest(int rev)
     UNUSED(rev);
     init_common_everest();
 
-    reg_set(SYS_IMP_APL_HID16, BIT(54));
     reg_set(SYS_IMP_APL_HID3, HID3_DEV_PCIE_THROTTLE_ENABLE);
     reg_mask(SYS_IMP_APL_HID3, HID3_DEV_PCIE_THROTTLE_LIMIT_MASK, HID3_DEV_PCIE_THROTTLE_LIMIT(60));
     reg_clr(SYS_IMP_APL_HID3, BIT(4));
@@ -104,7 +104,6 @@ void init_t6031_everest(int rev)
                  HID13_GROUP0_FF1_DELAY(4) | HID13_GROUP0_FF2_DELAY(4) | HID13_GROUP0_FF3_DELAY(4) |
                  HID13_GROUP0_FF4_DELAY(4) | HID13_GROUP0_FF5_DELAY(4) | HID13_GROUP0_FF6_DELAY(4) |
                  HID13_GROUP0_FF7_DELAY(4) | HID13_RESET_CYCLES(0));
-    reg_set(SYS_IMP_APL_HID16, BIT(54));
 
     msr(SYS_IMP_APL_HID26, HID26_GROUP1_OFFSET(0xF88F65588LL) | HID26_GROUP2_OFFSET(0x3F28));
     /* This is new to M3 and i have no idea what it is yet */

--- a/src/chickens_everest.c
+++ b/src/chickens_everest.c
@@ -10,6 +10,13 @@ static void init_common_everest(void)
 
     reg_set(SYS_IMP_APL_HID18,
             HID18_GEXIT_EL_SPECULATION_DISABLE | HID18_GENTER_SPECULATION_DISABLE);
+
+    reg_mask(SYS_IMP_APL_HID27,
+             GENMASK(43, 40) | GENMASK(39, 36) | GENMASK(35, 32) | GENMASK(31, 28) |
+                 GENMASK(27, 24) | GENMASK(23, 20) | GENMASK(19, 16) | GENMASK(15, 8) |
+                 GENMASK(7, 4) | GENMASK(3, 0),
+             BIT(40) | BIT(36) | BIT(32) | BIT(28) | BIT(24) | BIT(20) | BIT(16) | 0x2b00uL |
+                 BIT(4) | BIT(0));
 }
 
 void init_t8122_everest(int rev)
@@ -36,13 +43,6 @@ void init_t8122_everest(int rev)
                             (0x2 << 24) | (0x2 << 28) | (0x2uL << 32)) |
             HID26_GROUP2_OFFSET(0x23 | (0x1 << 8) | (0x1 << 12) | (0x1 << 16) | (0x1 << 20) |
                                 (0x1 << 24)));
-
-    reg_mask(SYS_IMP_APL_HID27,
-             GENMASK(43, 40) | GENMASK(39, 36) | GENMASK(35, 32) | GENMASK(31, 28) |
-                 GENMASK(27, 24) | GENMASK(23, 20) | GENMASK(19, 16) | GENMASK(15, 8) |
-                 GENMASK(7, 4) | GENMASK(3, 0),
-             BIT(40) | BIT(36) | BIT(32) | BIT(28) | BIT(24) | BIT(20) | BIT(16) | 0x2b00uL |
-                 BIT(4) | BIT(0));
 
     reg_clr(s3_0_c15_c2_4, BIT(0) | BIT(1) | BIT(16) | BIT(17) | BIT(18) | BIT(22));
     reg_set(SYS_IMP_APL_HID16, BIT(54));
@@ -76,12 +76,6 @@ void init_t6030_everest(int rev)
                             (0x2 << 24) | (0x2 << 28) | (0x2uL << 32)) |
             HID26_GROUP2_OFFSET(0x23 | (0x1 << 8) | (0x1 << 12) | (0x1 << 16) | (0x1 << 20) |
                                 (0x1 << 24)));
-    reg_mask(SYS_IMP_APL_HID27,
-             GENMASK(43, 40) | GENMASK(39, 36) | GENMASK(35, 32) | GENMASK(31, 28) |
-                 GENMASK(27, 24) | GENMASK(23, 20) | GENMASK(19, 16) | GENMASK(15, 8) |
-                 GENMASK(7, 4) | GENMASK(3, 0),
-             BIT(40) | BIT(36) | BIT(32) | BIT(28) | BIT(24) | BIT(20) | BIT(16) | 0x2b00uL |
-                 BIT(4) | BIT(0));
 
     reg_set(SYS_IMP_APL_HID18, BIT(61));
 
@@ -113,12 +107,6 @@ void init_t6031_everest(int rev)
     reg_set(SYS_IMP_APL_HID16, BIT(54));
 
     msr(SYS_IMP_APL_HID26, HID26_GROUP1_OFFSET(0xF88F65588LL) | HID26_GROUP2_OFFSET(0x3F28));
-    reg_mask(SYS_IMP_APL_HID27,
-             GENMASK(43, 40) | GENMASK(39, 36) | GENMASK(35, 32) | GENMASK(31, 28) |
-                 GENMASK(27, 24) | GENMASK(23, 20) | GENMASK(19, 16) | GENMASK(15, 8) |
-                 GENMASK(7, 4) | GENMASK(3, 0),
-             BIT(40) | BIT(36) | BIT(32) | BIT(28) | BIT(24) | BIT(20) | BIT(16) | 0x2b00uL |
-                 BIT(4) | BIT(0));
     /* This is new to M3 and i have no idea what it is yet */
     reg_set(s3_0_c15_c2_3, BIT(3));
     reg_clr(s3_0_c15_c2_4, BIT(0) | BIT(1) | BIT(16) | BIT(17) | BIT(18) | BIT(22));

--- a/src/chickens_everest.c
+++ b/src/chickens_everest.c
@@ -71,6 +71,8 @@ void init_t8122_everest(int rev)
             HID18_GEXIT_EL_SPECULATION_DISABLE | HID18_GENTER_SPECULATION_DISABLE);
     reg_clr(s3_0_c15_c2_4, BIT(0) | BIT(1) | BIT(16) | BIT(17) | BIT(18) | BIT(22));
     reg_set(SYS_IMP_APL_HID16, BIT(54));
+
+    reg_set(SYS_IMP_APL_HID4, HID4_ENABLE_LFSR_STALL_LOAD_PIPE2_ISSUE);
 }
 
 void init_t6030_everest(int rev)

--- a/src/chickens_everest.c
+++ b/src/chickens_everest.c
@@ -7,6 +7,9 @@
 static void init_common_everest(void)
 {
     reg_set(SYS_IMP_APL_HID9, BIT(17));
+
+    reg_set(SYS_IMP_APL_HID18,
+            HID18_GEXIT_EL_SPECULATION_DISABLE | HID18_GENTER_SPECULATION_DISABLE);
 }
 
 void init_t8122_everest(int rev)
@@ -40,8 +43,7 @@ void init_t8122_everest(int rev)
                  GENMASK(7, 4) | GENMASK(3, 0),
              BIT(40) | BIT(36) | BIT(32) | BIT(28) | BIT(24) | BIT(20) | BIT(16) | 0x2b00uL |
                  BIT(4) | BIT(0));
-    reg_set(SYS_IMP_APL_HID18,
-            HID18_GEXIT_EL_SPECULATION_DISABLE | HID18_GENTER_SPECULATION_DISABLE);
+
     reg_clr(s3_0_c15_c2_4, BIT(0) | BIT(1) | BIT(16) | BIT(17) | BIT(18) | BIT(22));
     reg_set(SYS_IMP_APL_HID16, BIT(54));
 
@@ -81,8 +83,7 @@ void init_t6030_everest(int rev)
              BIT(40) | BIT(36) | BIT(32) | BIT(28) | BIT(24) | BIT(20) | BIT(16) | 0x2b00uL |
                  BIT(4) | BIT(0));
 
-    reg_set(SYS_IMP_APL_HID18,
-            BIT(61) | HID18_GENTER_SPECULATION_DISABLE | HID18_GEXIT_EL_SPECULATION_DISABLE);
+    reg_set(SYS_IMP_APL_HID18, BIT(61));
 
     reg_set(s3_0_c15_c2_3, BIT(3));
     reg_clr(s3_0_c15_c2_4, BIT(0) | BIT(1) | BIT(16) | BIT(17) | BIT(18) | BIT(22));
@@ -110,8 +111,6 @@ void init_t6031_everest(int rev)
                  HID13_GROUP0_FF4_DELAY(4) | HID13_GROUP0_FF5_DELAY(4) | HID13_GROUP0_FF6_DELAY(4) |
                  HID13_GROUP0_FF7_DELAY(4) | HID13_RESET_CYCLES(0));
     reg_set(SYS_IMP_APL_HID16, BIT(54));
-    reg_set(SYS_IMP_APL_HID18,
-            HID18_GEXIT_EL_SPECULATION_DISABLE | HID18_GENTER_SPECULATION_DISABLE);
 
     msr(SYS_IMP_APL_HID26, HID26_GROUP1_OFFSET(0xF88F65588LL) | HID26_GROUP2_OFFSET(0x3F28));
     reg_mask(SYS_IMP_APL_HID27,

--- a/src/chickens_everest.c
+++ b/src/chickens_everest.c
@@ -3,42 +3,15 @@
 #include "cpu_regs.h"
 #include "uart.h"
 #include "utils.h"
+
 static void init_common_everest(void)
 {
-    reg_set(SYS_IMP_APL_HID12, BIT(46));
-    reg_set(SYS_IMP_APL_HID3, HID3_DEV_PCIE_THROTTLE_ENABLE);
-    reg_mask(SYS_IMP_APL_HID3, GENMASK(ULONG(62), ULONG(56)), BIT(60) | BIT(59) | BIT(58));
-    reg_clr(SYS_IMP_APL_HID3, BIT(4));
-    reg_set(SYS_IMP_APL_HID9, BIT(17));
-    reg_mask(SYS_IMP_APL_HID13,
-             HID13_POST_OFF_CYCLES_MASK | HID13_POST_ON_CYCLES_MASK | HID13_PRE_CYCLES_MASK |
-                 HID13_GROUP0_FF1_DELAY_MASK | HID13_GROUP0_FF2_DELAY_MASK |
-                 HID13_GROUP0_FF3_DELAY_MASK | HID13_GROUP0_FF4_DELAY_MASK |
-                 HID13_GROUP0_FF5_DELAY_MASK | HID13_GROUP0_FF6_DELAY_MASK |
-                 HID13_GROUP0_FF7_DELAY_MASK | HID13_RESET_CYCLES_MASK,
-             HID13_POST_OFF_CYCLES(4) | HID13_POST_ON_CYCLES(5) | HID13_PRE_CYCLES(1) |
-                 HID13_GROUP0_FF1_DELAY(4) | HID13_GROUP0_FF2_DELAY(4) | HID13_GROUP0_FF3_DELAY(4) |
-                 HID13_GROUP0_FF4_DELAY(4) | HID13_GROUP0_FF5_DELAY(4) | HID13_GROUP0_FF6_DELAY(4) |
-                 HID13_GROUP0_FF7_DELAY(4) | HID13_RESET_CYCLES(0));
-    reg_set(SYS_IMP_APL_HID16, BIT(54));
-    reg_set(SYS_IMP_APL_HID18,
-            HID18_GEXIT_EL_SPECULATION_DISABLE | HID18_GENTER_SPECULATION_DISABLE);
-
-    msr(SYS_IMP_APL_HID26, HID26_GROUP1_OFFSET(0xF88F65588LL) | HID26_GROUP2_OFFSET(0x3F28));
-    reg_mask(SYS_IMP_APL_HID27,
-             GENMASK(43, 40) | GENMASK(39, 36) | GENMASK(35, 32) | GENMASK(31, 28) |
-                 GENMASK(27, 24) | GENMASK(23, 20) | GENMASK(19, 16) | GENMASK(15, 8) |
-                 GENMASK(7, 4) | GENMASK(3, 0),
-             BIT(40) | BIT(36) | BIT(32) | BIT(28) | BIT(24) | BIT(20) | BIT(16) | 0x2b00uL |
-                 BIT(4) | BIT(0));
-    /* This is new to M3 and i have no idea what it is yet */
-    reg_set(s3_0_c15_c2_3, BIT(3));
-    reg_clr(s3_0_c15_c2_4, BIT(0) | BIT(1) | BIT(16) | BIT(17) | BIT(18) | BIT(22));
 }
 
 void init_t8122_everest(int rev)
 {
     UNUSED(rev);
+    init_common_everest();
 
     reg_clr(SYS_IMP_APL_HID3, BIT(2));
     reg_mask(SYS_IMP_APL_HID3, GENMASK(62, 56), BIT(59));
@@ -78,6 +51,7 @@ void init_t8122_everest(int rev)
 void init_t6030_everest(int rev)
 {
     UNUSED(rev);
+    init_common_everest();
 
     reg_set(SYS_IMP_APL_HID16, BIT(54));
     reg_set(SYS_IMP_APL_HID3, HID3_DEV_PCIE_THROTTLE_ENABLE);
@@ -121,5 +95,36 @@ void init_t6031_everest(int rev)
 {
     UNUSED(rev);
     init_common_everest();
+
+    reg_set(SYS_IMP_APL_HID12, BIT(46));
+    reg_set(SYS_IMP_APL_HID3, HID3_DEV_PCIE_THROTTLE_ENABLE);
+    reg_mask(SYS_IMP_APL_HID3, GENMASK(ULONG(62), ULONG(56)), BIT(60) | BIT(59) | BIT(58));
+    reg_clr(SYS_IMP_APL_HID3, BIT(4));
+    reg_set(SYS_IMP_APL_HID9, BIT(17));
+    reg_mask(SYS_IMP_APL_HID13,
+             HID13_POST_OFF_CYCLES_MASK | HID13_POST_ON_CYCLES_MASK | HID13_PRE_CYCLES_MASK |
+                 HID13_GROUP0_FF1_DELAY_MASK | HID13_GROUP0_FF2_DELAY_MASK |
+                 HID13_GROUP0_FF3_DELAY_MASK | HID13_GROUP0_FF4_DELAY_MASK |
+                 HID13_GROUP0_FF5_DELAY_MASK | HID13_GROUP0_FF6_DELAY_MASK |
+                 HID13_GROUP0_FF7_DELAY_MASK | HID13_RESET_CYCLES_MASK,
+             HID13_POST_OFF_CYCLES(4) | HID13_POST_ON_CYCLES(5) | HID13_PRE_CYCLES(1) |
+                 HID13_GROUP0_FF1_DELAY(4) | HID13_GROUP0_FF2_DELAY(4) | HID13_GROUP0_FF3_DELAY(4) |
+                 HID13_GROUP0_FF4_DELAY(4) | HID13_GROUP0_FF5_DELAY(4) | HID13_GROUP0_FF6_DELAY(4) |
+                 HID13_GROUP0_FF7_DELAY(4) | HID13_RESET_CYCLES(0));
+    reg_set(SYS_IMP_APL_HID16, BIT(54));
+    reg_set(SYS_IMP_APL_HID18,
+            HID18_GEXIT_EL_SPECULATION_DISABLE | HID18_GENTER_SPECULATION_DISABLE);
+
+    msr(SYS_IMP_APL_HID26, HID26_GROUP1_OFFSET(0xF88F65588LL) | HID26_GROUP2_OFFSET(0x3F28));
+    reg_mask(SYS_IMP_APL_HID27,
+             GENMASK(43, 40) | GENMASK(39, 36) | GENMASK(35, 32) | GENMASK(31, 28) |
+                 GENMASK(27, 24) | GENMASK(23, 20) | GENMASK(19, 16) | GENMASK(15, 8) |
+                 GENMASK(7, 4) | GENMASK(3, 0),
+             BIT(40) | BIT(36) | BIT(32) | BIT(28) | BIT(24) | BIT(20) | BIT(16) | 0x2b00uL |
+                 BIT(4) | BIT(0));
+    /* This is new to M3 and i have no idea what it is yet */
+    reg_set(s3_0_c15_c2_3, BIT(3));
+    reg_clr(s3_0_c15_c2_4, BIT(0) | BIT(1) | BIT(16) | BIT(17) | BIT(18) | BIT(22));
+
     reg_set(SYS_IMP_APL_HID4, HID4_ENABLE_LFSR_STALL_LOAD_PIPE2_ISSUE);
 }


### PR DESCRIPTION
`init_common_everest()` was only used For T6031. Start by moving everything to the T6031 specific initialisation and then move every common bit from all 3 variants back to `init_common_everest()`.
It's unclear whether the remaining differences are genuine differences between the variants or caused by observing different macOS versions.