### PR TITLE
Support SPMI gen 4

### DIFF
--- a/proxyclient/m1n1/hw/spmi.py
+++ b/proxyclient/m1n1/hw/spmi.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: MIT
 import struct
 
-from ..utils import *
+from .spmi1 import SPMI1Regs, R_CMD, R_REPLY
+from .spmi4 import SPMI4Regs
 
 __all__ = ["SPMI"]
 
@@ -20,114 +21,6 @@ OPC_WRITE       = 0x40
 OPC_READ        = 0x60
 OPC_ZERO_WRITE  = 0x80
 
-class R_CMD(Register32):
-    EXTRA       = 31, 16
-    ALERT       = 15
-    SLAVE_ID    = 11, 8
-    OPCODE      = 7, 0
-
-class R_REPLY(Register32):
-    FRAME_PARITY = 31, 16
-    ACK          = 15
-    SLAVE_ID     = 14, 8
-    OPCODE       = 7, 0
-
-class R_STATUS(Register32):
-    RX_FULL     = 25
-    RX_EMPTY    = 24
-    RX_COUNT    = 23, 16
-    TX_FULL     = 9
-    TX_EMPTY    = 8
-    TX_COUNT    = 7, 0
-
-class R_CURSORS(Register32):
-    RX_CURSOR_R    = 29, 24
-    RX_CURSOR_W    = 21, 16
-    TX_CURSOR_R    = 13,  8
-    TX_CURSOR_W    =  5,  0
-
-class R_PEEK_POS(Register32):
-    BUFFER_POS = 23, 16
-    ''' buffer position to read (0..capacity-1) '''
-    FIFO_IDX = 8
-    ''' FIFO to read from (0 = TX, 1 = RX) '''
-
-class R_ACTION(Register32):
-    CLEAR_FIFOS    = 0
-
-class IRQs(Register32):
-    ALERT       = 0  # a command with the ALERT flag completed
-
-    UNK_4       = 4
-    UNK_5       = 5
-    READ_FAIL_1 = 6  # read command failed
-    ACK_FAIL    = 7  # command was not ACKed
-    UNK_8       = 8
-    UNK_9       = 9
-    UNK_10      = 10
-    READ_FAIL_2 = 11 # read command failed
-    UNK_12      = 12
-    UNK_13      = 13
-
-    UNK_16      = 16
-    UNK_17      = 17
-
-    FATAL       = 27 # read from RX FIFO while empty. level/sticky interrupt
-
-class SPMIRegs(RegMap):
-    STATUS            = 0x00, R_STATUS
-    ''' [RO] status about the RX and TX FIFOs '''
-    CMD               = 0x04, R_CMD
-    ''' [WO] write 32 bits to the TX FIFO '''
-    REPLY             = 0x08, R_REPLY
-    ''' [RO] consume 32 bits from the RX FIFO '''
-
-    # setting a bit in one of these registers causes the IRQ line
-    # to be asserted whenever the same bit at the register at
-    # address +0x40 (see below) is set. clearing a bit only masks
-    # the interrupt, but doesn't prevent the bit from being set or
-    # cleared in register +0x40. these are zero on boot.
-    BUS_EVENTS_0_MASK = 0x20, Register32
-    BUS_EVENTS_1_MASK = 0x24, Register32
-    BUS_EVENTS_2_MASK = 0x28, Register32
-    BUS_EVENTS_3_MASK = 0x2c, Register32
-    BUS_EVENTS_4_MASK = 0x30, Register32
-    BUS_EVENTS_5_MASK = 0x34, Register32
-    BUS_EVENTS_6_MASK = 0x38, Register32
-    BUS_EVENTS_7_MASK = 0x3c, Register32
-    IRQ_MASK          = 0x40, IRQs
-
-    # bits in these registers are set in response to an event
-    # and can be cleared by writing a 1 to them. IRQ_FLAG is
-    # for events of the SPMI peripheral itself, while
-    # BUS_EVENTS_* is for generic events that can be triggered
-    # by other devices in the bus using (I presume) master
-    # commands against us, and allow the SPMI peripheral to
-    # also act as an interrupt controller
-    BUS_EVENTS_0_FLAG = 0x60, Register32
-    BUS_EVENTS_1_FLAG = 0x64, Register32
-    BUS_EVENTS_2_FLAG = 0x68, Register32
-    BUS_EVENTS_3_FLAG = 0x6c, Register32
-    BUS_EVENTS_4_FLAG = 0x70, Register32
-    BUS_EVENTS_5_FLAG = 0x74, Register32
-    BUS_EVENTS_6_FLAG = 0x78, Register32
-    BUS_EVENTS_7_FLAG = 0x7c, Register32
-    IRQ_FLAG          = 0x80, IRQs
-
-    CONFIG1           = 0xa0, Register32
-    ''' [RO] unknown, bits 2..0 settable in T6031, set to 0x6 or 0x7 on boot. master address? '''
-    ACTION1           = 0xa4, R_ACTION
-    ''' [WO] always reads 0, but writing a 1 to certain bits triggers bit-specific actions '''
-
-    CURSORS           = 0xb0, R_CURSORS
-    ''' [RO] read and write cursors for the two FIFOs '''
-    PEEK_POS          = 0xb4, R_PEEK_POS
-    ''' [RW] selects word to peek '''
-    PEEK_VALUE        = 0xb8, Register32
-    ''' [RO] current value at word selected by PEEK_POS '''
-    STATUS_2          = 0xbc, Register32
-    ''' [RO] only bit 0 seen, seems to indicate inability to talk on the bus '''
-
 class SPMI:
     def __init__(self, u, adt_path):
         self.u = u
