### PR TITLE
hv/trace_nvme: fix DBS reg names

### DIFF
--- a/proxyclient/hv/trace_nvme.py
+++ b/proxyclient/hv/trace_nvme.py
@@ -49,8 +49,8 @@ class NVMERegs(RegMap):
     NVME_REG_PMREBS = 0x0E0C, Register32
     NVME_REG_PMRSWTP = 0x0E10, Register32
     NVME_REG_DBS = 0x1000, Register32
-    NVME_REG_DBS_ASQ = 0x1004, Register32
-    NVME_REG_DBS_IOSQ = 0x100C, Register32
+    NVME_REG_DBS_ACQ = 0x1004, Register32
+    NVME_REG_DBS_IOCQ = 0x100C, Register32
 
 
 AppleTunnelSetTime = Struct(


### PR DESCRIPTION
0x1004 / 0x100c relate to the **completion** queues, not submision queues