### PR TITLE
adt: fix named_prop failure Error type

### DIFF
--- a/rust/src/adt.rs
+++ b/rust/src/adt.rs
@@ -69,6 +69,76 @@ impl<'a> Iterator for ADTPropertyStringIterator<'a> {
     }
 }
 
+/// ADTPropertiesIterator
+#[derive(Debug)]
+pub struct ADTPropertiesIterator {
+    next_property_res: Option<Result<&'static ADTProperty, AdtError>>,
+    remaining: usize,
+}
+
+impl Iterator for ADTPropertiesIterator {
+    type Item = Result<&'static ADTProperty, AdtError>;
+
+    fn next(&mut self) -> Option<Result<&'static ADTProperty, AdtError>> {
+        let Some(property_res) = self.next_property_res.take() else {
+            return None;
+        };
+        let remaining = core::mem::take(&mut self.remaining);
+        let property = match property_res {
+            Err(e) => return Some(Err(e)),
+            Ok(v) => v,
+        };
+
+        if remaining > 1 {
+            self.next_property_res = Some(property.next_property());
+            self.remaining = remaining - 1;
+        }
+
+        Some(Ok(property))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
+impl ExactSizeIterator for ADTPropertiesIterator {}
+
+/// ADTPropertiesIteratorMut
+#[derive(Debug)]
+pub struct ADTPropertiesIteratorMut {
+    next_property_res: Option<Result<&'static mut ADTProperty, AdtError>>,
+    remaining: usize,
+}
+
+impl Iterator for ADTPropertiesIteratorMut {
+    type Item = Result<&'static mut ADTProperty, AdtError>;
+
+    fn next(&mut self) -> Option<Result<&'static mut ADTProperty, AdtError>> {
+        let Some(property_res) = self.next_property_res.take() else {
+            return None;
+        };
+        let remaining = core::mem::take(&mut self.remaining);
+        let property = match property_res {
+            Err(e) => return Some(Err(e)),
+            Ok(v) => v,
+        };
+
+        if remaining > 1 {
+            self.next_property_res = Some(property.next_property_mut());
+            self.remaining = remaining - 1;
+        }
+
+        Some(Ok(property))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
+impl ExactSizeIterator for ADTPropertiesIteratorMut {}
+
 #[repr(C, packed(1))]
 pub struct ADTSegmentRanges {
     phys: u64,
@@ -360,6 +430,20 @@ impl ADTNode {
     pub fn first_property_mut(&self) -> Result<&'static mut ADTProperty, AdtError> {
         // SAFETY: We know we are a valid node, and our header never changes size
         unsafe { ADTProperty::from_ptr_mut(self.as_ptr().add(size_of::<ADTNode>()) as usize) }
+    }
+
+    pub fn properties(&self) -> ADTPropertiesIterator {
+        ADTPropertiesIterator {
+            next_property_res: Some(self.first_property()),
+            remaining: self.property_count as usize,
+        }
+    }
+
+    pub fn properties_mut(&self) -> ADTPropertiesIteratorMut {
+        ADTPropertiesIteratorMut {
+            next_property_res: Some(self.first_property_mut()),
+            remaining: self.property_count as usize,
+        }
     }
 
     /// Walk the properties at the top of the curret node's memory to arrive at

--- a/rust/src/adt.rs
+++ b/rust/src/adt.rs
@@ -450,12 +450,10 @@ impl ADTNode {
     /// the node immediately following it. This could be a child node or a sibling.
     /// Use the relevant wrappers for additional safety.
     fn next_node(&self) -> Result<&'static ADTNode, AdtError> {
-        let mut p = self.first_property()?;
-
-        // We already have the first property
-        for _ in 0..self.property_count - 1 {
-            p = p.next_property()?;
-        }
+        let p = self.properties()
+            .last()
+            .unwrap() // There is always at least the first property, or an error
+            ?;
 
         // SAFETY: We will only ever reach this code when we can guarantee that
         // p is a reference to the very last property of the node, meaning that
@@ -484,13 +482,11 @@ impl ADTNode {
     /// Searches the node for a property with the given name, and returns it if
     /// found.
     pub fn named_prop(&self, name: &str) -> Result<&'static ADTProperty, AdtError> {
-        let mut p = self.first_property()?;
-
-        for _ in 0..self.property_count {
+        for p in self.properties() {
+            let p = p?;
             if p.name() == name {
                 return Ok(p);
             }
-            p = p.next_property()?;
         }
         Err(AdtError::NotFound)
     }
@@ -502,13 +498,11 @@ impl ADTNode {
     /// Searches the node for a property with the given name, and returns a mutable
     /// reference to it if found.
     pub fn named_prop_mut(&self, name: &str) -> Result<&'static mut ADTProperty, AdtError> {
-        let mut p = self.first_property_mut()?;
-
-        for _ in 0..self.property_count {
+        for p in self.properties_mut() {
+            let p = p?;
             if p.name() == name {
                 return Ok(p);
             }
-            p = p.next_property_mut()?;
         }
         Err(AdtError::NotFound)
     }


### PR DESCRIPTION
If no property of this name exists, it should fail with `AdtError::NotFound`, but it attempted to run `next_property` on the last entry and thus returned `AdtError::BadOffset`.