@@ -135,7 +28,13 @@ class SPMI:
         self.iface = u.iface
         self.adt = u.adt[adt_path]
         self.base = self.adt.get_reg(0)[0]
-        self.regs = SPMIRegs(u, self.base)
+        gen = getattr(self.adt, "gen", -1)
+        if gen == 4:
+            self.regs = SPMI4Regs(u, self.base)
+        else:
+            # Includes the case where no "gen" property exists,
+            # which is the case on older macOS versions
+            self.regs = SPMI1Regs(u, self.base)
 
     def raw_read(self) -> int:
         for _ in range(1000):

--- a/proxyclient/m1n1/hw/spmi1.py
+++ b/proxyclient/m1n1/hw/spmi1.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: MIT
+from ..utils import *
+
+class R_CMD(Register32):
+    EXTRA       = 31, 16
+    ALERT       = 15
+    SLAVE_ID    = 11, 8
+    OPCODE      = 7, 0
+
+class R_REPLY(Register32):
+    FRAME_PARITY = 31, 16
+    ACK          = 15
+    SLAVE_ID     = 14, 8
+    OPCODE       = 7, 0
+
+class R_STATUS(Register32):
+    RX_FULL     = 25
+    RX_EMPTY    = 24
+    RX_COUNT    = 23, 16
+    TX_FULL     = 9
+    TX_EMPTY    = 8
+    TX_COUNT    = 7, 0
+
+class R_CURSORS(Register32):
+    RX_CURSOR_R    = 29, 24
+    RX_CURSOR_W    = 21, 16
+    TX_CURSOR_R    = 13,  8
+    TX_CURSOR_W    =  5,  0
+
+class R_PEEK_POS(Register32):
+    BUFFER_POS = 23, 16
+    ''' buffer position to read (0..capacity-1) '''
+    FIFO_IDX = 8
+    ''' FIFO to read from (0 = TX, 1 = RX) '''
+
+class R_ACTION(Register32):
+    CLEAR_FIFOS    = 0
+
+class IRQs(Register32):
+    ALERT       = 0  # a command with the ALERT flag completed
+
+    UNK_4       = 4
+    UNK_5       = 5
+    READ_FAIL_1 = 6  # read command failed
+    ACK_FAIL    = 7  # command was not ACKed
+    UNK_8       = 8
+    UNK_9       = 9
+    UNK_10      = 10
+    READ_FAIL_2 = 11 # read command failed
+    UNK_12      = 12
+    UNK_13      = 13
+
+    UNK_16      = 16
+    UNK_17      = 17
+
+    FATAL       = 27 # read from RX FIFO while empty. level/sticky interrupt
+
+class SPMI1Regs(RegMap):
+    STATUS            = 0x00, R_STATUS
+    ''' [RO] status about the RX and TX FIFOs '''
+    CMD               = 0x04, R_CMD
+    ''' [WO] write 32 bits to the TX FIFO '''
+    REPLY             = 0x08, R_REPLY
+    ''' [RO] consume 32 bits from the RX FIFO '''
+
+    # setting a bit in one of these registers causes the IRQ line
+    # to be asserted whenever the same bit at the register at
+    # address +0x40 (see below) is set. clearing a bit only masks
+    # the interrupt, but doesn't prevent the bit from being set or
+    # cleared in register +0x40. these are zero on boot.
+    BUS_EVENTS_0_MASK = 0x20, Register32
+    BUS_EVENTS_1_MASK = 0x24, Register32
+    BUS_EVENTS_2_MASK = 0x28, Register32
+    BUS_EVENTS_3_MASK = 0x2c, Register32
+    BUS_EVENTS_4_MASK = 0x30, Register32
+    BUS_EVENTS_5_MASK = 0x34, Register32
+    BUS_EVENTS_6_MASK = 0x38, Register32
+    BUS_EVENTS_7_MASK = 0x3c, Register32
+    IRQ_MASK          = 0x40, IRQs
+
+    # bits in these registers are set in response to an event
+    # and can be cleared by writing a 1 to them. IRQ_FLAG is
+    # for events of the SPMI peripheral itself, while
+    # BUS_EVENTS_* is for generic events that can be triggered
+    # by other devices in the bus using (I presume) master
+    # commands against us, and allow the SPMI peripheral to
+    # also act as an interrupt controller
+    BUS_EVENTS_0_FLAG = 0x60, Register32
+    BUS_EVENTS_1_FLAG = 0x64, Register32
+    BUS_EVENTS_2_FLAG = 0x68, Register32
+    BUS_EVENTS_3_FLAG = 0x6c, Register32
+    BUS_EVENTS_4_FLAG = 0x70, Register32
+    BUS_EVENTS_5_FLAG = 0x74, Register32
+    BUS_EVENTS_6_FLAG = 0x78, Register32
+    BUS_EVENTS_7_FLAG = 0x7c, Register32
+    IRQ_FLAG          = 0x80, IRQs
+
+    CONFIG1           = 0xa0, Register32
+    ''' [RO] unknown, bits 2..0 settable in T6031, set to 0x6 or 0x7 on boot. master address? '''
+    ACTION1           = 0xa4, R_ACTION
+    ''' [WO] always reads 0, but writing a 1 to certain bits triggers bit-specific actions '''
+
+    CURSORS           = 0xb0, R_CURSORS
+    ''' [RO] read and write cursors for the two FIFOs '''
+    PEEK_POS          = 0xb4, R_PEEK_POS
+    ''' [RW] selects word to peek '''
+    PEEK_VALUE        = 0xb8, Register32
+    ''' [RO] current value at word selected by PEEK_POS '''
+    STATUS_2          = 0xbc, Register32
+    ''' [RO] only bit 0 seen, seems to indicate inability to talk on the bus '''
+

