### PR TITLE
rust: Switch fatfs to a git dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "artwork"]
 	path = artwork
 	url = https://github.com/AsahiLinux/artwork.git
-[submodule "rust/vendor/rust-fatfs"]
-	path = rust/vendor/rust-fatfs
-	url = https://github.com/rafalh/rust-fatfs

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4,13 +4,14 @@ version = 4
 
 [[package]]
 name = "bitflags"
-version = "2.9.2"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "fatfs"
 version = "0.4.0"
+source = "git+https://github.com/rafalh/rust-fatfs?rev=4eccb50d011146fbed20e133d33b22f3c27292e7#4eccb50d011146fbed20e133d33b22f3c27292e7"
 dependencies = [
  "bitflags",
  "log",
@@ -18,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "rust"
@@ -33,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 
 [[package]]
 name = "versions"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = [ "staticlib" ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-fatfs = { path = "vendor/rust-fatfs", default-features = false, features = ["lfn", "alloc"], optional = true }
-uuid = { version = "1.23", default-features = false, optional = true }
+fatfs = { git = "https://github.com/rafalh/rust-fatfs", rev = "4eccb50d011146fbed20e133d33b22f3c27292e7", default-features = false, features = ["lfn", "alloc"], optional = true }
+uuid = {  version = "1.23", default-features = false, optional = true }
 versions = { path = "./versions" }
 
 [features]


### PR DESCRIPTION
There is no reason to vendor fatfs so declare as cargo git dependency using the same revision as the git submodule.