### PR TITLE
hv: write CNTHCTL_EL2 after counter redirection

### DIFF
--- a/src/hv.c
+++ b/src/hv.c
@@ -216,7 +216,6 @@ static void hv_init_secondary(struct hv_secondary_info_t *info)
         msr(SYS_ACTLR_EL12, info->actlr_el1);
     else
         msr(SYS_IMP_APL_ACTLR_EL12, info->actlr_el1);
-    msr(CNTHCTL_EL2, info->cnthctl);
     if (cpu_features->apple_sysregs_unlocked) {
         msr(SYS_IMP_APL_SPRR_CONFIG_EL1, info->sprr_config);
         msr(SYS_IMP_APL_GXF_CONFIG_EL1, info->gxf_config);
@@ -228,6 +227,10 @@ static void hv_init_secondary(struct hv_secondary_info_t *info)
 
     if (cpu_features->apple_sysregs_unlocked)
         reg_mask(SYS_IMP_APL_CYC_OVRD, CYC_OVRD_WFI_MODE_MASK, CYC_OVRD_WFI_MODE(0));
+
+    // For M3 and up, CNTHCTL_EL2 must be written after the counter redirection
+    sysop("isb");
+    msr(CNTHCTL_EL2, info->cnthctl);
 
     if (gxf_enabled())
         gl2_call(hv_set_gxf_vbar, 0, 0, 0, 0);


### PR DESCRIPTION
  Write `CNTHCTL_EL2` only after the secondary CPU's  counter-redirection is configured. This only happens on M3+ because only these SOCs do counter redirection.