### PR TITLE
hv: Set correct bit in hv_cpus_in_guest in hv_start_secondary

### DIFF
--- a/src/hv.c
+++ b/src/hv.c
@@ -256,7 +256,7 @@ void hv_start_secondary(int cpu, void *entry, u64 regs[4])
 
     printf("HV: Entering guest secondary %d at %p\n", cpu, entry);
     hv_started_cpus[cpu] = true;
-    __atomic_or_fetch(&hv_cpus_in_guest, BIT(smp_id()), __ATOMIC_ACQUIRE);
+    __atomic_or_fetch(&hv_cpus_in_guest, BIT(cpu), __ATOMIC_ACQUIRE);
 
     iodev_console_flush();
     smp_call4(cpu, hv_enter_secondary, (u64)entry, (u64)regs, 0, 0);


### PR DESCRIPTION
hv_start_secondary runs on the boot CPU called by the proxy such that smp_id() is always the same. Use the correct index instead.