--- a/proxyclient/m1n1/hw/spmi4.py
+++ b/proxyclient/m1n1/hw/spmi4.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: MIT
+from ..utils import *
+from .spmi1 import R_CMD, R_REPLY
+
+class R_STATUS(Register32):
+    RX_FULL     = 31
+    RX_EMPTY    = 30
+    RX_COUNT    = 23, 16
+    TX_FULL     = 15
+    TX_EMPTY    = 14
+    TX_COUNT    = 7, 0
+
+class SPMI4Regs(RegMap):
+    STATUS            = 0x200, R_STATUS
+    ''' [RO] status about the RX and TX FIFOs '''
+    CMD               = 0x210, R_CMD
+    ''' [WO] write 32 bits to the TX FIFO '''
+    REPLY             = 0x220, R_REPLY
+    ''' [RO] consume 32 bits from the RX FIFO '''

--- a/src/spmi.c
+++ b/src/spmi.c
@@ -4,25 +4,6 @@
 #include "adt.h"
 #include "malloc.h"
 
-#define SPMI_STATUS 0x00
-#define SPMI_CMD    0x04
-#define SPMI_REPLY  0x08
-
-#define SPMI_CMD_EXTRA  GENMASK(31, 16)
-#define SPMI_CMD_ACTIVE BIT(15)
-#define SPMI_CMD_ADDR   GENMASK(14, 8)
-#define SPMI_CMD_OPCODE GENMASK(7, 0)
-
-#define SPMI_REPLY_FRAME_PARITY GENMASK(31, 16)
-#define SPMI_REPLY_ACK          BIT(15)
-#define SPMI_REPLY_ADDR         GENMASK(14, 8)
-#define SPMI_REPLY_OPCODE       GENMASK(7, 0)
-
-#define SPMI_STATUS_RX_EMPTY BIT(24)
-#define SPMI_STATUS_RX_COUNT GENMASK(23, 16)
-#define SPMI_STATUS_TX_EMPTY BIT(8)
-#define SPMI_STATUS_TX_COUNT GENMASK(7, 0)
-
 #define SPMI_OPC_RESET    0x10
 #define SPMI_OPC_SLEEP    0x11
 #define SPMI_OPC_SHUTDOWN 0x12
