### PR TITLE
CI: Create m1n1.bin artifacts in addition to uefi-only boot.bin ones

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: installer
+name: release
 
 # Controls when the action will run.
 on:
@@ -12,13 +12,13 @@ on:
     tags: [ 'v*' ]
   pull_request:
     branches: [ main ]
-    paths: [ .github/workflows/installer.yml ]
+    paths: [ .github/workflows/release.yml ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
-  uefi-only-boot-bin:
+  release-binaries:
     runs-on: ubuntu-latest
 
     steps:
@@ -57,12 +57,26 @@ jobs:
 
       # env vars to include date and kernel tag in artifact name
       - name: Export git info
+        shell: bash
         run: |
           echo "GIT_DATE=$(git log -1 --format=%cd --date=format:%Y%m%d)" >> $GITHUB_ENV
           echo "KERNEL_REF=$(git --git-dir=linux/.git describe --tags --always)" >> $GITHUB_ENV
+          if [ ${{ github.ref_type }} = "tag" ]; then
+              echo "M1N1_REF=${{ github.ref_name }}" | tr ';,<>/|"' '[_*]' >> $GITHUB_ENV
+          else
+              SHA=${{ github.sha }}
+              echo "M1N1_REF=${{ github.ref_name }}-${SHA:0:10}" | tr ';,<>/|"' '[_*]' >> $GITHUB_ENV
+          fi
 
       - name: Build
         run: make -k -j2 ARCH=aarch64-linux-gnu- RELEASE=1
+
+      - name: Archive m1n1.bin
+        uses: actions/upload-artifact@v7
+        with:
+          name: m1n1.bin-${{ env.M1N1_REF }}
+          path: |
+            build/m1n1.bin
 
       - name: Update u-boot apple device trees
         run: |


### PR DESCRIPTION
Also upload m1n1.bin release artifacts. Rename the workflow from "installer" to "release" to catch its purpose.