@@ -38,8 +19,72 @@
 #define SPMI_OPC_READ       0x60
 #define SPMI_OPC_ZERO_WRITE 0x80
 
+struct spmi_regs {
+    size_t status_offset;
+    size_t cmd_offset;
+    size_t reply_offset;
+
+    u32 cmd_extra_mask;
+    u32 cmd_active_mask;
+    u32 cmd_addr_mask;
+    u32 cmd_opcode_mask;
+
+    u32 reply_frame_parity_mask;
+    u32 reply_ack_mask;
+    u32 reply_addr_mask;
+    u32 reply_opcode_mask;
+
+    u32 status_rx_empty_mask;
+    u32 status_rx_count_mask;
+    u32 status_tx_empty_mask;
+    u32 status_tx_count_mask;
+};
+
+static const struct spmi_regs regs_gen1 = {
+    .status_offset = 0x00,
+    .cmd_offset = 0x04,
+    .reply_offset = 0x08,
+
+    .cmd_extra_mask = GENMASK(31, 16),
+    .cmd_active_mask = BIT(15),
+    .cmd_addr_mask = GENMASK(14, 8),
+    .cmd_opcode_mask = GENMASK(7, 0),
+
+    .reply_frame_parity_mask = GENMASK(31, 16),
+    .reply_ack_mask = BIT(15),
+    .reply_addr_mask = GENMASK(14, 8),
+    .reply_opcode_mask = GENMASK(7, 0),
+
+    .status_rx_empty_mask = BIT(24),
+    .status_rx_count_mask = GENMASK(23, 16),
+    .status_tx_empty_mask = BIT(8),
+    .status_tx_count_mask = GENMASK(7, 0),
+};
+
+static const struct spmi_regs regs_gen4 = {
+    .status_offset = 0x200,
+    .cmd_offset = 0x210,
+    .reply_offset = 0x220,
+
+    .cmd_extra_mask = GENMASK(31, 16),
+    .cmd_active_mask = BIT(15),
+    .cmd_addr_mask = GENMASK(14, 8),
+    .cmd_opcode_mask = GENMASK(7, 0),
+
+    .reply_frame_parity_mask = GENMASK(31, 16),
+    .reply_ack_mask = BIT(15),
+    .reply_addr_mask = GENMASK(14, 8),
+    .reply_opcode_mask = GENMASK(7, 0),
+
+    .status_rx_empty_mask = BIT(30),
+    .status_rx_count_mask = GENMASK(23, 16),
+    .status_tx_empty_mask = BIT(14),
+    .status_tx_count_mask = GENMASK(7, 0),
+};
+
 struct spmi_dev {
     uintptr_t base;
+    const struct spmi_regs *regs;
 };
 
 spmi_dev_t *spmi_init(const char *adt_node)
@@ -58,9 +103,23 @@ spmi_dev_t *spmi_init(const char *adt_node)
         return NULL;
     }
 
+    s32 gen;
+    int ret = ADT_GETPROP(adt, adt_offset, "gen", &gen);
+    if (ret == -1) // NotFound
+        gen = -1;
+    else if (ret < 0) {
+        printf("spmi: Error getting %s gen\n", adt_node);
+        return NULL;
+    }
+
     spmi_dev_t *dev = calloc(1, sizeof(*dev));
     if (!dev)
         return NULL;
+
+    if (gen >= 4)
+        dev->regs = &regs_gen4;
+    else // Includes the error case (-1) as old adts don't have the gen property
+        dev->regs = &regs_gen1;
 
     dev->base = base;
     return dev;
@@ -74,7 +133,7 @@ void spmi_shutdown(spmi_dev_t *dev)
 static int wait_rx_fifo(spmi_dev_t *dev)
 {
     for (size_t i = 0; i < 1000; i++) {
-        if (!(read32(dev->base + SPMI_STATUS) & SPMI_STATUS_RX_EMPTY))
+        if (!(read32(dev->base + dev->regs->status_offset) & dev->regs->status_rx_empty_mask))
             return 0;
         udelay(10);
     }
@@ -95,49 +154,51 @@ static int raw_command(spmi_dev_t *dev, u8 addr, u8 opc, u16 extra, const u8 *da
     }
 
     // ensure FIFOs are in the correct state
-    if (!(read32(dev->base + SPMI_STATUS) & SPMI_STATUS_TX_EMPTY)) {
+    if (!(read32(dev->base + dev->regs->status_offset) & dev->regs->status_tx_empty_mask)) {
         printf("spmi: TX FIFO has unsent commands\n");
         return -SPMI_ERR_UNKNOWN;
     }
 
-    while (!(read32(dev->base + SPMI_STATUS) & SPMI_STATUS_RX_EMPTY))
-        printf("spmi: Leftover RX data: 0x%x\n", read32(dev->base + SPMI_REPLY));
+    while (!(read32(dev->base + dev->regs->status_offset) & dev->regs->status_rx_empty_mask))
+        printf("spmi: Leftover RX data: 0x%x\n", read32(dev->base + dev->regs->reply_offset));
 
     // write command
-    write32(dev->base + SPMI_CMD, FIELD_PREP(SPMI_CMD_EXTRA, extra) | SPMI_CMD_ACTIVE |
-                                      FIELD_PREP(SPMI_CMD_ADDR, addr) |
-                                      FIELD_PREP(SPMI_CMD_OPCODE, opc));
+    write32(dev->base + dev->regs->cmd_offset, FIELD_PREP(dev->regs->cmd_extra_mask, extra) |
+                                                   dev->regs->cmd_active_mask |
+                                                   FIELD_PREP(dev->regs->cmd_addr_mask, addr) |
+                                                   FIELD_PREP(dev->regs->cmd_opcode_mask, opc));
 
     for (size_t i = 0; i < len_in;) {
         u32 data = 0;
         for (size_t j = 0; (j < 4) && (i < len_in);)
             data |= data_in[i++] << (j++ * 8);
-        write32(dev->base + SPMI_CMD, data);
+        write32(dev->base + dev->regs->cmd_offset, data);
     }
 
     // read response
     if (wait_rx_fifo(dev) < 0)
         return -SPMI_ERR_UNKNOWN;
-    u32 reply = read32(dev->base + SPMI_REPLY);
+    u32 reply = read32(dev->base + dev->regs->reply_offset);
 
-    if (FIELD_GET(SPMI_REPLY_OPCODE, reply) != opc || FIELD_GET(SPMI_REPLY_ADDR, reply) != addr) {
+    if (FIELD_GET(dev->regs->reply_opcode_mask, reply) != opc ||
+        FIELD_GET(dev->regs->reply_addr_mask, reply) != addr) {
         printf("spmi: Unexpected SPMI response 0x%x, leftover RX data?\n", reply);
         return -SPMI_ERR_UNKNOWN;
     }
 
     for (size_t i = 0; i < len_out;) {
-        if (read32(dev->base + SPMI_STATUS) & SPMI_STATUS_RX_EMPTY) {
+        if (read32(dev->base + dev->regs->status_offset) & dev->regs->status_rx_empty_mask) {
             printf("spmi: Reply was shorter than expected\n");
             return -SPMI_ERR_UNKNOWN;
         }
-        u32 data = read32(dev->base + SPMI_REPLY);
+        u32 data = read32(dev->base + dev->regs->reply_offset);
         for (size_t j = 0; (j < 4) && (i < len_out);)
             data_out[i++] = data >> (j++ * 8);
     }
 
-    if (FIELD_GET(SPMI_REPLY_FRAME_PARITY, reply) != MASK(len_out))
+    if (FIELD_GET(dev->regs->reply_frame_parity_mask, reply) != MASK(len_out))
         return -SPMI_ERR_BUS_IO;
-    if (!len_out && !(reply & SPMI_REPLY_ACK))
+    if (!len_out && !(reply & dev->regs->reply_ack_mask))
         return -SPMI_ERR_BUS_IO;
     return 0;
 }


### PR DESCRIPTION
This allows reset_panic_counter (on the proxyclient side) and tps65989x (on the m1n1 side, in combination with #594) to work on M5 machines. Tested on T6050.